### PR TITLE
В 171 строке исправлено написание "комьюнити"

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -168,7 +168,7 @@ blocks:
                 color: #54BA7E
 
   - type: 'card-layout-block'
-    title: 'Коммьюнити и коммуникация с Битрикс24'
+    title: 'Комьюнити и коммуникация с Битрикс24'
     children:
       - type: 'background-card'
         title: 'Улучшить документацию'


### PR DESCRIPTION
Согласно gramota.ru слово "комьюнити" пишется с одной м вместо двух: https://gramota.ru/poisk?query=%D0%9A%D0%BE%D0%BC%D1%8C%D1%8E%D0%BD%D0%B8%D1%82%D0%B8&mode=spravka