### PR TITLE
Правильные заголовки методов

### DIFF
--- a/api-reference/crm/timeline/activities/binding/crm-activity-binding-delete.md
+++ b/api-reference/crm/timeline/activities/binding/crm-activity-binding-delete.md
@@ -1,4 +1,4 @@
-# Получить список привязок дела crm.activity.binding.delete
+# Удалить привязку дела crm.activity.binding.delete
 
 {% note warning "Мы еще обновляем эту страницу" %}
 

--- a/api-reference/crm/timeline/activities/binding/crm-activity-binding-list.md
+++ b/api-reference/crm/timeline/activities/binding/crm-activity-binding-list.md
@@ -1,4 +1,4 @@
-# Удалить привязку дела crm.activity.binding.list
+# Получить список привязок дела crm.activity.binding.list
 
 {% note warning "Мы еще обновляем эту страницу" %}
 


### PR DESCRIPTION
Заголовки  методов crm.activity.binding.list и crm.activity.binding.delete были перепутаны между собой. 