### PR TITLE
Исправление ошибки в заголовке и самой статье

### DIFF
--- a/api-reference/widgets/crm/detail-tab.md
+++ b/api-reference/widgets/crm/detail-tab.md
@@ -1,4 +1,4 @@
-# Вкладка в детальной карточке элемента CRM CRM_XXX_DETAIL_TAB, CRM_DYNAMIC_XXX_TAB
+# Вкладка в детальной карточке элемента CRM CRM_XXX_DETAIL_TAB, CRM_DYNAMIC_XXX_DETAIL_TAB
 
 > Scope: [`crm`](../../scopes/permissions.md)
 
@@ -17,7 +17,7 @@
 || `CRM_CONTACT_DETAIL_TAB` | Вкладка в карточке [контакта](../../crm/contacts/) ||
 || `CRM_COMPANY_DETAIL_TAB` | Вкладка в карточке [компании](../../crm/companies/) ||
 || `CRM_QUOTE_DETAIL_TAB` | Вкладка в карточке [коммерческого предложения](../../crm/quote/) ||
-|| `CRM_DYNAMIC_XXX_TAB` | Вкладка в карточке элемента пользовательского типа объектов CRM. Вместо XXX необходимо указывать числовой идентификатор конкретного [пользовательского типа объектов](../../crm/universal/). Например, `CRM_DYNAMIC_183_TAB` ||
+|| `CRM_DYNAMIC_XXX_DETAIL_TAB` | Вкладка в карточке элемента пользовательского типа объектов CRM. Вместо XXX необходимо указывать числовой идентификатор конкретного [пользовательского типа объектов](../../crm/universal/). Например, `CRM_DYNAMIC_183_DETAIL_TAB` ||
 |#
 
 ## Что получает обработчик


### PR DESCRIPTION
В заголовке и статье была ошибка в коде места встройки пользовательского типа объектов. Изменено с "CRM_DYNAMIC_XXX_TAB" на "CRM_DYNAMIC_XXX__DETAIL_TAB"