### PR TITLE
docs(tasks): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/tasks/checklist-item/task-checklist-item-add.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-add.md
@@ -100,39 +100,100 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.add',
-            {
-                TASKID: 13,
-                FIELDS: {
-                    TITLE: 'Подготовить отчет',
-                    PARENT_ID: 457,
-                    SORT_INDEX: 200,
-                    IS_COMPLETE: 'N',
-                    IS_IMPORTANT: 'Y',
-                    MEMBERS: {
-                        547: {
-                            TYPE: 'A'
-                        }
-                    }
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created checklist item with ID:', result);
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ChecklistItemAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<ChecklistItemAddResult>({
+        method: 'task.checklistitem.add',
+        params: {
+          TASKID: 13,
+          FIELDS: {
+            TITLE: 'Prepare the report',
+            PARENT_ID: 457,
+            SORT_INDEX: 200,
+            IS_COMPLETE: 'N',
+            IS_IMPORTANT: 'Y',
+            MEMBERS: {
+              547: {
+                TYPE: 'A',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created checklist item with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.add',
+            params: {
+              TASKID: 13,
+              FIELDS: {
+                TITLE: 'Prepare the report',
+                PARENT_ID: 457,
+                SORT_INDEX: 200,
+                IS_COMPLETE: 'N',
+                IS_IMPORTANT: 'Y',
+                MEMBERS: {
+                  547: {
+                    TYPE: 'A',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created checklist item with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-complete.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-complete.md
@@ -64,28 +64,75 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.complete
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.complete',
-            {
-                TASKID: 8017,
-                ITEMID: 433,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Completed checklist item with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.checklistitem.complete',
+        params: {
+          TASKID: 8017,
+          ITEMID: 433,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item completed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function completeChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.complete',
+            params: {
+              TASKID: 8017,
+              ITEMID: 433,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item completed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', completeChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-delete.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-delete.md
@@ -62,27 +62,75 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.delete
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.delete',
-            {
-                TASKID: 13,
-                ITEMID: 475
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted checklist item:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.checklistitem.delete',
+        params: {
+          TASKID: 13,
+          ITEMID: 475,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.delete',
+            params: {
+              TASKID: 13,
+              ITEMID: 475,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-get-list.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-get-list.md
@@ -73,63 +73,121 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.getlist
     ```
 
-- JS
+- TS
 
-    ```javascript
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type ChecklistItem = {
+      ID: string
+      TASK_ID: string
+      PARENT_ID: string
+      CREATED_BY: string
+      TITLE: string
+      SORT_INDEX: string
+      IS_COMPLETE: 'Y' | 'N'
+      IS_IMPORTANT: 'Y' | 'N'
+      TOGGLED_BY: string | null
+      TOGGLED_DATE: ISODate | null
+      MEMBERS: Array<{
+        ID: string
+        TYPE: string
+        NAME: string
+        PERSONAL_PHOTO: string
+        PERSONAL_GENDER: string
+        IMAGE: string
+        IS_COLLABER: boolean
+      }>
+      ATTACHMENTS: Record<string, {
+        ATTACHMENT_ID: number
+        NAME: string
+        SIZE: string
+        FILE_ID: string
+        DOWNLOAD_URL: string
+        VIEW_URL: string
+      }>
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'task.checklistitem.getlist',
-        {
-        TASKID: 8017,
-        ORDER: {
-            IS_COMPLETE: 'ASC'
-        }
+      // task.checklistitem.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ChecklistItem[]>({
+        method: 'task.checklistitem.getlist',
+        params: {
+          TASKID: 8017,
+          ORDER: {
+            IS_COMPLETE: 'ASC',
+          },
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist items count:', result.length, 'First item:', result[0]?.ID, result[0]?.TITLE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+- UMD
 
-    try {
-    const generator = $b24.fetchListMethod('task.checklistitem.getlist', {
-        TASKID: 8017,
-        ORDER: {
-        IS_COMPLETE: 'ASC'
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getChecklistItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.checklistitem.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.getlist',
+            params: {
+              TASKID: 8017,
+              ORDER: {
+                IS_COMPLETE: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist items count:', result.length, 'First item:', result[0]?.ID, result[0]?.TITLE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+      }
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-    const response = await $b24.callMethod('task.checklistitem.getlist', {
-        TASKID: 8017,
-        ORDER: {
-        IS_COMPLETE: 'ASC'
-        }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+      document.addEventListener('DOMContentLoaded', getChecklistItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-get-manifest.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-get-manifest.md
@@ -47,24 +47,72 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.getmanifest
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.getmanifest',
-            []
-        );
-        
-        const result = response.getData().result;
-        console.log('Manifest data:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ManifestResult = Record<string, unknown>
+
+    try {
+      const response = await $b24.actions.v2.call.make<ManifestResult>({
+        method: 'task.checklistitem.getmanifest',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getChecklistItemManifest() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.getmanifest',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getChecklistItemManifest)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-get.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-get.md
@@ -64,27 +64,106 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.get
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.get',
-            {
-                TASKID: 8017,
-                ITEMID: 479
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved checklist item:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ChecklistItemResult = {
+      ID: string
+      TASK_ID: string
+      PARENT_ID: string
+      CREATED_BY: string
+      TITLE: string
+      SORT_INDEX: string
+      IS_COMPLETE: string
+      IS_IMPORTANT: string
+      TOGGLED_BY: string | null
+      TOGGLED_DATE: string
+      MEMBERS: Array<{
+        ID: string
+        TYPE: string
+        NAME: string
+        PERSONAL_PHOTO: string
+        PERSONAL_GENDER: string
+        IMAGE: string
+        IS_COLLABER: boolean
+      }>
+      ATTACHMENTS: Record<string, {
+        ATTACHMENT_ID: number
+        NAME: string
+        SIZE: string
+        FILE_ID: string
+        DOWNLOAD_URL: string
+        VIEW_URL: string
+      }>
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ChecklistItemResult>({
+        method: 'task.checklistitem.get',
+        params: {
+          TASKID: 8017,
+          ITEMID: 479,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item:', result.ID, result.TITLE, 'complete:', result.IS_COMPLETE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.get',
+            params: {
+              TASKID: 8017,
+              ITEMID: 479,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item:', result.ID, result.TITLE, 'complete:', result.IS_COMPLETE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-is-action-allowed.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-is-action-allowed.md
@@ -65,28 +65,77 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.isactionallowed
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.isactionallowed',
-            {
-                TASKID: 8017,
-                ITEMID: 475,
-                ACTIONID: 2
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Action allowed:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.checklistitem.isactionallowed',
+        params: {
+          TASKID: 8017,
+          ITEMID: 475,
+          ACTIONID: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Action allowed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkActionAllowed() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.isactionallowed',
+            params: {
+              TASKID: 8017,
+              ITEMID: 475,
+              ACTIONID: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Action allowed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkActionAllowed)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-move-after-item.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-move-after-item.md
@@ -70,28 +70,81 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.moveafteritem
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.moveafteritem',
-            {
-                TASKID: 13,
-                ITEMID: 475,
-                AFTERITEMID: 447
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Moved checklist item:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // result is null when the item is successfully moved
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveChecklistItemResult = null
+
+    try {
+      const response = await $b24.actions.v2.call.make<MoveChecklistItemResult>({
+        method: 'task.checklistitem.moveafteritem',
+        params: {
+          TASKID: 13,
+          ITEMID: 475,
+          AFTERITEMID: 447,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item moved successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.moveafteritem',
+            params: {
+              TASKID: 13,
+              ITEMID: 475,
+              AFTERITEMID: 447,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item moved successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-renew.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-renew.md
@@ -64,28 +64,78 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.renew
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.renew',
-            {
-                TASKID: 13,
-                ITEMID: 475,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Renewed checklist item with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RenewResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<RenewResult>({
+        method: 'task.checklistitem.renew',
+        params: {
+          TASKID: 13,
+          ITEMID: 475,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item renewed successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renewChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.renew',
+            params: {
+              TASKID: 13,
+              ITEMID: 475,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item renewed successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renewChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/checklist-item/task-checklist-item-update.md
+++ b/api-reference/tasks/checklist-item/task-checklist-item-update.md
@@ -108,42 +108,100 @@
     https://**put_your_bitrix24_address**/rest/task.checklistitem.update
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.checklistitem.update',
-            {
-                TASKID: 13,
-                ITEMID: 475,
-                FIELDS: {
-                    TITLE: 'Подготовить отчет',
-                    PARENT_ID: 447,
-                    SORT_INDEX: 100,
-                    IS_COMPLETE: 'N',
-                    IS_IMPORTANT: 'N',
-                    MEMBERS: {
-                        547: {
-                            TYPE: 'A'
-                        },
-                        125: {
-                            TYPE: 'U'
-                        }
-                    }
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated checklist item with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ChecklistItemUpdateResult = null
+
+    try {
+      const response = await $b24.actions.v2.call.make<ChecklistItemUpdateResult>({
+        method: 'task.checklistitem.update',
+        params: {
+          TASKID: 13,
+          ITEMID: 475,
+          FIELDS: {
+            TITLE: 'Prepare report',
+            PARENT_ID: 447,
+            SORT_INDEX: 100,
+            IS_COMPLETE: 'N',
+            IS_IMPORTANT: 'N',
+            MEMBERS: {
+              547: { TYPE: 'A' },
+              125: { TYPE: 'U' },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item updated successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.checklistitem.update',
+            params: {
+              TASKID: 13,
+              ITEMID: 475,
+              FIELDS: {
+                TITLE: 'Prepare report',
+                PARENT_ID: 447,
+                SORT_INDEX: 100,
+                IS_COMPLETE: 'N',
+                IS_IMPORTANT: 'N',
+                MEMBERS: {
+                  547: { TYPE: 'A' },
+                  125: { TYPE: 'U' },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item updated successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/events-comment/on-task-comment-add.md
+++ b/api-reference/tasks/comment-item/events-comment/on-task-comment-add.md
@@ -175,27 +175,78 @@ array(
 
 {% list tabs %}
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.bind',
-    		{
-    			"event": "OnTaskCommentAdd",
-    			"handler": "https://example.com/handler.php"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (event.bind returns true on success)
+    type EventBindResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<EventBindResult>({
+        method: 'event.bind',
+        params: {
+          event: 'OnTaskCommentAdd',
+          handler: 'https://example.com/handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event bound successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindTaskCommentAddEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'OnTaskCommentAdd',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event bound successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindTaskCommentAddEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/events-comment/on-task-comment-delete.md
+++ b/api-reference/tasks/comment-item/events-comment/on-task-comment-delete.md
@@ -152,27 +152,78 @@ array(
 
 {% list tabs %}
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.bind',
-    		{
-    			"event": "OnTaskCommentDelete",
-    			"handler": "https://example.com/handler.php"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (event.bind returns true on success)
+    type EventBindResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<EventBindResult>({
+        method: 'event.bind',
+        params: {
+          event: 'OnTaskCommentDelete',
+          handler: 'https://example.com/handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event bound successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindOnTaskCommentDeleteEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'OnTaskCommentDelete',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event bound successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindOnTaskCommentDeleteEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/events-comment/on-task-comment-update.md
+++ b/api-reference/tasks/comment-item/events-comment/on-task-comment-update.md
@@ -152,27 +152,78 @@ array(
 
 {% list tabs %}
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.bind',
-    		{
-    			"event": "OnTaskCommentUpdate",
-    			"handler": "https://example.com/handler.php"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (event.bind returns true on success)
+    type BindEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<BindEventResult>({
+        method: 'event.bind',
+        params: {
+          event: 'OnTaskCommentUpdate',
+          handler: 'https://example.com/handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event bound successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindOnTaskCommentUpdate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'OnTaskCommentUpdate',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event bound successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindOnTaskCommentUpdate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-add.md
+++ b/api-reference/tasks/comment-item/task-comment-item-add.md
@@ -91,33 +91,88 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.commentitem.add',
-    		{
-    			"TASKID": 8017,
-    			"FIELDS": {
-    				"POST_MESSAGE": "Текст нового комментария к задаче",
-    				"AUTHOR_ID": 503,
-    				"POST_DATE": "2025-07-15T14:30:00+03:00",
-    				"UF_FORUM_MESSAGE_DOC": ["n4755", "n4753"]
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (the ID of the newly created comment)
+    type CommentItemAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<CommentItemAddResult>({
+        method: 'task.commentitem.add',
+        params: {
+          TASKID: 8017,
+          FIELDS: {
+            POST_MESSAGE: 'Text of the new task comment',
+            AUTHOR_ID: 503,
+            POST_DATE: '2025-07-15T14:30:00+03:00',
+            UF_FORUM_MESSAGE_DOC: ['n4755', 'n4753'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New comment ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.add',
+            params: {
+              TASKID: 8017,
+              FIELDS: {
+                POST_MESSAGE: 'Text of the new task comment',
+                AUTHOR_ID: 503,
+                POST_DATE: '2025-07-15T14:30:00+03:00',
+                UF_FORUM_MESSAGE_DOC: ['n4755', 'n4753'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New comment ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-delete.md
+++ b/api-reference/tasks/comment-item/task-comment-item-delete.md
@@ -70,28 +70,78 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.delete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.commentitem.delete',
-    		{
-    			"TASKID": 8017,
-    			"ITEMID": 3155
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteCommentResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteCommentResult>({
+        method: 'task.commentitem.delete',
+        params: {
+          TASKID: 8017,
+          ITEMID: 3155,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Comment deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.delete',
+            params: {
+              TASKID: 8017,
+              ITEMID: 3155,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Comment deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-get-list.md
+++ b/api-reference/tasks/comment-item/task-comment-item-get-list.md
@@ -98,71 +98,116 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.getlist
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'task.commentitem.getlist',
-        {
-          "TASKID": 8017,
-          "ORDER": {
-            "POST_DATE": "asc",
-          },
-          "FILTER": {
-            "AUTHOR_ID": 503,
-            ">=POST_DATE": "2025-01-01",
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each comment item returned in the result array
+    type TaskCommentItem = {
+      ID: string
+      AUTHOR_ID: string
+      AUTHOR_NAME: string
+      AUTHOR_EMAIL: string
+      POST_DATE: ISODate | null
+      POST_MESSAGE: string
+      POST_MESSAGE_HTML: string | null
+      ATTACHED_OBJECTS: Record<string, {
+        ATTACHMENT_ID: string
+        NAME: string
+        SIZE: string
+        FILE_ID: string
+        DOWNLOAD_URL: string
+        VIEW_URL: string
+      }>
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('task.commentitem.getlist', {
-        "TASKID": 8017,
-        "ORDER": {
-          "POST_DATE": "asc",
+      // task.commentitem.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskCommentItem[]>({
+        method: 'task.commentitem.getlist',
+        params: {
+          TASKID: 8017,
+          ORDER: {
+            POST_DATE: 'asc',
+          },
+          FILTER: {
+            AUTHOR_ID: 503,
+            '>=POST_DATE': '2025-01-01',
+          },
         },
-        "FILTER": {
-          "AUTHOR_ID": 503,
-          ">=POST_DATE": "2025-01-01",
-        }
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Comments fetched:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.commentitem.getlist', {
-        "TASKID": 8017,
-        "ORDER": {
-          "POST_DATE": "asc",
-        },
-        "FILTER": {
-          "AUTHOR_ID": 503,
-          ">=POST_DATE": "2025-01-01",
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskCommentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.commentitem.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.getlist',
+            params: {
+              TASKID: 8017,
+              ORDER: {
+                POST_DATE: 'asc',
+              },
+              FILTER: {
+                AUTHOR_ID: 503,
+                '>=POST_DATE': '2025-01-01',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Comments fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskCommentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-get-manifest.md
+++ b/api-reference/tasks/comment-item/task-comment-item-get-manifest.md
@@ -47,25 +47,72 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.getmanifest
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.commentitem.getmanifest',
-    		[]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ManifestResult = Record<string, unknown>
+
+    try {
+      const response = await $b24.actions.v2.call.make<ManifestResult>({
+        method: 'task.commentitem.getmanifest',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getManifest() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.getmanifest',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getManifest)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-get.md
+++ b/api-reference/tasks/comment-item/task-comment-item-get.md
@@ -70,28 +70,96 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.get
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.commentitem.get',
-    		{
-    			"TASKID": 8017,
-    			"ITEMID": 3157
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type AttachedObject = {
+      ATTACHMENT_ID: string
+      NAME: string
+      SIZE: string
+      FILE_ID: string
+      DOWNLOAD_URL: string
+      VIEW_URL: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CommentItemGetResult = {
+      POST_MESSAGE_HTML: string | null
+      ID: string
+      AUTHOR_ID: string
+      AUTHOR_NAME: string
+      AUTHOR_EMAIL: string
+      POST_DATE: ISODate | null
+      POST_MESSAGE: string
+      ATTACHED_OBJECTS: Record<string, AttachedObject>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CommentItemGetResult>({
+        method: 'task.commentitem.get',
+        params: {
+          TASKID: 8017,
+          ITEMID: 3157,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.POST_MESSAGE, result.POST_DATE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCommentItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.get',
+            params: {
+              TASKID: 8017,
+              ITEMID: 3157,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.POST_MESSAGE, result.POST_DATE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCommentItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-is-action-allowed.md
+++ b/api-reference/tasks/comment-item/task-comment-item-is-action-allowed.md
@@ -63,29 +63,77 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.isactionallowed
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.commentitem.isactionallowed',
-    		{
-    			"TASKID": 8017,
-    			"ITEMID": 3157,
-    			"ACTIONID": 2
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.commentitem.isactionallowed',
+        params: {
+          TASKID: 8017,
+          ITEMID: 3157,
+          ACTIONID: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Is action allowed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkIsActionAllowed() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.isactionallowed',
+            params: {
+              TASKID: 8017,
+              ITEMID: 3157,
+              ACTIONID: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Is action allowed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkIsActionAllowed)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/comment-item/task-comment-item-update.md
+++ b/api-reference/tasks/comment-item/task-comment-item-update.md
@@ -92,32 +92,86 @@
     https://**put_your_bitrix24_address**/rest/task.commentitem.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.commentitem.update',
-    		{
-    			"TASKID": 8017,
-    			"ITEMID": 3167,
-    			"FIELDS": {
-    				"POST_MESSAGE": "Комментарий обновлен",
-    				"UF_FORUM_MESSAGE_DOC": ["n4755"]
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateCommentResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateCommentResult>({
+        method: 'task.commentitem.update',
+        params: {
+          TASKID: 8017,
+          ITEMID: 3167,
+          FIELDS: {
+            POST_MESSAGE: 'Comment updated',
+            UF_FORUM_MESSAGE_DOC: ['n4755'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Comment updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTaskComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.commentitem.update',
+            params: {
+              TASKID: 8017,
+              ITEMID: 3167,
+              FIELDS: {
+                POST_MESSAGE: 'Comment updated',
+                UF_FORUM_MESSAGE_DOC: ['n4755'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Comment updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTaskComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-comment-add.md
+++ b/api-reference/tasks/deprecated/task-comment-add.md
@@ -57,25 +57,83 @@
     https://**put_your_bitrix24_address**/rest/task.comment.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.comment.add',
-    		[1, 'текст комментария']
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result (comment ID)
+    type TaskCommentAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskCommentAddResult>({
+        method: 'task.comment.add',
+        params: {
+          TASKID: 1,
+          FIELDS: {
+            POST_MESSAGE: 'comment text',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created comment ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.comment.add',
+            params: {
+              TASKID: 1,
+              FIELDS: {
+                POST_MESSAGE: 'comment text',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created comment ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-add-file.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-add-file.md
@@ -58,30 +58,85 @@
     https://**put_your_bitrix24_address**/rest/task.item.addfile
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"task.item.addfile",
-    		{
-    			TASK_ID: "140",
-    			FILE: {
-    				NAME: "desc.txt",
-    				CONTENT: "BASE64_ENCODED_CONTENT_OF_DESC.TXT"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version — the page does not show a JSON response example
+    // Shape of the payload returned in result (ID of the uploaded file)
+    type AddFileResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddFileResult>({
+        method: 'task.item.addfile',
+        params: {
+          TASK_ID: '140',
+          FILE: {
+            NAME: 'desc.txt',
+            CONTENT: 'BASE64_ENCODED_CONTENT_OF_DESC.TXT',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Uploaded file ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addFileToTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.addfile',
+            params: {
+              TASK_ID: '140',
+              FILE: {
+                NAME: 'desc.txt',
+                CONTENT: 'BASE64_ENCODED_CONTENT_OF_DESC.TXT',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Uploaded file ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addFileToTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-add-to-favourite.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-add-to-favourite.md
@@ -71,29 +71,83 @@
     https://your-domain.ru/rest/task.item.addtofavorite
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"task.item.addtofavorite",
-    		{
-    			TASK_ID: 10,
-    			PARAMS: {
-    				AFFECT_CHILDREN: "Y"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify result shape — no response example is provided on this page
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddToFavouriteResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddToFavouriteResult>({
+        method: 'task.item.addtofavorite',
+        params: {
+          TASK_ID: 10,
+          PARAMS: {
+            AFFECT_CHILDREN: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task added to favourites:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskToFavourite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.addtofavorite',
+            params: {
+              TASK_ID: 10,
+              PARAMS: {
+                AFFECT_CHILDREN: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task added to favourites:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskToFavourite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-add.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-add.md
@@ -58,26 +58,85 @@
     https://**put_your_bitrix24_address**/rest/task.item.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const dt = new Date();
-    	const response = await $b24.callMethod(
-    		'task.item.add',
-    		[{TITLE: 'created via REST API at ' + dt.toLocaleString(), RESPONSIBLE_ID: 1, DEADLINE: '2013-05-13T16:06:06+03:00'}]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // task.item.add returns the ID of the newly created task
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskItemAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskItemAddResult>({
+        method: 'task.item.add',
+        params: {
+          fields: {
+            TITLE: 'created via REST API at ' + new Date().toLocaleString(),
+            RESPONSIBLE_ID: 1,
+            DEADLINE: '2013-05-13T16:06:06+03:00',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New task ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.add',
+            params: {
+              fields: {
+                TITLE: 'created via REST API at ' + new Date().toLocaleString(),
+                RESPONSIBLE_ID: 1,
+                DEADLINE: '2013-05-13T16:06:06+03:00',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New task ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskItem)
+    </script>
     ```
 
 - PHP
@@ -178,25 +237,83 @@
     https://**put_your_bitrix24_address**/rest/task.item.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.update',
-    		[1, {UF_CRM_TASK: ["L_4", "C_7", "CO_5", "D_10"]}]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // task.item.update returns true on success
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskItemUpdateResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskItemUpdateResult>({
+        method: 'task.item.update',
+        params: {
+          TASKID: 1,
+          FIELDS: {
+            UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task CRM fields updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTaskCrmFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.update',
+            params: {
+              TASKID: 1,
+              FIELDS: {
+                UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task CRM fields updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTaskCrmFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-approve.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-approve.md
@@ -54,25 +54,77 @@
     https://**put_your_bitrix24_address**/rest/task.item.approve
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.approve',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ApproveResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<ApproveResult>({
+        method: 'task.item.approve',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task approved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function approveTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.approve',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task approved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', approveTaskItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-complete.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-complete.md
@@ -54,25 +54,78 @@
     https://**put_your_bitrix24_address**/rest/task.item.complete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.complete',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version — no JSON response section found on this page
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskItemCompleteResult = boolean | null
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskItemCompleteResult>({
+        method: 'task.item.complete',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task marked as complete:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function completeTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // TODO: verify API version — no JSON response section found on this page
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.complete',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task marked as complete:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', completeTaskItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-defer.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-defer.md
@@ -54,25 +54,77 @@
     https://**put_your_bitrix24_address**/rest/task.item.defer
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.defer',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeferTaskItemResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeferTaskItemResult>({
+        method: 'task.item.defer',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task deferred:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deferTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.defer',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task deferred:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deferTaskItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-delegate.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-delegate.md
@@ -57,25 +57,73 @@
     https://**put_your_bitrix24_address**/rest/task.item.delegate
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.delegate',
-    		[13, 3]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version — the page has no JSON response shape
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DelegateResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DelegateResult>({
+        method: 'task.item.delegate',
+        params: [13, 3],
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task delegated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function delegateTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.delegate',
+            params: [13, 3],
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task delegated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', delegateTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-delete-file.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-delete-file.md
@@ -56,27 +56,78 @@
     https://your-domain.ru/rest/task.item.deletefile
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.deletefile',
-    		{
-    			TASK_ID: 3,
-    			ATTACHMENT_ID: 28
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteFileResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteFileResult>({
+        method: 'task.item.deletefile',
+        params: {
+          TASK_ID: 3,
+          ATTACHMENT_ID: 28,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File unlinked from task:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.deletefile',
+            params: {
+              TASK_ID: 3,
+              ATTACHMENT_ID: 28,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File unlinked from task:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-delete-from-favorite.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-delete-from-favorite.md
@@ -58,29 +58,83 @@
     https://your-domain.ru/rest/task.item.deletefromfavorite
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.deletefromfavorite',
-    		{
-    			TASK_ID: 10,
-    			PARAMS: {
-    				AFFECT_CHILDREN: "Y"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteFromFavoriteResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteFromFavoriteResult>({
+        method: 'task.item.deletefromfavorite',
+        params: {
+          TASK_ID: 10,
+          PARAMS: {
+            AFFECT_CHILDREN: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task removed from favorites:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFromFavorite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.deletefromfavorite',
+            params: {
+              TASK_ID: 10,
+              PARAMS: {
+                AFFECT_CHILDREN: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task removed from favorites:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFromFavorite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-delete.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-delete.md
@@ -54,25 +54,75 @@
     https://**put_your_bitrix24_address**/rest/task.item.delete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.delete',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      // TODO: verify API version — this page has no JSON response example
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.item.delete',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // TODO: verify API version — this page has no JSON response example
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.delete',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTaskItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-disapprove.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-disapprove.md
@@ -54,25 +54,76 @@
     https://**put_your_bitrix24_address**/rest/task.item.disapprove
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.disapprove',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DisapproveResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DisapproveResult>({
+        method: 'task.item.disapprove',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Disapprove result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function disapproveTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.disapprove',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Disapprove result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', disapproveTaskItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-get-allowed-actions.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-get-allowed-actions.md
@@ -78,25 +78,77 @@
     https://**put_your_bitrix24_address**/rest/task.item.getallowedactions
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.getallowedactions',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // The method returns an array of allowed action IDs for the task
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AllowedActionsResult = number[]
+
+    try {
+      const response = await $b24.actions.v2.call.make<AllowedActionsResult>({
+        method: 'task.item.getallowedactions',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Allowed action IDs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAllowedActions() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.getallowedactions',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Allowed action IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAllowedActions)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-get-allowed-task-actions-as-strings.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-get-allowed-task-actions-as-strings.md
@@ -54,25 +54,76 @@
     https://**put_your_bitrix24_address**/rest/task.item.getallowedtaskactionsasstrings
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.getallowedtaskactionsasstrings',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AllowedTaskActionsResult = Record<string, boolean>
+
+    try {
+      const response = await $b24.actions.v2.call.make<AllowedTaskActionsResult>({
+        method: 'task.item.getallowedtaskactionsasstrings',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Allowed task actions:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAllowedTaskActionsAsStrings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.getallowedtaskactionsasstrings',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Allowed task actions:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAllowedTaskActionsAsStrings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-get-data.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-get-data.md
@@ -54,25 +54,79 @@
     https://**put_your_bitrix24_address**/rest/task.item.getdata
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.getdata',
-    		[2]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskDataResult = {
+      [key: string]: unknown
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskDataResult>({
+        method: 'task.item.getdata',
+        params: {
+          TASKID: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.getdata',
+            params: {
+              TASKID: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-get-dependson.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-get-dependson.md
@@ -54,25 +54,73 @@
     https://**put_your_bitrix24_address**/rest/task.item.getdependson
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.getdependson',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number[]>({
+        method: 'task.item.getdependson',
+        params: {
+          TASKID: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dependent task IDs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskDependencies() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.getdependson',
+            params: {
+              TASKID: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dependent task IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskDependencies)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-get-description.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-get-description.md
@@ -60,25 +60,79 @@
     https://**put_your_bitrix24_address**/rest/task.item.getdescription
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.getdescription',
-    		[13, 1]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result
+    type TaskDescriptionResult = string
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskDescriptionResult>({
+        method: 'task.item.getdescription',
+        params: {
+          TASKID: 13,
+          USERID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task description:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskDescription() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.getdescription',
+            params: {
+              TASKID: 13,
+              USERID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task description:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskDescription)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-get-manifest.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-get-manifest.md
@@ -51,25 +51,74 @@
     https://**put_your_bitrix24_address**/rest/task.item.getmanifest
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.getmanifest',
-    		[]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result
+    // NOTE: the manifest format may change without notice — it is for reference only
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ManifestResult = Record<string, unknown>
+
+    try {
+      const response = await $b24.actions.v2.call.make<ManifestResult>({
+        method: 'task.item.getmanifest',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getManifest() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.getmanifest',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getManifest)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-is-action-allowed.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-is-action-allowed.md
@@ -57,25 +57,75 @@
     https://**put_your_bitrix24_address**/rest/task.item.isactionallowed
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.isactionallowed',
-    		[13, 6]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.item.isactionallowed',
+        params: {
+          TASKID: 13,
+          ACTION: 6,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Is action allowed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkIsActionAllowed() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.isactionallowed',
+            params: {
+              TASKID: 13,
+              ACTION: 6,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Is action allowed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkIsActionAllowed)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-list.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-list.md
@@ -134,44 +134,82 @@
     https://**put_your_bitrix24_address**/rest/task.item.list?auth=**put_access_token_here**
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (each task is a map of field values)
+    type TaskItemListResult = Record<string, unknown>[]
+
     try {
-      const response = await $b24.callListMethod(
-        'task.item.list',
-        {},
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('task.item.list', {}, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // task.item.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskItemListResult>({
+        method: 'task.item.list',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Tasks fetched:', result.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.item.list', {}, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTaskList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.item.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.list',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Tasks fetched:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTaskList)
+    </script>
     ```
 
 - PHP
@@ -254,71 +292,100 @@
     https://**put_your_bitrix24_address**/rest/task.item.list
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (each task is a map of field values)
+    type TaskItemListResult = Record<string, unknown>[]
+
     try {
-      const response = await $b24.callListMethod(
-        'task.item.list',
-        [
-          {ID: 'desc'},        // Сортировка по ID — по убыванию.
-          {ID: [1, 2, 3, 4, 5, 6]},    // Фильтр
-          {
-            NAV_PARAMS: { // постраничка
-              nPageSize: 2,    // по 2 элемента на странице.
-              iNumPage: 2    // страница номер 2        
-            }
-          }
-        ],
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('task.item.list', [
-        {ID: 'desc'},        // Сортировка по ID — по убыванию.
-        {ID: [1, 2, 3, 4, 5, 6]},    // Фильтр
-        {
-          NAV_PARAMS: { // постраничка
-            nPageSize: 2,    // по 2 элемента на странице.
-            iNumPage: 2    // страница номер 2        
-          }
-        }
-      ], 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+      // task.item.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskItemListResult>({
+        method: 'task.item.list',
+        params: {
+          order: { ID: 'desc' },
+          filter: { ID: [1, 2, 3, 4, 5, 6] },
+          params: {
+            NAV_PARAMS: {
+              nPageSize: 2,
+              iNumPage: 2,
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Tasks on page:', result.length)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.item.list', [
-        {ID: 'desc'},        // Сортировка по ID — по убыванию.
-        {ID: [1, 2, 3, 4, 5, 6]},    // Фильтр
-        {
-          NAV_PARAMS: { // постраничка
-            nPageSize: 2,    // по 2 элемента на странице.
-            iNumPage: 2    // страница номер 2        
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchFilteredTaskList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.item.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.list',
+            params: {
+              order: { ID: 'desc' },
+              filter: { ID: [1, 2, 3, 4, 5, 6] },
+              params: {
+                NAV_PARAMS: {
+                  nPageSize: 2,
+                  iNumPage: 2,
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
+
+          const result = response.getData().result
+          console.info('Tasks on page:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      ], 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchFilteredTaskList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-renew.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-renew.md
@@ -54,25 +54,77 @@
     https://**put_your_bitrix24_address**/rest/task.item.renew
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.renew',
-    		[13]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskRenewResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskRenewResult>({
+        method: 'task.item.renew',
+        params: {
+          taskId: 13,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task renewed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renewTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.renew',
+            params: {
+              taskId: 13,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task renewed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renewTaskItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-start-execution.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-start-execution.md
@@ -55,25 +55,77 @@
     https://**put_your_bitrix24_address**/rest/task.item.startexecution
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.startexecution',
-    		[3]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // TODO: verify API version — no JSON response shape found on the page
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StartExecutionResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<StartExecutionResult>({
+        method: 'task.item.startexecution',
+        params: {
+          taskId: 3,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task started:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startTaskExecution() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.startexecution',
+            params: {
+              taskId: 3,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task started:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startTaskExecution)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-item-update.md
+++ b/api-reference/tasks/deprecated/task-item/task-item-update.md
@@ -59,25 +59,82 @@
     https://**put_your_bitrix24_address**/rest/task.item.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.update',
-    		[1, {TIME_ESTIMATE: 113}]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskItemUpdateResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskItemUpdateResult>({
+        method: 'task.item.update',
+        params: {
+          taskId: 1,
+          fields: {
+            TIME_ESTIMATE: 113,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTaskItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.update',
+            params: {
+              taskId: 1,
+              fields: {
+                TIME_ESTIMATE: 113,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTaskItem)
+    </script>
     ```
 
 - PHP
@@ -169,25 +226,82 @@
     https://**put_your_bitrix24_address**/rest/task.item.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.item.update',
-    		[1, {UF_CRM_TASK: ["L_4", "C_7", "CO_5", "D_10"]}]
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskItemUpdateResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskItemUpdateResult>({
+        method: 'task.item.update',
+        params: {
+          taskId: 1,
+          fields: {
+            UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task CRM links updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTaskCrmLinks() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.update',
+            params: {
+              taskId: 1,
+              fields: {
+                UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task CRM links updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTaskCrmLinks)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-item/task-log-item-list.md
+++ b/api-reference/tasks/deprecated/task-item/task-log-item-list.md
@@ -56,44 +56,93 @@
     https://**put_your_bitrix24_address**/rest/task.logitem.list
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskLogItemListResult = Array<{
+      CREATED_DATE: ISODate | null
+      USER_ID: string
+      TASK_ID: string
+      FIELD: string
+      FROM_VALUE: string
+      TO_VALUE: string
+    }>
+
     try {
-      const response = await $b24.callListMethod(
-        'task.logitem.list',
-        [1205],
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('task.logitem.list', [1205], 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // task.logitem.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskLogItemListResult>({
+        method: 'task.logitem.list',
+        params: {
+          taskId: 1205,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Log items count:', result.length, 'First item:', result[0])
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.logitem.list', [1205], 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTaskLogItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.logitem.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.logitem.list',
+            params: {
+              taskId: 1205,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Log items count:', result.length, 'First item:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTaskLogItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/deprecated/task-items-get-list.md
+++ b/api-reference/tasks/deprecated/task-items-get-list.md
@@ -132,44 +132,82 @@
     https://**put_your_bitrix24_address**/rest/task.items.getlist?auth=**put_access_token_here**
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // TODO: verify API version — no response shape defined on this page
+    type TaskItem = Record<string, unknown>
+
     try {
-      const response = await $b24.callListMethod(
-        'task.items.getlist',
-        {},
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('task.items.getlist', {}, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // task.items.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskItem[]>({
+        method: 'task.items.getlist',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Tasks retrieved:', result.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.items.getlist', {}, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskItemsList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.items.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.items.getlist',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Tasks retrieved:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskItemsList)
+    </script>
     ```
 
 - PHP
@@ -253,71 +291,92 @@
     https://**put_your_bitrix24_address**/rest/task.items.getlist
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // TODO: verify API version — no response shape defined on this page
+    type TaskItem = Record<string, unknown>
+
     try {
-      const response = await $b24.callListMethod(
-        'task.items.getlist',
-        [
-          {ID: 'desc'},        // Сортировка по ID — по убыванию.
-          {ID: [1, 2, 3, 4, 5, 6]},    // Фильтр
-          ['ID', 'TITLE'],    // Выбираемые поля
-          {
-            NAV_PARAMS: {        // постраничка
-              iNumPage: 2        // страница номер 2
-            }
-          }
-        ],
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('task.items.getlist', [
-        {ID: 'desc'},        // Сортировка по ID — по убыванию.
-        {ID: [1, 2, 3, 4, 5, 6]},    // Фильтр
-        ['ID', 'TITLE'],    // Выбираемые поля
-        {
-          NAV_PARAMS: {        // постраничка
-            iNumPage: 2        // страница номер 2
-          }
-        }
-      ], 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+      // task.items.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskItem[]>({
+        method: 'task.items.getlist',
+        params: {
+          order: { ID: 'desc' },               // sort by ID descending
+          filter: { ID: [1, 2, 3, 4, 5, 6] },  // filter by IDs
+          select: ['ID', 'TITLE'],              // return only these fields
+          NAV_PARAMS: { iNumPage: 2 },          // page 2
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Tasks on page:', result.length)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.items.getlist', [
-        {ID: 'desc'},        // Сортировка по ID — по убыванию.
-        {ID: [1, 2, 3, 4, 5, 6]},    // Фильтр
-        ['ID', 'TITLE'],    // Выбираемые поля
-        {
-          NAV_PARAMS: {        // постраничка
-            iNumPage: 2        // страница номер 2
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskItemsListFiltered() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.items.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.items.getlist',
+            params: {
+              order: { ID: 'desc' },               // sort by ID descending
+              filter: { ID: [1, 2, 3, 4, 5, 6] },  // filter by IDs
+              select: ['ID', 'TITLE'],              // return only these fields
+              NAV_PARAMS: { iNumPage: 2 },          // page 2
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
+
+          const result = response.getData().result
+          console.info('Tasks on page:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      ], 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskItemsListFiltered)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-add.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-add.md
@@ -93,30 +93,84 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.elapseditem.add',
-    		{
-    			"TASKID" : 691,
-    			"ARFIELDS": {
-    				"SECONDS": 113, 
-    				"COMMENT_TEXT": "текст комментария",
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ElapsedItemAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<ElapsedItemAddResult>({
+        method: 'task.elapseditem.add',
+        params: {
+          TASKID: 691,
+          ARFIELDS: {
+            SECONDS: 113,
+            COMMENT_TEXT: 'comment text',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New elapsed item ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addElapsedItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.add',
+            params: {
+              TASKID: 691,
+              ARFIELDS: {
+                SECONDS: 113,
+                COMMENT_TEXT: 'comment text',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New elapsed item ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addElapsedItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-delete.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-delete.md
@@ -70,27 +70,79 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.delete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.elapseditem.delete',
-    		{
-    			"TASKID": 691,
-    			"ITEMID": 5,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // The server returns result:null on successful delete
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteElapsedItemResult = null
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteElapsedItemResult>({
+        method: 'task.elapseditem.delete',
+        params: {
+          TASKID: 691,
+          ITEMID: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Elapsed item deleted successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteElapsedItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.delete',
+            params: {
+              TASKID: 691,
+              ITEMID: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Elapsed item deleted successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteElapsedItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-get-list.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-get-list.md
@@ -151,48 +151,104 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.getlist
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'task.elapseditem.getlist',
-        [
-          1, 
-          {'ID': 'desc'},
-          {'<ID': 50}
-        ],
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    type ElapsedItem = {
+      ID: string
+      TASK_ID: string
+      USER_ID: string
+      COMMENT_TEXT: string
+      SECONDS: string
+      MINUTES: string
+      SOURCE: string
+      CREATED_DATE: ISODate | null
+      DATE_START: ISODate | null
+      DATE_STOP: ISODate | null
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('task.elapseditem.getlist', [{'ID': 'desc'}, {'>=CREATED_DATE': '2024-02-16'}, ['ID', 'TASK_ID'], {"NAV_PARAMS":{"nPageSize":2}}], 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // task.elapseditem.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ElapsedItem[]>({
+        method: 'task.elapseditem.getlist',
+        params: {
+          TASKID: 1,
+          ORDER: { ID: 'desc' },
+          FILTER: { '>=CREATED_DATE': '2024-02-16' },
+          SELECT: ['ID', 'TASK_ID'],
+          PARAMS: { NAV_PARAMS: { nPageSize: 2 } },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Elapsed items count:', result.length, 'First item:', result[0])
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('task.elapseditem.getlist', [{'ID': 'desc'}, {'>=CREATED_DATE': '2024-02-16'}, ['ID', 'TASK_ID'], {"NAV_PARAMS":{"nPageSize":2}}], 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getElapsedItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.elapseditem.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.getlist',
+            params: {
+              TASKID: 1,
+              ORDER: { ID: 'desc' },
+              FILTER: { '>=CREATED_DATE': '2024-02-16' },
+              SELECT: ['ID', 'TASK_ID'],
+              PARAMS: { NAV_PARAMS: { nPageSize: 2 } },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Elapsed items count:', result.length, 'First item:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getElapsedItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-get-manifest.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-get-manifest.md
@@ -45,24 +45,72 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.getmanifest
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.elapseditem.getmanifest',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetManifestResult = Record<string, unknown>
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetManifestResult>({
+        method: 'task.elapseditem.getmanifest',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getManifest() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.getmanifest',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getManifest)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-get.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-get.md
@@ -64,27 +64,89 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.get
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.elapseditem.get',
-    		{
-    			"TASKID": 691,
-    			"ITEMID": 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ElapsedItemResult = {
+      ID: string
+      TASK_ID: string
+      USER_ID: string
+      COMMENT_TEXT: string
+      SECONDS: string
+      MINUTES: string
+      SOURCE: string
+      CREATED_DATE: ISODate | null
+      DATE_START: ISODate | null
+      DATE_STOP: ISODate | null
+    }[]
+
+    try {
+      const response = await $b24.actions.v2.call.make<ElapsedItemResult>({
+        method: 'task.elapseditem.get',
+        params: {
+          TASKID: 691,
+          ITEMID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result[0].ID, result[0].SECONDS, result[0].CREATED_DATE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getElapsedItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.get',
+            params: {
+              TASKID: 691,
+              ITEMID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result[0].ID, result[0].SECONDS, result[0].CREATED_DATE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getElapsedItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-is-action-allowed.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-is-action-allowed.md
@@ -67,28 +67,77 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.isActionAllowed
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.elapseditem.isActionAllowed',
-    		{
-    			"TASKID" : 691,
-    			"ITEMID": 5,
-    			"ACTIONID": 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.elapseditem.isActionAllowed',
+        params: {
+          TASKID: 691,
+          ITEMID: 5,
+          ACTIONID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Is action allowed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkIsActionAllowed() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.isActionAllowed',
+            params: {
+              TASKID: 691,
+              ITEMID: 5,
+              ACTIONID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Is action allowed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkIsActionAllowed)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/elapsed-item/task-elapsed-item-update.md
+++ b/api-reference/tasks/elapsed-item/task-elapsed-item-update.md
@@ -97,31 +97,87 @@
     https://**put_your_bitrix24_address**/rest/task.elapseditem.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.elapseditem.update',
-    		{
-    			"TASKID": 691,
-    			"ITEMID": 5,
-    			"ARFIELDS": {
-    				"SECONDS": 113, 
-    				"COMMENT_TEXT": "текст комментария",
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // The method returns null on success
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateElapsedItemResult = null
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateElapsedItemResult>({
+        method: 'task.elapseditem.update',
+        params: {
+          TASKID: 691,
+          ITEMID: 5,
+          ARFIELDS: {
+            SECONDS: 113,
+            COMMENT_TEXT: 'comment text',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Elapsed item updated successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateElapsedItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.elapseditem.update',
+            params: {
+              TASKID: 691,
+              ITEMID: 5,
+              ARFIELDS: {
+                SECONDS: 113,
+                COMMENT_TEXT: 'comment text',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Elapsed item updated successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateElapsedItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/events-tasks/on-task-add.md
+++ b/api-reference/tasks/events-tasks/on-task-add.md
@@ -139,27 +139,78 @@ array(
 
 {% list tabs %}
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.bind',
-    		{
-    			"event": "onTaskAdd",
-    			"handler": "https://example.com/handler.php"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (event.bind returns true on success)
+    type BindEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<BindEventResult>({
+        method: 'event.bind',
+        params: {
+          event: 'onTaskAdd',
+          handler: 'https://example.com/handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event bound successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindOnTaskAddEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'onTaskAdd',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event bound successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindOnTaskAddEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/events-tasks/on-task-delete.md
+++ b/api-reference/tasks/events-tasks/on-task-delete.md
@@ -141,27 +141,78 @@ array(
 
 {% list tabs %}
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.bind',
-    		{
-    			"event": "onTaskDelete",
-    			"handler": "https://example.com/handler.php"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BindEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<BindEventResult>({
+        method: 'event.bind',
+        params: {
+          event: 'onTaskDelete',
+          handler: 'https://example.com/handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event bound successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindTaskDeleteEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'onTaskDelete',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event bound successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindTaskDeleteEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/events-tasks/on-task-update.md
+++ b/api-reference/tasks/events-tasks/on-task-update.md
@@ -139,27 +139,78 @@ array(
 
 {% list tabs %}
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.bind',
-    		{
-    			"event": "onTaskUpdate",
-    			"handler": "https://example.com/handler.php"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (event.bind returns true on success)
+    type EventBindResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<EventBindResult>({
+        method: 'event.bind',
+        params: {
+          event: 'onTaskUpdate',
+          handler: 'https://example.com/handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event bound successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindTaskUpdateEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'onTaskUpdate',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event bound successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindTaskUpdateEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-activate.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-activate.md
@@ -57,26 +57,73 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.activate
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.activate',
-    		{
-    			flowId: 517
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.flow.Flow.activate',
+        params: {
+          flowId: 517,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Flow activated/deactivated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function activateFlow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.activate',
+            params: {
+              flowId: 517,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Flow activated/deactivated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', activateFlow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-create.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-create.md
@@ -173,43 +173,119 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.create
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.create',
-    		{
-    			flowData: {
-    				name: 'Unique Flow Name',
-    				description: 'Описание потока',
-    				plannedCompletionTime: 7200,
-    				distributionType: 'manually',
-    				responsibleList: [
-    					[
-    						'user','3'
-    					]
-    				],
-    				taskCreators: [
-    					[
-    						'meta-user','all-users'
-    					]
-    				],
-    				matchWorkTime: 1,
-    				notifyAtHalfTime: 0
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FlowCreateResult = {
+      id: number
+      creatorId: number
+      ownerId: number
+      groupId: number
+      templateId: number
+      efficiency: number
+      active: boolean
+      plannedCompletionTime: number
+      activity: ISODate
+      name: string
+      description: string
+      distributionType: string
+      responsibleList: string[][]
+      demo: boolean
+      responsibleCanChangeDeadline: boolean
+      matchWorkTime: boolean
+      taskControl: boolean
+      notifyAtHalfTime: boolean
+      notifyOnQueueOverflow: number | null
+      notifyOnTasksInProgressOverflow: number | null
+      notifyWhenEfficiencyDecreases: number | null
+      taskCreators: string[][]
+      team: string[][]
+      trialFeatureEnabled: boolean
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FlowCreateResult>({
+        method: 'tasks.flow.Flow.create',
+        params: {
+          flowData: {
+            name: 'Unique Flow Name',
+            description: 'Flow description',
+            plannedCompletionTime: 7200,
+            distributionType: 'manually',
+            responsibleList: [['user', '3']],
+            taskCreators: [['meta-user', 'all-users']],
+            matchWorkTime: 1,
+            notifyAtHalfTime: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created flow:', result.id, result.name, result.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createFlow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.create',
+            params: {
+              flowData: {
+                name: 'Unique Flow Name',
+                description: 'Flow description',
+                plannedCompletionTime: 7200,
+                distributionType: 'manually',
+                responsibleList: [['user', '3']],
+                taskCreators: [['meta-user', 'all-users']],
+                matchWorkTime: 1,
+                notifyAtHalfTime: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created flow:', result.id, result.name, result.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createFlow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-delete.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-delete.md
@@ -63,28 +63,82 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.delete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.delete',
-    		{
-    			flowData: {
-    				id: 517
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FlowDeleteResult = {
+      deleted: boolean,
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FlowDeleteResult>({
+        method: 'tasks.flow.Flow.delete',
+        params: {
+          flowData: {
+            id: 517,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Flow deleted:', result.deleted)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFlow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.delete',
+            params: {
+              flowData: {
+                id: 517,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Flow deleted:', result.deleted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFlow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-get.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-get.md
@@ -56,26 +56,101 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.get
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.get',
-    		{
-    			flowId: 517
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FlowGetResult = {
+      id: number,
+      creatorId: number,
+      ownerId: number,
+      groupId: number,
+      templateId: number,
+      efficiency: number,
+      active: boolean,
+      plannedCompletionTime: number,
+      activity: ISODate | null,
+      name: string,
+      description: string,
+      distributionType: string,
+      responsibleList: string[][],
+      demo: boolean,
+      responsibleCanChangeDeadline: boolean,
+      matchWorkTime: boolean,
+      taskControl: boolean,
+      notifyAtHalfTime: boolean,
+      notifyOnQueueOverflow: number | null,
+      notifyOnTasksInProgressOverflow: number | null,
+      notifyWhenEfficiencyDecreases: number | null,
+      taskCreators: string[][],
+      team: string[][],
+      trialFeatureEnabled: boolean,
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FlowGetResult>({
+        method: 'tasks.flow.Flow.get',
+        params: {
+          flowId: 517,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Flow:', result.id, result.name, result.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFlow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.get',
+            params: {
+              flowId: 517,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Flow:', result.id, result.name, result.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFlow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-is-exists.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-is-exists.md
@@ -65,28 +65,82 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.isExists
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.isExists',
-    		{
-    			flowData: {
-    				name: 'Flow Name'
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FlowIsExistsResult = {
+      exists: boolean
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FlowIsExistsResult>({
+        method: 'tasks.flow.Flow.isExists',
+        params: {
+          flowData: {
+            name: 'Flow Name',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Flow exists:', result.exists)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkFlowIsExists() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.isExists',
+            params: {
+              flowData: {
+                name: 'Flow Name',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Flow exists:', result.exists)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkFlowIsExists)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-pin.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-pin.md
@@ -57,26 +57,76 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.pin
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.pin',
-    		{
-    			flowId: 517
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PinResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<PinResult>({
+        method: 'tasks.flow.Flow.pin',
+        params: {
+          flowId: 517,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pin result:', result) // true = pinned, false = unpinned
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pinFlow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.pin',
+            params: {
+              flowId: 517,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pin result:', result) // true = pinned, false = unpinned
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pinFlow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/flow/tasks-flow-flow-update.md
+++ b/api-reference/tasks/flow/tasks-flow-flow-update.md
@@ -178,44 +178,137 @@
     https://your-domain.bitrix24.com/rest/tasks.flow.Flow.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.flow.Flow.update',
-    		{
-    			flowData: {
-    				id: 517,
-    				name: 'Updated Flow Name',
-    				description: 'Updated description',
-    				plannedCompletionTime: 7200,
-    				distributionType: 'manually',
-    				responsibleList: [
-    					[
-    						'user','3'
-    					]
-    				],
-    				taskCreators: [
-    					[
-    						'meta-user','all-users'
-    					]
-    				],
-    				matchWorkTime: 1,
-    				notifyAtHalfTime: 0
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FlowUpdateResult = {
+      id: number
+      creatorId: number
+      ownerId: number
+      groupId: number
+      templateId: number
+      efficiency: number
+      active: boolean
+      plannedCompletionTime: number
+      activity: ISODate
+      name: string
+      description: string
+      distributionType: string
+      responsibleList: string[][]
+      demo: boolean
+      responsibleCanChangeDeadline: boolean
+      matchWorkTime: boolean
+      taskControl: boolean
+      notifyAtHalfTime: boolean
+      notifyOnQueueOverflow: number | null
+      notifyOnTasksInProgressOverflow: number
+      notifyWhenEfficiencyDecreases: number | null
+      taskCreators: string[][]
+      team: string[][]
+      trialFeatureEnabled: boolean
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FlowUpdateResult>({
+        method: 'tasks.flow.Flow.update',
+        params: {
+          flowData: {
+            id: 517,
+            name: 'Updated Flow Name',
+            description: 'Updated description',
+            plannedCompletionTime: 7200,
+            distributionType: 'manually',
+            responsibleList: [
+              [
+                'user', '3',
+              ],
+            ],
+            taskCreators: [
+              [
+                'meta-user', 'all-users',
+              ],
+            ],
+            matchWorkTime: 1,
+            notifyAtHalfTime: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated flow:', result.id, result.name, result.distributionType)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateFlow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.flow.Flow.update',
+            params: {
+              flowData: {
+                id: 517,
+                name: 'Updated Flow Name',
+                description: 'Updated description',
+                plannedCompletionTime: 7200,
+                distributionType: 'manually',
+                responsibleList: [
+                  [
+                    'user', '3',
+                  ],
+                ],
+                taskCreators: [
+                  [
+                    'meta-user', 'all-users',
+                  ],
+                ],
+                matchWorkTime: 1,
+                notifyAtHalfTime: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated flow:', result.id, result.name, result.distributionType)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateFlow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/planner/task-planner-get-list.md
+++ b/api-reference/tasks/planner/task-planner-get-list.md
@@ -45,51 +45,86 @@
     https://**put_your_bitrix24_address**/rest/task.planner.getlist
     ```
 
-- JS
+- TS
 
-    ```javascript
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    try {
-        const response = await $b24.callListMethod(
-        "task.planner.getlist",
-        {},
-        (progress) => {
-            console.log("Progress:", progress);
-        }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) {
-        console.log("Entity:", entity);
-        }
-    } catch (error) {
-        console.error("Request failed", error);
-    }
+    declare const $b24: B24Frame
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PlannerGetListResult = number[]
 
     try {
-        const generator = $b24.fetchListMethod("task.planner.getlist", {}, "ID");
-        for await (const page of generator) {
-        for (const entity of page) {
-            console.log("Entity:", entity);
-        }
-        }
-    } catch (error) {
-        console.error("Request failed", error);
-    }
+      // task.planner.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PlannerGetListResult>({
+        method: 'task.planner.getlist',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-        const response = await $b24.callMethod("task.planner.getlist", {}, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) {
-        console.log("Entity:", entity);
-        }
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task IDs in the day plan:', result, 'Total on this page:', result.length)
+      }
     } catch (error) {
-        console.error("Request failed", error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPlannerTaskList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.planner.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.planner.getlist',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task IDs in the day plan:', result, 'Total on this page:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPlannerTaskList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/result/tasks-task-result-add-from-comment.md
+++ b/api-reference/tasks/result/tasks-task-result-add-from-comment.md
@@ -62,27 +62,87 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.result.addFromComment
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.addFromComment',
-            {
-                commentId: 3199,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Task result added from comment:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskResultAddResult = {
+      id: number
+      taskId: number
+      commentId: number
+      createdBy: number
+      createdAt: ISODate
+      updatedAt: ISODate
+      status: number
+      text: string
+      formattedText: string
+      files: null
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskResultAddResult>({
+        method: 'tasks.task.result.addFromComment',
+        params: {
+          commentId: 3199,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.taskId, result.text)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskResultFromComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.result.addFromComment',
+            params: {
+              commentId: 3199,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.taskId, result.text)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskResultFromComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/result/tasks-task-result-delete-from-comment.md
+++ b/api-reference/tasks/result/tasks-task-result-delete-from-comment.md
@@ -62,27 +62,77 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.result.deleteFromComment
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.deleteFromComment',
-            {
-                commentId: 3199,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted comment with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // result is null on success (the comment was unfixed from the task result)
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteFromCommentResult = null
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteFromCommentResult>({
+        method: 'tasks.task.result.deleteFromComment',
+        params: {
+          commentId: 3199,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Comment successfully unfixed from task result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFromComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.result.deleteFromComment',
+            params: {
+              commentId: 3199,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Comment successfully unfixed from task result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFromComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/result/tasks-task-result-list.md
+++ b/api-reference/tasks/result/tasks-task-result-list.md
@@ -54,43 +54,99 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.result.list
     ```
 
-- JS
+- TS
 
-    ```javascript
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of one task result item returned in result[]
+    type TaskResultItem = {
+      id: number
+      taskId: number
+      commentId: number
+      createdBy: number
+      createdAt: ISODate | null
+      updatedAt: ISODate | null
+      status: number
+      text: string
+      formattedText: string
+      files: number[]
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'tasks.task.result.list',
-        { taskId: 8017 },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+      // tasks.task.result.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskResultItem[]>({
+        method: 'tasks.task.result.list',
+        params: {
+          taskId: 8017,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-
-    try {
-    const generator = $b24.fetchListMethod('tasks.task.result.list', { taskId: 8017 }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task results count:', result.length, 'First result:', result[0]?.id, result[0]?.text)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
+- UMD
 
-    try {
-    const response = await $b24.callMethod('tasks.task.result.list', { taskId: 8017 }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTaskResultList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // tasks.task.result.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.result.list',
+            params: {
+              taskId: 8017,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task results count:', result.length, 'First result:', result[0]?.id, result[0]?.text)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTaskResultList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/stages/task-stages-add.md
+++ b/api-reference/tasks/stages/task-stages-add.md
@@ -96,32 +96,89 @@
     https://your-domain.bitrix24.com/rest/task.stages.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.stages.add',
-    		{
-    			fields: {
-    				TITLE: 'Название стадии',
-    				COLOR: '#FFAAEE',
-    				AFTER_ID: 1,
-    				ENTITY_ID: 1
-    			},
-    			isAdmin: false,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // ID of the added stage returned in result
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StageAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<StageAddResult>({
+        method: 'task.stages.add',
+        params: {
+          fields: {
+            TITLE: 'Stage title',
+            COLOR: '#FFAAEE',
+            AFTER_ID: 1,
+            ENTITY_ID: 1,
+          },
+          isAdmin: false,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New stage ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.stages.add',
+            params: {
+              fields: {
+                TITLE: 'Stage title',
+                COLOR: '#FFAAEE',
+                AFTER_ID: 1,
+                ENTITY_ID: 1,
+              },
+              isAdmin: false,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New stage ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/stages/task-stages-can-move-task.md
+++ b/api-reference/tasks/stages/task-stages-can-move-task.md
@@ -65,27 +65,75 @@
     https://your-domain.bitrix24.com/rest/task.stages.canmovetask
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.stages.canmovetask',
-    		{
-    			entityId: entityId,
-    			entityType: entityType
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.stages.canmovetask',
+        params: {
+          entityId: 1,
+          entityType: 'U',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Can move task:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkCanMoveTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.stages.canmovetask',
+            params: {
+              entityId: 1,
+              entityType: 'U',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Can move task:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkCanMoveTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/stages/task-stages-delete.md
+++ b/api-reference/tasks/stages/task-stages-delete.md
@@ -61,26 +61,73 @@
     https://your-domain.bitrix24.com/rest/task.stages.delete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.stages.delete',
-    		{
-    			id: stageId,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.stages.delete',
+        params: {
+          id: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stage deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.stages.delete',
+            params: {
+              id: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stage deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/stages/task-stages-get.md
+++ b/api-reference/tasks/stages/task-stages-get.md
@@ -63,26 +63,91 @@
     https://your-domain.bitrix24.com/rest/task.stages.get
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.stages.get',
-    		{
-    			entityId: entityId,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each stage in the result map
+    type StageInfo = {
+      ID: string
+      TITLE: string
+      SORT: string
+      COLOR: string
+      SYSTEM_TYPE: string | null
+      ENTITY_ID: string
+      ENTITY_TYPE: string
+      ADDITIONAL_FILTER: unknown[]
+      TO_UPDATE: unknown[]
+      TO_UPDATE_ACCESS: null
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // result is a map of stage ID → StageInfo
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StagesGetResult = Record<string, StageInfo>
+
+    try {
+      const response = await $b24.actions.v2.call.make<StagesGetResult>({
+        method: 'task.stages.get',
+        params: {
+          entityId: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stages:', Object.values(result).map(s => `${s.ID}: ${s.TITLE}`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskStages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.stages.get',
+            params: {
+              entityId: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stages:', Object.values(result).map(s => `${s.ID}: ${s.TITLE}`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskStages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/stages/task-stages-move-task.md
+++ b/api-reference/tasks/stages/task-stages-move-task.md
@@ -79,29 +79,82 @@
     https://your-domain.bitrix24.com/rest/task.stages.movetask
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.stages.movetask',
-    		{
-    			id: taskId,
-    			stageId: stageId,
-    			before: 3,
-    			after: 4
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveTaskResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<MoveTaskResult>({
+        method: 'task.stages.movetask',
+        params: {
+          id: 1,
+          stageId: 2,
+          before: 3,
+          after: 4,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task moved successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.stages.movetask',
+            params: {
+              id: 1,
+              stageId: 2,
+              before: 3,
+              after: 4,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task moved successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/stages/task-stages-update.md
+++ b/api-reference/tasks/stages/task-stages-update.md
@@ -87,27 +87,83 @@
     https://your-domain.bitrix24.com/rest/task.stages.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.stages.update',
-    		{
-    			id: stageId,
-    			fields: fields
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.stages.update',
+        params: {
+          id: 5,
+          fields: {
+            TITLE: 'New Stage',
+            SORT: 200,
+            COLOR: 'FF5733',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stage updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.stages.update',
+            params: {
+              id: 5,
+              fields: {
+                TITLE: 'New Stage',
+                SORT: 200,
+                COLOR: 'FF5733',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stage updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/task-dependence-add.md
+++ b/api-reference/tasks/task-dependence-add.md
@@ -63,27 +63,80 @@
     https://**put_your_bitrix24_address**/rest/task.dependence.add
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.dependence.add', {
-    			"taskIdFrom": 100,
-    			"taskIdTo": 101,
-    			"linkType": 0
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (empty array on success)
+    type DependenceAddResult = unknown[]
+
+    try {
+      const response = await $b24.actions.v2.call.make<DependenceAddResult>({
+        method: 'task.dependence.add',
+        params: {
+          taskIdFrom: 100,
+          taskIdTo: 101,
+          linkType: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dependence added, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskDependence() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.dependence.add',
+            params: {
+              taskIdFrom: 100,
+              taskIdTo: 101,
+              linkType: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dependence added, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskDependence)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/task-dependence-delete.md
+++ b/api-reference/tasks/task-dependence-delete.md
@@ -56,26 +56,78 @@
     https://**put_your_bitrix24_address**/rest/task.dependence.delete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'task.dependence.delete', {
-    			"taskIdFrom": 100,
-    			"taskIdTo": 101,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (empty array on success)
+    type DeleteDependenceResult = never[]
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteDependenceResult>({
+        method: 'task.dependence.delete',
+        params: {
+          taskIdFrom: 100,
+          taskIdTo: 101,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dependency deleted successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDependence() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.dependence.delete',
+            params: {
+              taskIdFrom: 100,
+              taskIdTo: 101,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dependency deleted successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDependence)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-add.md
+++ b/api-reference/tasks/tasks-task-add.md
@@ -81,42 +81,97 @@ SE_PARAMETER: [
     https://**put_your_bitrix24_address**/rest/tasks.task.add
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            "tasks.task.add",
-            {
-                fields: {               
-                    TITLE: "Название задачи", // Название задачи
-                    DEADLINE: "2025-12-31T23:59:59", // Крайний срок
-                    CREATED_BY: 456, // Идентификатор постановщика
-                    RESPONSIBLE_ID: 123, // Идентификатор исполнителя
-                    // Пример передачи нескольких значений в поле UF_CRM_TASK
-                    UF_CRM_TASK: [
-                        "L_4", // Привязка к лиду
-                        "C_7", // Привязка к контакту
-                        "CO_5", // Привязка к компании
-                        "D_10" // Привязка к сделке
-                    ],
-                    // Пример передачи нескольких файлов в поле UF_TASK_WEBDAV_FILES
-                    UF_TASK_WEBDAV_FILES: [
-                        "n12345", // Идентификатор первого файла диска
-                        "n67890" // Идентификатор второго файла диска
-                    ]
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.info("Задача успешно создана с ID " + result.task.id);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Minimal shape of result.task; the API returns the full task object
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskAddResult = {
+      task: { id: string }
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskAddResult>({
+        method: 'tasks.task.add',
+        params: {
+          fields: {
+            TITLE: 'Task title', // Task title (required)
+            DEADLINE: '2025-12-31T23:59:59', // Deadline, ISO 8601
+            CREATED_BY: 456, // Creator ID
+            RESPONSIBLE_ID: 123, // Responsible person ID (required)
+            // Bind the task to several CRM entities via UF_CRM_TASK
+            UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'], // Lead 4 / Contact 7 / Company 5 / Deal 10
+            // Attach several Drive files via UF_TASK_WEBDAV_FILES (prefix IDs with "n")
+            UF_TASK_WEBDAV_FILES: ['n12345', 'n67890']
+          }
+        },
+        requestId: Text.getUuidRfc4122() // optional unique tracking id for this request
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(`Task created with ID ${result.task.id}`)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.add',
+            params: {
+              fields: {
+                TITLE: 'Task title', // Task title (required)
+                DEADLINE: '2025-12-31T23:59:59', // Deadline, ISO 8601
+                CREATED_BY: 456, // Creator ID
+                RESPONSIBLE_ID: 123, // Responsible person ID (required)
+                // Bind the task to several CRM entities via UF_CRM_TASK
+                UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'], // Lead 4 / Contact 7 / Company 5 / Deal 10
+                // Attach several Drive files via UF_TASK_WEBDAV_FILES (prefix IDs with "n")
+                UF_TASK_WEBDAV_FILES: ['n12345', 'n67890']
+              }
+            },
+            requestId: B24Js.Text.getUuidRfc4122() // optional unique tracking id for this request
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(`Task created with ID ${result.task.id}`)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-approve.md
+++ b/api-reference/tasks/tasks-task-approve.md
@@ -56,27 +56,83 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.approve
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.approve',
-            {
-                taskId: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Approved task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskApproveResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+        [key: string]: unknown
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskApproveResult>({
+        method: 'tasks.task.approve',
+        params: {
+          taskId: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Approved task:', result.task.id, result.task.title, 'status:', result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function approveTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.approve',
+            params: {
+              taskId: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Approved task:', result.task.id, result.task.title, 'status:', result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', approveTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-complete.md
+++ b/api-reference/tasks/tasks-task-complete.md
@@ -56,28 +56,83 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.complete
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.task.complete',
-            {
-                taskId: 1,
-            }
-    	);
-    	
-    	const result = response.getData().result;
-        console.log('Completed task with ID:', result);
-        
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result.task
+    type CompleteTaskResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+        [key: string]: unknown
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CompleteTaskResult>({
+        method: 'tasks.task.complete',
+        params: {
+          taskId: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Completed task:', result.task.id, result.task.title, result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function completeTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.complete',
+            params: {
+              taskId: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Completed task:', result.task.id, result.task.title, result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', completeTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-counters-get.md
+++ b/api-reference/tasks/tasks-task-counters-get.md
@@ -71,28 +71,89 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.counters.get
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.counters.get',
-            {
-                userId: 547,
-                groupId: 0,
-                type: 'view_all',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Task counters:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CounterInfo = {
+      counter: number
+      code: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CountersGetResult = {
+      expired?: CounterInfo
+      new_comments?: CounterInfo
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CountersGetResult>({
+        method: 'tasks.task.counters.get',
+        params: {
+          userId: 547,
+          groupId: 0,
+          type: 'view_all',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task counters:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskCounters() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.counters.get',
+            params: {
+              userId: 547,
+              groupId: 0,
+              type: 'view_all',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task counters:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskCounters)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-defer.md
+++ b/api-reference/tasks/tasks-task-defer.md
@@ -56,27 +56,82 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.defer
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.defer',
-            {
-                taskId: 1,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deferred task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result.task (match the "response handling" section)
+    type TaskDeferResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskDeferResult>({
+        method: 'tasks.task.defer',
+        params: {
+          taskId: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deferred task:', result.task.id, result.task.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deferTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.defer',
+            params: {
+              taskId: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deferred task:', result.task.id, result.task.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deferTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-delegate.md
+++ b/api-reference/tasks/tasks-task-delegate.md
@@ -60,28 +60,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.delegate
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.delegate',
-            {
-                taskId: 8017,
-                userId: 547,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Delegated task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskDelegateResult = {
+      task: {
+        id: string
+        title: string
+        responsibleId: string
+        status: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskDelegateResult>({
+        method: 'tasks.task.delegate',
+        params: {
+          taskId: 8017,
+          userId: 547,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Delegated task ID:', result.task.id, 'New responsible:', result.task.responsibleId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function delegateTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.delegate',
+            params: {
+              taskId: 8017,
+              userId: 547,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Delegated task ID:', result.task.id, 'New responsible:', result.task.responsibleId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', delegateTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-delete.md
+++ b/api-reference/tasks/tasks-task-delete.md
@@ -56,27 +56,79 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.delete
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.delete',
-            {
-                taskId: 8131,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // The API wraps the deletion flag: result.task === true on success
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskDeleteResult = {
+      task: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskDeleteResult>({
+        method: 'tasks.task.delete',
+        params: {
+          taskId: 8131 // ID of the task to delete
+        },
+        requestId: Text.getUuidRfc4122() // optional unique tracking id for this request
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else if (response.getData()!.result.task) {
+        console.info('Task deleted successfully')
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.delete',
+            params: {
+              taskId: 8131 // ID of the task to delete
+            },
+            requestId: B24Js.Text.getUuidRfc4122() // optional unique tracking id for this request
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          if (response.getData().result.task) {
+            console.info('Task deleted successfully')
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-disapprove.md
+++ b/api-reference/tasks/tasks-task-disapprove.md
@@ -56,27 +56,84 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.disapprove
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.disapprove',
-            {
-                taskId: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Disapproved task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskDisapproveResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+        responsibleId: string
+        [key: string]: unknown
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskDisapproveResult>({
+        method: 'tasks.task.disapprove',
+        params: {
+          taskId: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.task.id, result.task.title, result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function disapproveTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.disapprove',
+            params: {
+              taskId: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.task.id, result.task.title, result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', disapproveTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-favorite-add.md
+++ b/api-reference/tasks/tasks-task-favorite-add.md
@@ -54,27 +54,73 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.favorite.add
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.favorite.add',
-            {
-                taskId: 119,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Favorite added:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.task.favorite.add',
+        params: {
+          taskId: 119,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task added to favorites:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskToFavorites() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.favorite.add',
+            params: {
+              taskId: 119,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task added to favorites:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskToFavorites)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-favorite-remove.md
+++ b/api-reference/tasks/tasks-task-favorite-remove.md
@@ -54,27 +54,73 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.favorite.remove
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.favorite.remove',
-            {
-                taskId: 119,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Favorite removed:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.task.favorite.remove',
+        params: {
+          taskId: 119,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task removed from favorites:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function removeFavoriteTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.favorite.remove',
+            params: {
+              taskId: 119,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task removed from favorites:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', removeFavoriteTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-files-attach.md
+++ b/api-reference/tasks/tasks-task-files-attach.md
@@ -67,28 +67,80 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.files.attach
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.files.attach',
-            {
-                taskId: 8017,
-                fileId: 1065
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('File attached:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachFileResult = {
+      attachmentId: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachFileResult>({
+        method: 'tasks.task.files.attach',
+        params: {
+          taskId: 8017,
+          fileId: 1065,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Attachment ID:', result.attachmentId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function attachFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.files.attach',
+            params: {
+              taskId: 8017,
+              fileId: 1065,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Attachment ID:', result.attachmentId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', attachFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-get-access.md
+++ b/api-reference/tasks/tasks-task-get-access.md
@@ -60,28 +60,80 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.getaccess
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.getaccess',
-            {
-                taskId: 8017,
-                users: [503, 547],
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Access data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskAccessResult = {
+      allowedActions: Record<string, Record<string, boolean>>
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskAccessResult>({
+        method: 'tasks.task.getaccess',
+        params: {
+          taskId: 8017,
+          users: [503, 547],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Allowed actions by user:', result.allowedActions)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskAccess() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.getaccess',
+            params: {
+              taskId: 8017,
+              users: [503, 547],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Allowed actions by user:', result.allowedActions)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskAccess)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-get-fields.md
+++ b/api-reference/tasks/tasks-task-get-fields.md
@@ -45,25 +45,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.getFields
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.getFields',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Task fields:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // A single field descriptor and the map returned in result.fields
+    type TaskFieldDescription = {
+      title: string | null
+      type: string
+      required?: boolean
+      primary?: boolean
+      default?: unknown
+      values?: Record<string, string> | string[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskFieldsResult = {
+      fields: Record<string, TaskFieldDescription>
     }
+
+    try {
+      // tasks.task.getFields takes no parameters
+      const response = await $b24.actions.v2.call.make<TaskFieldsResult>({
+        method: 'tasks.task.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122() // optional unique tracking id for this request
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const fields = response.getData()!.result.fields
+        console.info(`Loaded ${Object.keys(fields).length} task fields`)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function loadTaskFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // tasks.task.getFields takes no parameters
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122() // optional unique tracking id for this request
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const fields = response.getData().result.fields
+          console.info(`Loaded ${Object.keys(fields).length} task fields`)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', loadTaskFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-get.md
+++ b/api-reference/tasks/tasks-task-get.md
@@ -71,36 +71,110 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.get
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.get',
-            {
-                taskId: 8017,
-                select: [
-                    'ID',
-                    'TITLE',
-                    'DESCRIPTION',
-                    'CREATED_BY',
-                    'RESPONSIBLE_ID',
-                    'DEADLINE',
-                    'UF_CRM_TASK',
-                    'UF_TASK_WEBDAV_FILES'
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Fetched task:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // result.task limited to the requested (select) fields, in the SDK camelCase form
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskGetResult = {
+      task: {
+        id: string
+        title: string
+        description: string
+        createdBy: string
+        responsibleId: string
+        deadline: ISODate | null
+        ufCrmTask: string[]
+        ufTaskWebdavFiles: number[]
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskGetResult>({
+        method: 'tasks.task.get',
+        params: {
+          taskId: 8017, // ID of the task to read
+          // Request only the fields you need
+          select: [
+            'ID',
+            'TITLE',
+            'DESCRIPTION',
+            'CREATED_BY',
+            'RESPONSIBLE_ID',
+            'DEADLINE',
+            'UF_CRM_TASK',
+            'UF_TASK_WEBDAV_FILES'
+          ]
+        },
+        requestId: Text.getUuidRfc4122() // optional unique tracking id for this request
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const task = response.getData()!.result.task
+        console.info(`Fetched task ${task.id}: ${task.title}`)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.get',
+            params: {
+              taskId: 8017, // ID of the task to read
+              // Request only the fields you need
+              select: [
+                'ID',
+                'TITLE',
+                'DESCRIPTION',
+                'CREATED_BY',
+                'RESPONSIBLE_ID',
+                'DEADLINE',
+                'UF_CRM_TASK',
+                'UF_TASK_WEBDAV_FILES'
+              ]
+            },
+            requestId: B24Js.Text.getUuidRfc4122() // optional unique tracking id for this request
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const task = response.getData().result.task
+          console.info(`Fetched task ${task.id}: ${task.title}`)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-history-list.md
+++ b/api-reference/tasks/tasks-task-history-list.md
@@ -66,60 +66,109 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.history.list
     ```
 
-- JS
+- TS
 
-    ```javascript
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskHistoryResult = {
+      list: Array<{
+        id: number
+        createdDate: ISODate
+        field: string
+        value: {
+          from: string | null
+          to: string | null
+        }
+        user: {
+          id: number
+          name: string
+          lastName: string
+          secondName: string
+          login: string
+        }
+      }>
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'tasks.task.history.list',
-        {
-            taskId: 8137,
-            filter: { FIELD: 'COMMENT' },
-            order: { createdDate: 'ASC' }
+      // tasks.task.history.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TaskHistoryResult>({
+        method: 'tasks.task.history.list',
+        params: {
+          taskId: 8137,
+          filter: { FIELD: 'COMMENT' },
+          order: { createdDate: 'ASC' },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('History entries:', result.list.length, result.list)
+      }
     } catch (error) {
-    console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+- UMD
 
-    try {
-    const generator = $b24.fetchListMethod('tasks.task.history.list', {
-        taskId: 8137,
-        filter: { FIELD: 'COMMENT' },
-        order: { createdDate: 'ASC' }
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTaskHistory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
+          // tasks.task.history.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.history.list',
+            params: {
+              taskId: 8137,
+              filter: { FIELD: 'COMMENT' },
+              order: { createdDate: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-    try {
-    const response = await $b24.callMethod('tasks.task.history.list', {
-        taskId: 8137,
-        filter: { FIELD: 'COMMENT' },
-        order: { createdDate: 'ASC' }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('History entries:', result.list.length, result.list)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTaskHistory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-list.md
+++ b/api-reference/tasks/tasks-task-list.md
@@ -169,114 +169,149 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.list
     ```
 
-- JS
+- TS
 
-    ```javascript
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of a single task in result.tasks. Only the fields read below are typed here;
+    // the request selects more — add them to this type as you start using them.
+    type TaskListItem = {
+      id: string
+      title: string
+      status: string
+      deadline: ISODate | null
+      responsibleId: string
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'tasks.task.list',
-        {
-        order: {
-            'DEADLINE': 'asc',
-            'PRIORITY': 'desc'
-        },
-        filter: {
-            '!STATUS': 6,
-            '>=DEADLINE': new Date().toISOString().split('T')[0],
-            'RESPONSIBLE_ID': 547,
-            '::SUBFILTER-PARAMS': { 'FAVORITE': 'Y' }
-        },
-        select: [
+      // tasks.task.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<{ tasks: TaskListItem[] }>({
+        method: 'tasks.task.list',
+        params: {
+          // Sorting: nearest deadline first, then higher priority
+          order: { DEADLINE: 'asc', PRIORITY: 'desc' },
+          filter: {
+            '!STATUS': 6, // exclude deferred tasks
+            '>=DEADLINE': new Date().toISOString().split('T')[0], // not overdue (UTC date; adjust to the portal time zone if needed)
+            RESPONSIBLE_ID: 547, // tasks of a specific responsible person
+            '::SUBFILTER-PARAMS': { FAVORITE: 'Y' } // favorites only
+          },
+          // Request only the fields you need
+          select: [
             'ID', 'TITLE', 'DESCRIPTION', 'STATUS', 'subStatus',
             'DEADLINE', 'CREATED_DATE', 'RESPONSIBLE_ID',
             'ACCOMPLICES', 'AUDITORS', 'TAGS', 'COUNTERS',
             'PRIORITY', 'MARK'
-        ],
-        params: {
-            'WITH_TIMER_INFO': true,
-            'WITH_RESULT_INFO': true,
-            'WITH_PARSED_DESCRIPTION': true,
+          ],
+          // Extra computed data
+          params: {
+            WITH_TIMER_INFO: true,
+            WITH_RESULT_INFO: true,
+            WITH_PARSED_DESCRIPTION: true
+          },
+          // Page offset (not the page number): the page size is fixed at 50, so the
+          // Nth page is start = (N - 1) * 50.
+          start: 0
         },
-        },
-        (progress) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122() // optional unique tracking id for this request
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const tasks = response.getData()!.result.tasks
+        // getTotal() is deprecated (removed in SDK 2.0); for the full match count fetch
+        // everything via a list helper (see above) and read its length.
+        console.info(`Loaded ${tasks.length} tasks (one page)`)
+        for (const task of tasks) {
+          console.info(`#${task.id}: ${task.title}`)
+        }
+      }
     } catch (error) {
-    console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+- UMD
 
-    try {
-    const generator = $b24.fetchListMethod('tasks.task.list', {
-        order: {
-        'DEADLINE': 'asc',
-        'PRIORITY': 'desc'
-        },
-        filter: {
-        '!STATUS': 6,
-        '>=DEADLINE': new Date().toISOString().split('T')[0],
-        'RESPONSIBLE_ID': 547,
-        '::SUBFILTER-PARAMS': { 'FAVORITE': 'Y' }
-        },
-        select: [
-        'ID', 'TITLE', 'DESCRIPTION', 'STATUS', 'subStatus',
-        'DEADLINE', 'CREATED_DATE', 'RESPONSIBLE_ID',
-        'ACCOMPLICES', 'AUDITORS', 'TAGS', 'COUNTERS',
-        'PRIORITY', 'MARK'
-        ],
-        params: {
-        'WITH_TIMER_INFO': true,
-        'WITH_RESULT_INFO': true,
-        'WITH_PARSED_DESCRIPTION': true,
-        },
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listTasks() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
+          // tasks.task.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.list',
+            params: {
+              // Sorting: nearest deadline first, then higher priority
+              order: { DEADLINE: 'asc', PRIORITY: 'desc' },
+              filter: {
+                '!STATUS': 6, // exclude deferred tasks
+                '>=DEADLINE': new Date().toISOString().split('T')[0], // not overdue (UTC date; adjust to the portal time zone if needed)
+                RESPONSIBLE_ID: 547, // tasks of a specific responsible person
+                '::SUBFILTER-PARAMS': { FAVORITE: 'Y' } // favorites only
+              },
+              // Request only the fields you need
+              select: [
+                'ID', 'TITLE', 'DESCRIPTION', 'STATUS', 'subStatus',
+                'DEADLINE', 'CREATED_DATE', 'RESPONSIBLE_ID',
+                'ACCOMPLICES', 'AUDITORS', 'TAGS', 'COUNTERS',
+                'PRIORITY', 'MARK'
+              ],
+              // Extra computed data
+              params: {
+                WITH_TIMER_INFO: true,
+                WITH_RESULT_INFO: true,
+                WITH_PARSED_DESCRIPTION: true
+              },
+              // Page offset (not the page number): the page size is fixed at 50, so the
+              // Nth page is start = (N - 1) * 50.
+              start: 0
+            },
+            requestId: B24Js.Text.getUuidRfc4122() // optional unique tracking id for this request
+          })
 
-    try {
-    const response = await $b24.callMethod('tasks.task.list', {
-        order: {
-        'DEADLINE': 'asc',
-        'PRIORITY': 'desc'
-        },
-        filter: {
-        '!STATUS': 6,
-        '>=DEADLINE': new Date().toISOString().split('T')[0],
-        'RESPONSIBLE_ID': 547,
-        '::SUBFILTER-PARAMS': { 'FAVORITE': 'Y' }
-        },
-        select: [
-        'ID', 'TITLE', 'DESCRIPTION', 'STATUS', 'subStatus',
-        'DEADLINE', 'CREATED_DATE', 'RESPONSIBLE_ID',
-        'ACCOMPLICES', 'AUDITORS', 'TAGS', 'COUNTERS',
-        'PRIORITY', 'MARK'
-        ],
-        params: {
-        'WITH_TIMER_INFO': true,
-        'WITH_RESULT_INFO': true,
-        'WITH_PARSED_DESCRIPTION': true,
-        },
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const tasks = response.getData().result.tasks
+          // getTotal() is deprecated (removed in SDK 2.0); for the full match count fetch
+          // everything via a list helper (see above) and read its length.
+          console.info(`Loaded ${tasks.length} tasks (one page)`)
+          for (const task of tasks) {
+            console.info(`#${task.id}: ${task.title}`)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listTasks)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-mute.md
+++ b/api-reference/tasks/tasks-task-mute.md
@@ -54,27 +54,81 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.mute
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.mute',
-            {
-                id: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Muted task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskMuteResult = {
+      task: {
+        id: string
+        isMuted: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskMuteResult>({
+        method: 'tasks.task.mute',
+        params: {
+          id: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task muted, isMuted:', result.task.isMuted, 'taskId:', result.task.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function muteTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.mute',
+            params: {
+              id: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task muted, isMuted:', result.task.isMuted, 'taskId:', result.task.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', muteTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-pause.md
+++ b/api-reference/tasks/tasks-task-pause.md
@@ -56,27 +56,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.pause
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.pause',
-            {
-                taskId: 1,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deferred task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result.task
+    type TaskPauseResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+        createdDate: ISODate | null
+        changedDate: ISODate | null
+        deadline: ISODate | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskPauseResult>({
+        method: 'tasks.task.pause',
+        params: {
+          taskId: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task paused — id:', result.task.id, 'status:', result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pauseTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.pause',
+            params: {
+              taskId: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task paused — id:', result.task.id, 'status:', result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pauseTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-pin.md
+++ b/api-reference/tasks/tasks-task-pin.md
@@ -54,27 +54,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.pin
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.pin',
-            {
-                id: 3897,
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Pinned task:', result.task);
+    declare const $b24: B24Frame
 
-        processResult(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskPinResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+        isPinned: string
+        createdDate: ISODate | null
+        deadline: ISODate | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskPinResult>({
+        method: 'tasks.task.pin',
+        params: {
+          id: 3897,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pinned task:', result.task.id, result.task.title, result.task.isPinned)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pinTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.pin',
+            params: {
+              id: 3897,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pinned task:', result.task.id, result.task.title, result.task.isPinned)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pinTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-renew.md
+++ b/api-reference/tasks/tasks-task-renew.md
@@ -56,27 +56,82 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.renew
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.renew',
-            {
-                taskId: 1,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deferred task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskRenewResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskRenewResult>({
+        method: 'tasks.task.renew',
+        params: {
+          taskId: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Renewed task:', result.task.id, result.task.title, result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renewTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.renew',
+            params: {
+              taskId: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Renewed task:', result.task.id, result.task.title, result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renewTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-start-watch.md
+++ b/api-reference/tasks/tasks-task-start-watch.md
@@ -54,27 +54,87 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.startwatch
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.startwatch',
-            {
-                taskId: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Started watching task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type TaskData = {
+      id: string
+      title: string
+      status: string
+      responsibleId: string
+      createdDate: ISODate | null
+      deadline: ISODate | null
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskStartWatchResult = {
+      task: TaskData
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskStartWatchResult>({
+        method: 'tasks.task.startwatch',
+        params: {
+          taskId: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Watching task:', result.task.id, result.task.title, result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startWatchTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.startwatch',
+            params: {
+              taskId: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Watching task:', result.task.id, result.task.title, result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startWatchTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-start.md
+++ b/api-reference/tasks/tasks-task-start.md
@@ -56,27 +56,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.start
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.start',
-            {
-                taskId: 1,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deferred task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskStartResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+        responsibleId: string
+        createdDate: ISODate | null
+        deadline: ISODate | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskStartResult>({
+        method: 'tasks.task.start',
+        params: {
+          taskId: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task started:', result.task.id, result.task.title, result.task.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.start',
+            params: {
+              taskId: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task started:', result.task.id, result.task.title, result.task.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-stop-watch.md
+++ b/api-reference/tasks/tasks-task-stop-watch.md
@@ -54,27 +54,82 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.stopwatch
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.stopwatch',
-            {
-                taskId: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Stopped watching task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StopWatchResult = {
+      task: {
+        id: string
+        title: string
+        status: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StopWatchResult>({
+        method: 'tasks.task.stopwatch',
+        params: {
+          taskId: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stopped watching task:', result.task.id, result.task.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function stopWatch() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.stopwatch',
+            params: {
+              taskId: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stopped watching task:', result.task.id, result.task.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', stopWatch)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-unmute.md
+++ b/api-reference/tasks/tasks-task-unmute.md
@@ -54,27 +54,83 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.unmute
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.unmute',
-            {
-                id: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Unmuted task with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result.task
+    type TaskUnmuteResult = {
+      task: {
+        id: string
+        isMuted: string
+        title: string
+        status: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskUnmuteResult>({
+        method: 'tasks.task.unmute',
+        params: {
+          id: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task unmuted:', result.task.id, '| isMuted:', result.task.isMuted, '| title:', result.task.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unmuteTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.unmute',
+            params: {
+              id: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task unmuted:', result.task.id, '| isMuted:', result.task.isMuted, '| title:', result.task.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unmuteTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-unpin.md
+++ b/api-reference/tasks/tasks-task-unpin.md
@@ -54,27 +54,82 @@
     https://**put_your_bitrix24_address**/rest/tasks.task.unpin
     ```
 
-- JS
+- TS
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.unpin',
-            {
-                id: 3897,
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Unpinned task:', result.task);
+    declare const $b24: B24Frame
 
-        processResult(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UnpinTaskResult = {
+      task: {
+        id: string
+        title: string
+        isPinned: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UnpinTaskResult>({
+        method: 'tasks.task.unpin',
+        params: {
+          id: 3897,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unpinned task id:', result.task.id, 'isPinned:', result.task.isPinned)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unpinTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.unpin',
+            params: {
+              id: 3897,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unpinned task id:', result.task.id, 'isPinned:', result.task.isPinned)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unpinTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/tasks-task-update.md
+++ b/api-reference/tasks/tasks-task-update.md
@@ -77,41 +77,93 @@ SE_PARAMETER: [
     https://**put_your_bitrix24_address**/rest/tasks.task.update
     ```
 
-- JS
+- TS
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"tasks.task.update",
-    		{
-    			taskId: 11, // Идентификатор задачи, которую вы хотите обновить
-    			fields: {
-    				// Пример передачи нескольких значений в поле UF_CRM_TASK
-    				UF_CRM_TASK: [
-    					"L_4", // Привязка к лиду с id 4
-    					"C_7", // Привязка к контакту с id 7
-    					"CO_5", // Привязка к компании с id 5
-    					"D_10" // Привязка к сделке с id 10
-    				],
-    				// Пример передачи нескольких файлов в поле UF_TASK_WEBDAV_FILES
-    				UF_TASK_WEBDAV_FILES: [
-    					"n12345", // Идентификатор первого файла диска
-    					"n67890" // Идентификатор второго файла диска
-    				],
-    				RESPONSIBLE_ID: 123 // Идентификатор нового исполнителя
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("Задача успешно обновлена");
+    declare const $b24: B24Frame
+
+    // Minimal shape of result.task; the API returns the full task object
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskUpdateResult = {
+      task: { id: string }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskUpdateResult>({
+        method: 'tasks.task.update',
+        params: {
+          taskId: 11, // ID of the task to update
+          fields: {
+            // Bind the task to several CRM entities via UF_CRM_TASK
+            UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'], // Lead 4 / Contact 7 / Company 5 / Deal 10
+            // Attach several Drive files via UF_TASK_WEBDAV_FILES (prefix IDs with "n")
+            UF_TASK_WEBDAV_FILES: ['n12345', 'n67890'],
+            RESPONSIBLE_ID: 123 // New responsible person ID
+          }
+        },
+        requestId: Text.getUuidRfc4122() // optional unique tracking id for this request
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(`Task ${result.task.id} updated`)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.task.update',
+            params: {
+              taskId: 11, // ID of the task to update
+              fields: {
+                // Bind the task to several CRM entities via UF_CRM_TASK
+                UF_CRM_TASK: ['L_4', 'C_7', 'CO_5', 'D_10'], // Lead 4 / Contact 7 / Company 5 / Deal 10
+                // Attach several Drive files via UF_TASK_WEBDAV_FILES (prefix IDs with "n")
+                UF_TASK_WEBDAV_FILES: ['n12345', 'n67890'],
+                RESPONSIBLE_ID: 123 // New responsible person ID
+              }
+            },
+            requestId: B24Js.Text.getUuidRfc4122() // optional unique tracking id for this request
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(`Task ${result.task.id} updated`)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-add-attachment-by-content.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-add-attachment-by-content.md
@@ -92,30 +92,112 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.addAttachmentByContent
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.addAttachmentByContent',
-            {
-                templateId: 139,
-                checkListItemId: 37,
-                attachmentParameters: {
-                    NAME: 'dashboard-note.txt',
-                    CONTENT: 'RGFzaGJvYXJkIG5vdGU='
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CheckListItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: Array<{
+          id: string
+          type: string
+          name: string
+          personalPhoto: string
+          personalGender: string
+          image: string
+          isCollaber: boolean
+        }>
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CheckListItemResult>({
+        method: 'tasks.template.checklist.addAttachmentByContent',
+        params: {
+          templateId: 139,
+          checkListItemId: 37,
+          attachmentParameters: {
+            NAME: 'dashboard-note.txt',
+            CONTENT: 'RGFzaGJvYXJkIG5vdGU=',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem.id, result.checkListItem.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addAttachmentByContent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.addAttachmentByContent',
+            params: {
+              templateId: 139,
+              checkListItemId: 37,
+              attachmentParameters: {
+                NAME: 'dashboard-note.txt',
+                CONTENT: 'RGFzaGJvYXJkIG5vdGU=',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem.id, result.checkListItem.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addAttachmentByContent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-add-attachments-from-disk.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-add-attachments-from-disk.md
@@ -85,27 +85,106 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.addAttachmentsFromDisk
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.addAttachmentsFromDisk',
-            {
-                templateId: 139,
-                checkListItemId: 37,
-                filesIds: ['n5065', 'n5067']
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddAttachmentsResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: Array<{
+          id: string
+          type: string
+          name: string
+          personalPhoto: string
+          personalGender: string
+          image: string
+          isCollaber: boolean
+        }>
+        attachments: Record<string, string>
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddAttachmentsResult>({
+        method: 'tasks.template.checklist.addAttachmentsFromDisk',
+        params: {
+          templateId: 139,
+          checkListItemId: 37,
+          filesIds: ['n5065', 'n5067'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem.id, result.checkListItem.attachments)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addAttachmentsFromDisk() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.addAttachmentsFromDisk',
+            params: {
+              templateId: 139,
+              checkListItemId: 37,
+              filesIds: ['n5065', 'n5067'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem.id, result.checkListItem.attachments)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addAttachmentsFromDisk)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-add.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-add.md
@@ -122,37 +122,118 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.add
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.add',
-            {
-                templateId: 139,
-                fields: {
-                    TITLE: '4. Подготовить дашборд',
-                    PARENT_ID: 23,
-                    SORT_INDEX: 200,
-                    IS_COMPLETE: 'N',
-                    IS_IMPORTANT: 'Y',
-                    MEMBERS: {
-                        547: {
-                            TYPE: 'A'
-                        }
-                    }
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ChecklistItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number
+        parentId: number
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: { type: string; id: number }[]
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ChecklistItemResult>({
+        method: 'tasks.template.checklist.add',
+        params: {
+          templateId: 139,
+          fields: {
+            TITLE: '4. Prepare the dashboard',
+            PARENT_ID: 23,
+            SORT_INDEX: 200,
+            IS_COMPLETE: 'N',
+            IS_IMPORTANT: 'Y',
+            MEMBERS: {
+              547: {
+                TYPE: 'A',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem.id, result.checkListItem.title, result.checkListItem.isComplete)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.add',
+            params: {
+              templateId: 139,
+              fields: {
+                TITLE: '4. Prepare the dashboard',
+                PARENT_ID: 23,
+                SORT_INDEX: 200,
+                IS_COMPLETE: 'N',
+                IS_IMPORTANT: 'Y',
+                MEMBERS: {
+                  547: {
+                    TYPE: 'A',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem.id, result.checkListItem.title, result.checkListItem.isComplete)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-complete.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-complete.md
@@ -65,26 +65,96 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.complete
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.complete',
-            {
-                templateId: 139,
-                checkListItemId: 27
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CompleteCheckListItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number | null
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: unknown[]
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CompleteCheckListItemResult>({
+        method: 'tasks.template.checklist.complete',
+        params: {
+          templateId: 139,
+          checkListItemId: 27,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item', result.checkListItem.id, 'completed:', result.checkListItem.isComplete)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function completeCheckListItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.complete',
+            params: {
+              templateId: 139,
+              checkListItemId: 27,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item', result.checkListItem.id, 'completed:', result.checkListItem.isComplete)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', completeCheckListItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-delete.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-delete.md
@@ -65,26 +65,75 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.delete
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.delete',
-            {
-                templateId: 139,
-                checkListItemId: 29
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.template.checklist.delete',
+        params: {
+          templateId: 139,
+          checkListItemId: 29,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Checklist item deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.delete',
+            params: {
+              templateId: 139,
+              checkListItemId: 29,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Checklist item deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-get.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-get.md
@@ -65,26 +65,96 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.get
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.get',
-            {
-                templateId: 139,
-                checkListItemId: 37
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CheckListItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number | null
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: object[]
+        attachments: Record<string, string>
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CheckListItemResult>({
+        method: 'tasks.template.checklist.get',
+        params: {
+          templateId: 139,
+          checkListItemId: 37,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.get',
+            params: {
+              templateId: 139,
+              checkListItemId: 37,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-list.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-list.md
@@ -138,105 +138,140 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.list
     ```
 
-- JS
+- TS
 
-    ```javascript
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    try {
-        const response = await $b24.callListMethod(
-            'tasks.template.checklist.list',
-            {
-                templateId: 139,
-                filter: {
-                    IS_COMPLETE: 'N',
-                    IS_IMPORTANT: 'N'
-                },
-                select: [
-                    'ID',
-                    'TEMPLATE_ID',
-                    'PARENT_ID',
-                    'TITLE',
-                    'SORT_INDEX',
-                    'IS_COMPLETE',
-                    'IS_IMPORTANT'
-                ],
-                order: {
-                    SORT_INDEX: 'asc',
-                    ID: 'desc'
-                }
-            },
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    type CheckListItem = {
+      id: string
+      templateId: string
+      parentId: number | string
+      title: string
+      sortIndex: string
+      isComplete: string
+      isImportant: string
     }
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CheckListItemsResult = {
+      checkListItems: Record<string, CheckListItem>
+    }
 
     try {
-        const generator = $b24.fetchListMethod('tasks.template.checklist.list', {
-            templateId: 139,
-            filter: {
+      // tasks.template.checklist.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CheckListItemsResult>({
+        method: 'tasks.template.checklist.list',
+        params: {
+          templateId: 139,
+          filter: {
+            IS_COMPLETE: 'N',
+            IS_IMPORTANT: 'N',
+          },
+          select: [
+            'ID',
+            'TEMPLATE_ID',
+            'PARENT_ID',
+            'TITLE',
+            'SORT_INDEX',
+            'IS_COMPLETE',
+            'IS_IMPORTANT',
+          ],
+          order: {
+            SORT_INDEX: 'asc',
+            ID: 'desc',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          'Checklist items count:', Object.keys(result.checkListItems).length,
+          'Items:', result.checkListItems
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listTemplateChecklistItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // tasks.template.checklist.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.list',
+            params: {
+              templateId: 139,
+              filter: {
                 IS_COMPLETE: 'N',
-                IS_IMPORTANT: 'N'
-            },
-            select: [
+                IS_IMPORTANT: 'N',
+              },
+              select: [
                 'ID',
                 'TEMPLATE_ID',
                 'PARENT_ID',
                 'TITLE',
                 'SORT_INDEX',
                 'IS_COMPLETE',
-                'IS_IMPORTANT'
-            ],
-            order: {
+                'IS_IMPORTANT',
+              ],
+              order: {
                 SORT_INDEX: 'asc',
-                ID: 'desc'
-            }
-        }, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity) }
+                ID: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            'Checklist items count:', Object.keys(result.checkListItems).length,
+            'Items:', result.checkListItems
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+      }
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-        const response = await $b24.callMethod('tasks.template.checklist.list', {
-            templateId: 139,
-            filter: {
-                IS_COMPLETE: 'N',
-                IS_IMPORTANT: 'N'
-            },
-            select: [
-                'ID',
-                'TEMPLATE_ID',
-                'PARENT_ID',
-                'TITLE',
-                'SORT_INDEX',
-                'IS_COMPLETE',
-                'IS_IMPORTANT'
-            ],
-            order: {
-                SORT_INDEX: 'asc',
-                ID: 'desc'
-            }
-        }, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+      document.addEventListener('DOMContentLoaded', listTemplateChecklistItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-move-after.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-move-after.md
@@ -69,27 +69,98 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.moveAfter
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.moveAfter',
-            {
-                templateId: 139,
-                checkListItemId: 25,
-                afterItemId: 29
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result
+    type CheckListItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number | null
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: unknown[]
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CheckListItemResult>({
+        method: 'tasks.template.checklist.moveAfter',
+        params: {
+          templateId: 139,
+          checkListItemId: 25,
+          afterItemId: 29,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.moveAfter',
+            params: {
+              templateId: 139,
+              checkListItemId: 25,
+              afterItemId: 29,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-move-before.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-move-before.md
@@ -71,27 +71,93 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.moveBefore
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.moveBefore',
-            {
-                templateId: 139,
-                checkListItemId: 37,
-                beforeItemId: 29
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveBeforeResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number
+        title: string
+        sortIndex: number
+        isComplete: boolean
+        isImportant: boolean
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MoveBeforeResult>({
+        method: 'tasks.template.checklist.moveBefore',
+        params: {
+          templateId: 139,
+          checkListItemId: 37,
+          beforeItemId: 29,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Moved item id:', result.checkListItem.id, 'title:', result.checkListItem.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveChecklistItemBefore() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.moveBefore',
+            params: {
+              templateId: 139,
+              checkListItemId: 37,
+              beforeItemId: 29,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Moved item id:', result.checkListItem.id, 'title:', result.checkListItem.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveChecklistItemBefore)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-remove-attachments.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-remove-attachments.md
@@ -75,27 +75,106 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.removeAttachments
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.removeAttachments',
-            {
-                templateId: 139,
-                checkListItemId: 37,
-                attachmentsIds: [1119, 1121]
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CheckListItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: Array<{
+          id: string
+          type: string
+          name: string
+          personalPhoto: string
+          personalGender: string
+          image: string
+          isCollaber: boolean
+        }>
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CheckListItemResult>({
+        method: 'tasks.template.checklist.removeAttachments',
+        params: {
+          templateId: 139,
+          checkListItemId: 37,
+          attachmentsIds: [1119, 1121],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated checklist item:', result.checkListItem)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function removeAttachments() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.removeAttachments',
+            params: {
+              templateId: 139,
+              checkListItemId: 37,
+              attachmentsIds: [1119, 1121],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated checklist item:', result.checkListItem)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', removeAttachments)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-renew.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-renew.md
@@ -65,26 +65,96 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.renew
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.renew',
-            {
-                templateId: 139,
-                checkListItemId: 27
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ChecklistRenewResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number | null
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: unknown[]
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ChecklistRenewResult>({
+        method: 'tasks.template.checklist.renew',
+        params: {
+          templateId: 139,
+          checkListItemId: 27,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renewChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.renew',
+            params: {
+              templateId: 139,
+              checkListItemId: 27,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renewChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/checklist/tasks-template-checklist-update.md
+++ b/api-reference/tasks/template/checklist/tasks-template-checklist-update.md
@@ -108,29 +108,106 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.checklist.update
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.checklist.update',
-            {
-                templateId: 139,
-                checkListItemId: 37,
-                fields: {
-                    TITLE: '4. Подготовить дашборд и отправить ссылку'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CheckListItemResult = {
+      checkListItem: {
+        id: number
+        copiedId: number | null
+        userId: number
+        createdBy: number | null
+        parentId: number
+        title: string
+        sortIndex: number
+        displaySortIndex: string
+        isComplete: boolean
+        isImportant: boolean
+        completedCount: number
+        members: Array<{
+          id: string
+          type: string
+          name: string
+        }>
+        attachments: unknown[]
+        nodeId: number | null
+        templateId: number
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CheckListItemResult>({
+        method: 'tasks.template.checklist.update',
+        params: {
+          templateId: 139,
+          checkListItemId: 37,
+          fields: {
+            TITLE: '4. Prepare dashboard and send the link',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.checkListItem)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateChecklistItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.checklist.update',
+            params: {
+              templateId: 139,
+              checkListItemId: 37,
+              fields: {
+                TITLE: '4. Prepare dashboard and send the link',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.checkListItem)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateChecklistItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/tasks-template-add.md
+++ b/api-reference/tasks/template/tasks-template-add.md
@@ -102,44 +102,115 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.add
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.add',
-            {
-                fields: {
-                    PARENT_ID: 8131,
-                    TITLE: 'Подготовка еженедельного статуса по проекту',
-                    DESCRIPTION: 'Шаблон задачи для подготовки и согласования еженедельного статуса по проекту с командой и руководителем',
-                    PRIORITY: 2,
-                    CREATED_BY: 101,
-                    RESPONSIBLE_ID: 102,
-                    REPLICATE: 'Y',
-                    START_DATE_PLAN_AFTER: '32400',
-                    END_DATE_PLAN_AFTER: '97200',
-                    REPLICATE_PARAMS: {
-                        PERIOD: 'weekly',
-                        EVERY_WEEK: 1,
-                        WEEK_DAYS: [2],
-                        TIME: '11:00',
-                        REPEAT_TILL: 'endless',
-                        START_DATE: '16.03.2026 00:00:00',
-                    },
-                    UF_CRM_TASK: ['L_1179', 'D_1833'],
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // The result field contains the ID of the created template
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateAddResult>({
+        method: 'tasks.template.add',
+        params: {
+          fields: {
+            PARENT_ID: 8131,
+            TITLE: 'Weekly project status preparation',
+            DESCRIPTION: 'Task template for preparing and approving weekly project status with the team and manager',
+            PRIORITY: 2,
+            CREATED_BY: 101,
+            RESPONSIBLE_ID: 102,
+            REPLICATE: 'Y',
+            START_DATE_PLAN_AFTER: '32400',
+            END_DATE_PLAN_AFTER: '97200',
+            REPLICATE_PARAMS: {
+              PERIOD: 'weekly',
+              EVERY_WEEK: 1,
+              WEEK_DAYS: [2],
+              TIME: '11:00',
+              REPEAT_TILL: 'endless',
+              START_DATE: '16.03.2026 00:00:00',
+            },
+            UF_CRM_TASK: ['L_1179', 'D_1833'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created template ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.add',
+            params: {
+              fields: {
+                PARENT_ID: 8131,
+                TITLE: 'Weekly project status preparation',
+                DESCRIPTION: 'Task template for preparing and approving weekly project status with the team and manager',
+                PRIORITY: 2,
+                CREATED_BY: 101,
+                RESPONSIBLE_ID: 102,
+                REPLICATE: 'Y',
+                START_DATE_PLAN_AFTER: '32400',
+                END_DATE_PLAN_AFTER: '97200',
+                REPLICATE_PARAMS: {
+                  PERIOD: 'weekly',
+                  EVERY_WEEK: 1,
+                  WEEK_DAYS: [2],
+                  TIME: '11:00',
+                  REPEAT_TILL: 'endless',
+                  START_DATE: '16.03.2026 00:00:00',
+                },
+                UF_CRM_TASK: ['L_1179', 'D_1833'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created template ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/tasks-template-delete.md
+++ b/api-reference/tasks/template/tasks-template-delete.md
@@ -59,25 +59,76 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.delete
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.delete',
-            {
-                templateId: 123
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteTemplateResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteTemplateResult>({
+        method: 'tasks.template.delete',
+        params: {
+          templateId: 123,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Template deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.delete',
+            params: {
+              templateId: 123,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Template deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/tasks-template-fields.md
+++ b/api-reference/tasks/template/tasks-template-fields.md
@@ -48,23 +48,81 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.fields
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.fields',
-            {}
-        );
-        const result = response.getData().result;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateFieldsResult = {
+      [fieldName: string]: {
+        title: string
+        type: string
+        required?: boolean
+        default?: string | number | null
+        values?: Record<string, string | null>
+        primary?: boolean
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateFieldsResult>({
+        method: 'tasks.template.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Template fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTemplateFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Template fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTemplateFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/tasks-template-get.md
+++ b/api-reference/tasks/template/tasks-template-get.md
@@ -72,25 +72,84 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.get
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.get',
-            {
-                templateId: 139
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskTemplateResult = {
+      ID: string
+      TITLE: string
+      DESCRIPTION: string
+      RESPONSIBLE_ID: string
+      CREATED_BY: string
+      REPLICATE: string
+      STATUS: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TaskTemplateResult>({
+        method: 'tasks.template.get',
+        params: {
+          templateId: 139,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.TITLE, result.RESPONSIBLE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.get',
+            params: {
+              templateId: 139,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.TITLE, result.RESPONSIBLE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/template/tasks-template-update.md
+++ b/api-reference/tasks/template/tasks-template-update.md
@@ -79,33 +79,92 @@
     https://**put_your_bitrix24_address**/rest/tasks.template.update
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.template.update',
-            {
-                templateId: 139,
-                fields: {
-                    TITLE: 'Подготовка еженедельного статуса по проекту и согласование',
-                    DESCRIPTION: 'Обновленный шаблон задачи для подготовки еженедельного статуса по проекту и финального согласования перед отправкой',
-                    PRIORITY: 1,
-                    TASK_CONTROL: 'Y',
-                    ADD_IN_REPORT: 'Y',
-                    UF_CRM_TASK: ['L_1179', 'D_1833']
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateUpdateResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateUpdateResult>({
+        method: 'tasks.template.update',
+        params: {
+          templateId: 139,
+          fields: {
+            TITLE: 'Prepare weekly project status and approval',
+            DESCRIPTION: 'Updated task template for preparing weekly project status and final approval before sending',
+            PRIORITY: 1,
+            TASK_CONTROL: 'Y',
+            ADD_IN_REPORT: 'Y',
+            UF_CRM_TASK: ['L_1179', 'D_1833'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Template updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.template.update',
+            params: {
+              templateId: 139,
+              fields: {
+                TITLE: 'Prepare weekly project status and approval',
+                DESCRIPTION: 'Updated task template for preparing weekly project status and final approval before sending',
+                PRIORITY: 1,
+                TASK_CONTROL: 'Y',
+                ADD_IN_REPORT: 'Y',
+                UF_CRM_TASK: ['L_1179', 'D_1833'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Template updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-add.md
+++ b/api-reference/tasks/user-field/task-item-user-field-add.md
@@ -208,41 +208,105 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.add
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.add',
-            {
-                PARAMS: {
-                    USER_TYPE_ID: 'string',
-                    FIELD_NAME: 'UF_TASK_CLIENT_REQUEST',
-                    XML_ID: 'UF_TASK_CLIENT_REQUEST',
-                    EDIT_FORM_LABEL: {
-                        ru: 'Запрос клиента',
-                        en: 'Client request'
-                    },
-                    LABEL: 'Запрос клиента',
-                    SORT: 220,
-                    MULTIPLE: 'N',
-                    MANDATORY: 'Y',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Уточнить цель и ожидаемый результат',
-                        ROWS: 10
-                    }
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'task.item.userfield.add',
+        params: {
+          PARAMS: {
+            USER_TYPE_ID: 'string',
+            FIELD_NAME: 'UF_TASK_CLIENT_REQUEST',
+            XML_ID: 'UF_TASK_CLIENT_REQUEST',
+            EDIT_FORM_LABEL: {
+              ru: 'Запрос клиента',
+              en: 'Client request',
+            },
+            LABEL: 'Client request',
+            SORT: 220,
+            MULTIPLE: 'N',
+            MANDATORY: 'Y',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Clarify the goal and expected result',
+              ROWS: 10,
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created user field ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.add',
+            params: {
+              PARAMS: {
+                USER_TYPE_ID: 'string',
+                FIELD_NAME: 'UF_TASK_CLIENT_REQUEST',
+                XML_ID: 'UF_TASK_CLIENT_REQUEST',
+                EDIT_FORM_LABEL: {
+                  ru: 'Запрос клиента',
+                  en: 'Client request',
+                },
+                LABEL: 'Client request',
+                SORT: 220,
+                MULTIPLE: 'N',
+                MANDATORY: 'Y',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Clarify the goal and expected result',
+                  ROWS: 10,
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created user field ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-delete.md
+++ b/api-reference/tasks/user-field/task-item-user-field-delete.md
@@ -59,25 +59,73 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.delete
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.delete',
-            {
-                ID: 1325
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'task.item.userfield.delete',
+        params: {
+          ID: 1325,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.delete',
+            params: {
+              ID: 1325,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-get-fields.md
+++ b/api-reference/tasks/user-field/task-item-user-field-get-fields.md
@@ -46,23 +46,81 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.getfields
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.getfields',
-            {}
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each field descriptor returned in result
+    type FieldDescriptor = {
+      type: string
+      title: string
+      isReadOnly?: boolean
+      isImmutable?: boolean
+      isMultiple?: boolean
     }
-    catch (error)
-    {
-        console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = Record<string, FieldDescriptor>
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'task.item.userfield.getfields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available user field schema keys:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.getfields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available user field schema keys:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-get-list.md
+++ b/api-reference/tasks/user-field/task-item-user-field-get-list.md
@@ -90,27 +90,105 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.getlist
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.getlist',
-            {
-                ORDER: {
-                    SORT: 'ASC'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    type UserFieldItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+      SETTINGS: Record<string, unknown>
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      // task.item.userfield.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<UserFieldItem[]>({
+        method: 'task.item.userfield.getlist',
+        params: {
+          ORDER: {
+            SORT: 'ASC',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User fields count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // task.item.userfield.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.getlist',
+            params: {
+              ORDER: {
+                SORT: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User fields count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-get-types.md
+++ b/api-reference/tasks/user-field/task-item-user-field-get-types.md
@@ -58,23 +58,75 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.gettypes
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.gettypes',
-            {}
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result
+    type UserFieldTypeItem = {
+      ID: string
+      title: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserFieldTypeItem[]>({
+        method: 'task.item.userfield.gettypes',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available user field types:', result.map(t => t.ID))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserFieldTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.gettypes',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available user field types:', result.map(t => t.ID))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserFieldTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-get.md
+++ b/api-reference/tasks/user-field/task-item-user-field-get.md
@@ -59,25 +59,103 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.get
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.get',
-            {
-                ID: 1325
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the user field object returned in result
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserFieldResult = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+      EDIT_FORM_LABEL: Record<string, string>
+      LIST_COLUMN_LABEL: Record<string, string>
+      LIST_FILTER_LABEL: Record<string, string>
+      ERROR_MESSAGE: Record<string, string>
+      HELP_MESSAGE: Record<string, string>
+      SETTINGS: {
+        SIZE: number
+        ROWS: number
+        REGEXP: string
+        MIN_LENGTH: number
+        MAX_LENGTH: number
+        DEFAULT_VALUE: string
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserFieldResult>({
+        method: 'task.item.userfield.get',
+        params: {
+          ID: 1325,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.FIELD_NAME, result.USER_TYPE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.get',
+            params: {
+              ID: 1325,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.FIELD_NAME, result.USER_TYPE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/tasks/user-field/task-item-user-field-update.md
+++ b/api-reference/tasks/user-field/task-item-user-field-update.md
@@ -182,32 +182,90 @@
     https://**put_your_bitrix24_address**/rest/task.item.userfield.update
     ```
 
-- JS
+- TS
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'task.item.userfield.update',
-            {
-                ID: 1325,
-                DATA: {
-                    EDIT_FORM_LABEL: {
-                        ru: 'Описание запроса клиента',
-                        en: 'Description of client request'
-                    },
-                    MANDATORY: 'N'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateUserFieldResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateUserFieldResult>({
+        method: 'task.item.userfield.update',
+        params: {
+          ID: 1325,
+          DATA: {
+            EDIT_FORM_LABEL: {
+              ru: 'Описание запроса клиента',
+              en: 'Description of client request',
+            },
+            MANDATORY: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- UMD
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'task.item.userfield.update',
+            params: {
+              ID: 1325,
+              DATA: {
+                EDIT_FORM_LABEL: {
+                  ru: 'Описание запроса клиента',
+                  en: 'Description of client request',
+                },
+                MANDATORY: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateUserField)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## Что

Актуализирует JS-примеры в разделе `api-reference/tasks/` (124 страницы методов) со снятого
с поддержки jsSDK (`$b24.callMethod` / `$b24.callListMethod` / `$b24.fetchListMethod` — удалены
в b24jssdk 2.0) на текущий actions API `@bitrix24/b24jssdk@1`.

## Что изменено

- Старый таб `- JS` заменён на два таба: `- TS` и `- UMD`.
- Меняются **только** примеры в JS-табе. Табы `cURL (Webhook)`, `cURL (OAuth)`, `PHP`, `BX24.js`,
  `PHP CRest` и весь текст страниц (описания, таблицы параметров, разделы про обработку ответа,
  коды ошибок) — **не тронуты**.
- Параметры запроса перенесены 1:1 из старых примеров.
- Списочные методы используют `actions.v2.call.make` с параметром `start` (хелперы
  `callList`/`fetchList` не принимают `order`); рядом — комментарий-подсказка про оба хелпера
  для полной выборки.
- Вызовы несуществующих функций (`processResult`/`processData`) заменены на осмысленный
  `console.info(...)` по реальным полям ответа.
- Многопримерные страницы конвертированы целиком (каждый пример).

## Проверка

Все примеры проходят `tsc --strict` (типы TS) и `node --check` (синтаксис UMD) против
зафиксированной версии SDK.