### PR TITLE
Метод calendar.event.delete, в коде PHP заменил crm.contact.details.c…

### DIFF
--- a/api-reference/calendar/calendar-event/calendar-event-delete.md
+++ b/api-reference/calendar/calendar-event/calendar-event-delete.md
@@ -62,8 +62,8 @@
     require_once('crest.php');
 
     $result = CRest::call(
-        'crm.contact.details.configuration.forceCommonScopeForAll',
-        []
+        'calendar.event.delete',
+        42
     );
 
     echo '<PRE>';

--- a/api-reference/calendar/calendar-event/calendar-event-delete.md
+++ b/api-reference/calendar/calendar-event/calendar-event-delete.md
@@ -63,7 +63,7 @@
 
     $result = CRest::call(
         'calendar.event.delete',
-        42
+        ['id' => 42],
     );
 
     echo '<PRE>';


### PR DESCRIPTION
В примере использования метода `calendar.event.delete` исправлен вызов:
- Было: `crm.contact.details.configuration.forceCommonScopeForAll`
- Стало: `calendar.event.delete`

Протестировал.