### PR TITLE
Исправлен пример метода catalog.productPropertyEnum.delete

### DIFF
--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-delete.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-delete.md
@@ -49,7 +49,7 @@ catalog.productPropertyEnum.delete(id)
 
     ```javascript
     BX24.callMethod(
-        'catalog.productPropertyEnum.add',
+        'catalog.productPropertyEnum.delete',
         {
             fields: {
                 propertyId: 128,

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-delete.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-delete.md
@@ -51,13 +51,7 @@ catalog.productPropertyEnum.delete(id)
     BX24.callMethod(
         'catalog.productPropertyEnum.delete',
         {
-            fields: {
-                propertyId: 128,
-                value: "Средний",
-                def: "Y",
-                sort: 123,
-                xmlId: "M"
-            }
+            id: 42 // Укажите ID удаляемого значения
         },
         function(result) {
             if (result.error())


### PR DESCRIPTION
В примере кода использовался метод .add, заменил на .delete.