### PR TITLE
docs(crm/deals): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/deals/contacts/crm-deal-contact-add.md
+++ b/api-reference/crm/deals/contacts/crm-deal-contact-add.md
@@ -97,33 +97,83 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.contact.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.contact.add',
-    		{
-    			id: 1875,
-    			fields: {
-    				CONTACT_ID: 55,
-    				IS_PRIMARY: "Y",
-    				SORT: 1000,
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.contact.add',
+        params: {
+          id: 1875,
+          fields: {
+            CONTACT_ID: 55,
+            IS_PRIMARY: 'Y',
+            SORT: 1000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact linked to deal:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDealContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.contact.add',
+            params: {
+              id: 1875,
+              fields: {
+                CONTACT_ID: 55,
+                IS_PRIMARY: 'Y',
+                SORT: 1000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact linked to deal:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDealContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/contacts/crm-deal-contact-delete.md
+++ b/api-reference/crm/deals/contacts/crm-deal-contact-delete.md
@@ -80,31 +80,79 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.contact.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.contact.delete',
-    		{
-    			id: 1875,
-    			fields: {
-    				CONTACT_ID: 55,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.contact.delete',
+        params: {
+          id: 1875,
+          fields: {
+            CONTACT_ID: 55,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact unlinked from deal:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDealContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.contact.delete',
+            params: {
+              id: 1875,
+              fields: {
+                CONTACT_ID: 55,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact unlinked from deal:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDealContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/contacts/crm-deal-contact-fields.md
+++ b/api-reference/crm/deals/contacts/crm-deal-contact-fields.md
@@ -45,26 +45,82 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.contact.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.contact.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealContactFields = Record<string, CrmDealContactFieldDescription>
+
+    type CrmDealContactFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealContactFields>({
+        method: 'crm.deal.contact.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal-contact fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDealContactFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.contact.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal-contact fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDealContactFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/contacts/crm-deal-contact-items-delete.md
+++ b/api-reference/crm/deals/contacts/crm-deal-contact-items-delete.md
@@ -56,28 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.contact.items.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.contact.items.delete',
-    		{
-    			id: 1875,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.contact.items.delete',
+        params: {
+          id: 1875,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('All contacts unlinked from deal:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDealContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.contact.items.delete',
+            params: {
+              id: 1875,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('All contacts unlinked from deal:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDealContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/contacts/crm-deal-contact-items-get.md
+++ b/api-reference/crm/deals/contacts/crm-deal-contact-items-get.md
@@ -56,28 +56,81 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.contact.items.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.contact.items.get',
-    		{
-    			id: 1875,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each contact binding returned in result[]
+    type DealContactBinding = {
+      CONTACT_ID: number
+      SORT: number
+      ROLE_ID: number
+      IS_PRIMARY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DealContactBinding[]>({
+        method: 'crm.deal.contact.items.get',
+        params: {
+          id: 1875,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contacts linked to deal:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDealContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.contact.items.get',
+            params: {
+              id: 1875,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contacts linked to deal:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDealContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/contacts/crm-deal-contact-items-set.md
+++ b/api-reference/crm/deals/contacts/crm-deal-contact-items-set.md
@@ -87,43 +87,103 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.contact.items.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.contact.items.set',
-    		{
-    			id: 1875,
-    			items: [
-    				{
-    					CONTACT_ID: 55,
-    					IS_PRIMARY: "Y",
-    					SORT: 100,
-    				},
-    				{
-    					CONTACT_ID: 54,
-    					SORT: 200,
-    				},
-    				{
-    					CONTACT_ID: 56,
-    					SORT: 400,
-    				}
-    			],
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.contact.items.set',
+        params: {
+          id: 1875,
+          items: [
+            {
+              CONTACT_ID: 55,
+              IS_PRIMARY: 'Y',
+              SORT: 100,
+            },
+            {
+              CONTACT_ID: 54,
+              SORT: 200,
+            },
+            {
+              CONTACT_ID: 56,
+              SORT: 400,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal contacts set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setDealContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.contact.items.set',
+            params: {
+              id: 1875,
+              items: [
+                {
+                  CONTACT_ID: 55,
+                  IS_PRIMARY: 'Y',
+                  SORT: 100,
+                },
+                {
+                  CONTACT_ID: 54,
+                  SORT: 200,
+                },
+                {
+                  CONTACT_ID: 56,
+                  SORT: 400,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal contacts set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setDealContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-add.md
+++ b/api-reference/crm/deals/crm-deal-add.md
@@ -256,64 +256,143 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const day = 60 * 60 * 24 * 1000;
-    	
-    	const now = new Date();
-    	const after10Days = new Date(now.getTime() + 10 * day);
-    	
-    	const response = await $b24.callMethod(
-    		'crm.deal.add',
-    		{
-    			fields: {
-    				TITLE: "Новая сделка #1",
-    				TYPE_ID: "COMPLEX",
-    				CATEGORY_ID: 0,
-    				STAGE_ID: "PREPARATION",
-    				IS_RECURRING: "N",
-    				IS_RETURN_CUSTOMER: "Y",
-    				IS_REPEATED_APPROACH: "Y",
-    				PROBABILITY: 99,
-    				CURRENCY_ID: "EUR",
-    				OPPORTUNITY: 1000000,
-    				IS_MANUAL_OPPORTUNITY: "Y",
-    				TAX_VALUE: 0.10,
-    				COMPANY_ID: 9,
-    				CONTACT_IDS: [84, 83],
-    				BEGINDATE: now.toISOString(),
-    				CLOSEDATE: after10Days.toISOString(),
-    				OPENED: "Y",
-    				CLOSED: "N",
-    				COMMENTS: "[B]Пример комментария[/B]",
-    				SOURCE_ID: "CALLBACK",
-    				SOURCE_DESCRIPTION: "Дополнительно об источнике",
-    				ADDITIONAL_INFO: "Дополнительная информация",
-    				UTM_SOURCE: "google",
-    				UTM_MEDIUM: "CPC",
-    				PARENT_ID_1220: 22,
-    				UF_CRM_1721244482250: "Привет мир!",
-    			},
-    			params: {
-    				REGISTER_SONET_EVENT: "N",
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    const day = 60 * 60 * 24 * 1000
+
+    const now = new Date()
+    const after10Days = new Date(now.getTime() + 10 * day)
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.deal.add',
+        params: {
+          fields: {
+            TITLE: 'New deal #1',
+            TYPE_ID: 'COMPLEX',
+            CATEGORY_ID: 0,
+            STAGE_ID: 'PREPARATION',
+            IS_RECURRING: 'N',
+            IS_RETURN_CUSTOMER: 'Y',
+            IS_REPEATED_APPROACH: 'Y',
+            PROBABILITY: 99,
+            CURRENCY_ID: 'EUR',
+            OPPORTUNITY: 1000000,
+            IS_MANUAL_OPPORTUNITY: 'Y',
+            TAX_VALUE: 0.10,
+            COMPANY_ID: 9,
+            CONTACT_IDS: [84, 83],
+            BEGINDATE: now.toISOString(),
+            CLOSEDATE: after10Days.toISOString(),
+            OPENED: 'Y',
+            CLOSED: 'N',
+            COMMENTS: '[B]Sample comment[/B]',
+            SOURCE_ID: 'CALLBACK',
+            SOURCE_DESCRIPTION: 'Additional information about the source',
+            ADDITIONAL_INFO: 'Additional information',
+            UTM_SOURCE: 'google',
+            UTM_MEDIUM: 'CPC',
+            PARENT_ID_1220: 22,
+            UF_CRM_1721244482250: 'Hello world!',
+          },
+          params: {
+            REGISTER_SONET_EVENT: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created deal id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const day = 60 * 60 * 24 * 1000
+
+          const now = new Date()
+          const after10Days = new Date(now.getTime() + 10 * day)
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.add',
+            params: {
+              fields: {
+                TITLE: 'New deal #1',
+                TYPE_ID: 'COMPLEX',
+                CATEGORY_ID: 0,
+                STAGE_ID: 'PREPARATION',
+                IS_RECURRING: 'N',
+                IS_RETURN_CUSTOMER: 'Y',
+                IS_REPEATED_APPROACH: 'Y',
+                PROBABILITY: 99,
+                CURRENCY_ID: 'EUR',
+                OPPORTUNITY: 1000000,
+                IS_MANUAL_OPPORTUNITY: 'Y',
+                TAX_VALUE: 0.10,
+                COMPANY_ID: 9,
+                CONTACT_IDS: [84, 83],
+                BEGINDATE: now.toISOString(),
+                CLOSEDATE: after10Days.toISOString(),
+                OPENED: 'Y',
+                CLOSED: 'N',
+                COMMENTS: '[B]Sample comment[/B]',
+                SOURCE_ID: 'CALLBACK',
+                SOURCE_DESCRIPTION: 'Additional information about the source',
+                ADDITIONAL_INFO: 'Additional information',
+                UTM_SOURCE: 'google',
+                UTM_MEDIUM: 'CPC',
+                PARENT_ID_1220: 22,
+                UF_CRM_1721244482250: 'Hello world!',
+              },
+              params: {
+                REGISTER_SONET_EVENT: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created deal id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-delete.md
+++ b/api-reference/crm/deals/crm-deal-delete.md
@@ -70,29 +70,73 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.delete',
-    		{
-    			id: 12,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.delete',
+        params: {
+          id: 12,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.delete',
+            params: {
+              id: 12,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-fields.md
+++ b/api-reference/crm/deals/crm-deal-fields.md
@@ -52,27 +52,82 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealFields = Record<string, CrmDealFieldDescription>
+
+    type CrmDealFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealFields>({
+        method: 'crm.deal.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDealFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDealFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-get.md
+++ b/api-reference/crm/deals/crm-deal-get.md
@@ -66,29 +66,94 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.get',
-    		{
-    			id: 410,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealResult = {
+      ID: string
+      TITLE: string
+      TYPE_ID: string
+      STAGE_ID: string
+      CATEGORY_ID: string
+      OPPORTUNITY: string
+      CURRENCY_ID: string
+      PROBABILITY: string
+      COMPANY_ID: string
+      CONTACT_ID: string
+      ASSIGNED_BY_ID: string
+      OPENED: string
+      CLOSED: string
+      BEGINDATE: ISODate | null
+      CLOSEDATE: ISODate | null
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealResult>({
+        method: 'crm.deal.get',
+        params: {
+          id: 410,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal:', result.ID, result.TITLE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.get',
+            params: {
+              id: 410,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal:', result.ID, result.TITLE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-list.md
+++ b/api-reference/crm/deals/crm-deal-list.md
@@ -168,20 +168,42 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const now = new Date();
-    const sixMonthAgo = new Date();
-    sixMonthAgo.setMonth(now.getMonth() - 6);
-    
+    declare const $b24: B24Frame
+
+    // Shape of each deal returned in result[] (subset shaped by `select`)
+    type CrmDealListItem = {
+      ID: string
+      TITLE: string
+      TYPE_ID: string
+      CATEGORY_ID: string
+      STAGE_ID: string
+      OPPORTUNITY: string
+      IS_MANUAL_OPPORTUNITY: string
+      ASSIGNED_BY_ID: string
+      DATE_CREATE: ISODate | null
+    }
+
+    const now = new Date()
+    const sixMonthAgo = new Date()
+    sixMonthAgo.setMonth(now.getMonth() - 6)
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.deal.list',
-        {
+      // crm.deal.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmDealListItem[]>({
+        method: 'crm.deal.list',
+        params: {
           select: [
             'ID',
             'TITLE',
@@ -208,104 +230,94 @@
             TITLE: 'ASC',
             OPPORTUNITY: 'ASC',
           },
+          start: 0,
         },
-        (result) => {
-          result.error()
-            ? console.error(result.error())
-            : console.info(result.data())
-          ;
-        },
-      );
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deals on this page:', result.length, result)
+      }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const now = new Date();
-    const sixMonthAgo = new Date();
-    sixMonthAgo.setMonth(now.getMonth() - 6);
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.deal.list', {
-        select: [
-          'ID',
-          'TITLE',
-          'TYPE_ID',
-          'CATEGORY_ID',
-          'STAGE_ID',
-          'OPPORTUNITY',
-          'IS_MANUAL_OPPORTUNITY',
-          'ASSIGNED_BY_ID',
-          'DATE_CREATE',
-        ],
-        filter: {
-          '=%TITLE': '%а',
-          CATEGORY_ID: 1,
-          TYPE_ID: 'COMPLEX',
-          STAGE_ID: 'C1:NEW',
-          '>OPPORTUNITY': 10000,
-          '<=OPPORTUNITY': 20000,
-          IS_MANUAL_OPPORTUNITY: 'Y',
-          '@ASSIGNED_BY_ID': [1, 6],
-          '>DATE_CREATE': sixMonthAgo,
-        },
-        order: {
-          TITLE: 'ASC',
-          OPPORTUNITY: 'ASC',
-        },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) {
-          console.log('Entity:', entity);
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listDeals() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const now = new Date()
+          const sixMonthAgo = new Date()
+          sixMonthAgo.setMonth(now.getMonth() - 6)
+
+          // crm.deal.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.list',
+            params: {
+              select: [
+                'ID',
+                'TITLE',
+                'TYPE_ID',
+                'CATEGORY_ID',
+                'STAGE_ID',
+                'OPPORTUNITY',
+                'IS_MANUAL_OPPORTUNITY',
+                'ASSIGNED_BY_ID',
+                'DATE_CREATE',
+              ],
+              filter: {
+                '=%TITLE': '%а',
+                CATEGORY_ID: 1,
+                TYPE_ID: 'COMPLEX',
+                STAGE_ID: 'C1:NEW',
+                '>OPPORTUNITY': 10000,
+                '<=OPPORTUNITY': 20000,
+                IS_MANUAL_OPPORTUNITY: 'Y',
+                '@ASSIGNED_BY_ID': [1, 6],
+                '>DATE_CREATE': sixMonthAgo,
+              },
+              order: {
+                TITLE: 'ASC',
+                OPPORTUNITY: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deals on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
       }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const now = new Date();
-    const sixMonthAgo = new Date();
-    sixMonthAgo.setMonth(now.getMonth() - 6);
-    
-    try {
-      const response = await $b24.callMethod('crm.deal.list', {
-        select: [
-          'ID',
-          'TITLE',
-          'TYPE_ID',
-          'CATEGORY_ID',
-          'STAGE_ID',
-          'OPPORTUNITY',
-          'IS_MANUAL_OPPORTUNITY',
-          'ASSIGNED_BY_ID',
-          'DATE_CREATE',
-        ],
-        filter: {
-          '=%TITLE': '%а',
-          CATEGORY_ID: 1,
-          TYPE_ID: 'COMPLEX',
-          STAGE_ID: 'C1:NEW',
-          '>OPPORTUNITY': 10000,
-          '<=OPPORTUNITY': 20000,
-          IS_MANUAL_OPPORTUNITY: 'Y',
-          '@ASSIGNED_BY_ID': [1, 6],
-          '>DATE_CREATE': sixMonthAgo,
-        },
-        order: {
-          TITLE: 'ASC',
-          OPPORTUNITY: 'ASC',
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) {
-        console.log('Entity:', entity);
-      }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+
+      document.addEventListener('DOMContentLoaded', listDeals)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-productrows-get.md
+++ b/api-reference/crm/deals/crm-deal-productrows-get.md
@@ -59,29 +59,92 @@
 	https://**put_your_bitrix24_address**/rest/crm.deal.productrows.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.productrows.get',
-    		{
-    			id: 5,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of each product row returned in result[]
+    type CrmDealProductRow = {
+      ID: string
+      OWNER_ID: string
+      OWNER_TYPE: string
+      PRODUCT_ID: number
+      PRODUCT_NAME: string
+      PRICE: number
+      QUANTITY: number
+      DISCOUNT_TYPE_ID: number
+      DISCOUNT_RATE: number
+      DISCOUNT_SUM: number
+      TAX_RATE: number | null
+      TAX_INCLUDED: string
+      MEASURE_CODE: number
+      MEASURE_NAME: string
+      SORT: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealProductRow[]>({
+        method: 'crm.deal.productrows.get',
+        params: {
+          id: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product rows:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDealProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.productrows.get',
+            params: {
+              id: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product rows:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDealProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-productrows-set.md
+++ b/api-reference/crm/deals/crm-deal-productrows-set.md
@@ -151,53 +151,121 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.productrows.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.productrows.set',
-    		{
-    			id: 5,
-    			rows: [
-    				{
-    					PRODUCT_ID: 456,
-    					PRICE: 1000,
-    					QUANTITY: 10,
-    					DISCOUNT_TYPE_ID: 1,
-    					DISCOUNT_SUM: 100,
-    					TAX_RATE: 13,
-    					MEASURE_CODE: 796,
-    					MEASURE_NAME: "шт",
-    					SORT: 10,
-    				},
-    				{
-    					PRODUCT_NAME: "Товар #2",
-    					PRICE: 500,
-    					QUANTITY: 5,
-    					DISCOUNT_TYPE_ID: 2,
-    					DISCOUNT_RATE: 10,
-    					TAX_RATE: 10,
-    					MEASURE_CODE: 166,
-    					MEASURE_NAME: "кг",
-    					SORT: 20,
-    				},
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.productrows.set',
+        params: {
+          id: 5,
+          rows: [
+            {
+              PRODUCT_ID: 456,
+              PRICE: 1000,
+              QUANTITY: 10,
+              DISCOUNT_TYPE_ID: 1,
+              DISCOUNT_SUM: 100,
+              TAX_RATE: 13,
+              MEASURE_CODE: 796,
+              MEASURE_NAME: 'pcs',
+              SORT: 10,
+            },
+            {
+              PRODUCT_NAME: 'Product #2',
+              PRICE: 500,
+              QUANTITY: 5,
+              DISCOUNT_TYPE_ID: 2,
+              DISCOUNT_RATE: 10,
+              TAX_RATE: 10,
+              MEASURE_CODE: 166,
+              MEASURE_NAME: 'kg',
+              SORT: 20,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product rows set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setDealProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.productrows.set',
+            params: {
+              id: 5,
+              rows: [
+                {
+                  PRODUCT_ID: 456,
+                  PRICE: 1000,
+                  QUANTITY: 10,
+                  DISCOUNT_TYPE_ID: 1,
+                  DISCOUNT_SUM: 100,
+                  TAX_RATE: 13,
+                  MEASURE_CODE: 796,
+                  MEASURE_NAME: 'pcs',
+                  SORT: 10,
+                },
+                {
+                  PRODUCT_NAME: 'Product #2',
+                  PRICE: 500,
+                  QUANTITY: 5,
+                  DISCOUNT_TYPE_ID: 2,
+                  DISCOUNT_RATE: 10,
+                  TAX_RATE: 10,
+                  MEASURE_CODE: 166,
+                  MEASURE_NAME: 'kg',
+                  SORT: 20,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product rows set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setDealProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/crm-deal-update.md
+++ b/api-reference/crm/deals/crm-deal-update.md
@@ -231,42 +231,105 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.update',
-    		{
-    			id: 123,
-    			fields: {
-    				TITLE: "Новое название сделки!",
-    				TYPE_ID: "GOODS",
-    				STAGE_ID: "WON",
-    				IS_RECCURING: "Y",
-    				IS_RETURN_CUSTOMER: "Y",
-    				OPPORTUNITY: 9999.99,
-    				IS_MANUAL_OPPORTUNITY: "Y",
-    				ASSIGNED_BY_ID: 1,
-    				UF_CRM_1725365197310: "Строка",
-    				PARENT_ID_1032: 1,
-    			},
-    			params: {
-    				REGISTER_SONET_EVENT: "N",
-    				REGISTER_HISTORY_EVENT: "N",
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error() ? console.error(result.error()) : console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.update',
+        params: {
+          id: 123,
+          fields: {
+            TITLE: 'New deal title!',
+            TYPE_ID: 'GOODS',
+            STAGE_ID: 'WON',
+            IS_RECCURING: 'Y',
+            IS_RETURN_CUSTOMER: 'Y',
+            OPPORTUNITY: 9999.99,
+            IS_MANUAL_OPPORTUNITY: 'Y',
+            ASSIGNED_BY_ID: 1,
+            UF_CRM_1725365197310: 'String',
+            PARENT_ID_1032: 1,
+          },
+          params: {
+            REGISTER_SONET_EVENT: 'N',
+            REGISTER_HISTORY_EVENT: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.update',
+            params: {
+              id: 123,
+              fields: {
+                TITLE: 'New deal title!',
+                TYPE_ID: 'GOODS',
+                STAGE_ID: 'WON',
+                IS_RECCURING: 'Y',
+                IS_RETURN_CUSTOMER: 'Y',
+                OPPORTUNITY: 9999.99,
+                IS_MANUAL_OPPORTUNITY: 'Y',
+                ASSIGNED_BY_ID: 1,
+                UF_CRM_1725365197310: 'String',
+                PARENT_ID_1032: 1,
+              },
+              params: {
+                REGISTER_SONET_EVENT: 'N',
+                REGISTER_HISTORY_EVENT: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/custom-form/crm-deal-details-configuration-force-common-scope-for-all.md
+++ b/api-reference/crm/deals/custom-form/crm-deal-details-configuration-force-common-scope-for-all.md
@@ -81,27 +81,77 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.details.configuration.forceCommonScopeForAll
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.details.configuration.forceCommonScopeForAll',
-    		{
-    			extras: {
-    				dealCategoryId: 32,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.details.configuration.forceCommonScopeForAll',
+        params: {
+          extras: {
+            dealCategoryId: 32,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Common card forced for all users:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function forceCommonDealCard() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.details.configuration.forceCommonScopeForAll',
+            params: {
+              extras: {
+                dealCategoryId: 32,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Common card forced for all users:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', forceCommonDealCard)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/custom-form/crm-deal-details-configuration-get.md
+++ b/api-reference/crm/deals/custom-form/crm-deal-details-configuration-get.md
@@ -96,31 +96,93 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.details.configuration.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.details.configuration.get',
-    		{
-    			scope: "C",
-    			extras: {
-    				dealCategoryId: 32,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each section returned in result[]
+    type CrmDealDetailsSection = {
+      name: string
+      title: string
+      type: string
+      elements: CrmDealDetailsSectionElement[]
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    type CrmDealDetailsSectionElement = {
+      name: string
+      optionFlags?: string
+      options?: Record<string, unknown>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealDetailsSection[] | null>({
+        method: 'crm.deal.details.configuration.get',
+        params: {
+          scope: 'C',
+          extras: {
+            dealCategoryId: 32,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Card sections:', result?.length ?? 0, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDealCardConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.details.configuration.get',
+            params: {
+              scope: 'C',
+              extras: {
+                dealCategoryId: 32,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Card sections:', result?.length ?? 0, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDealCardConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/custom-form/crm-deal-details-configuration-reset.md
+++ b/api-reference/crm/deals/custom-form/crm-deal-details-configuration-reset.md
@@ -97,29 +97,81 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.details.configuration.reset
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.details.configuration.reset',
-    		{
-    			scope: "P",
-    			userId: 1,
-    			extras: {
-    				dealCategoryId: 32,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.details.configuration.reset',
+        params: {
+          scope: 'P',
+          userId: 1,
+          extras: {
+            dealCategoryId: 32,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Configuration reset:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function resetDealCardConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.details.configuration.reset',
+            params: {
+              scope: 'P',
+              userId: 1,
+              extras: {
+                dealCategoryId: 32,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Configuration reset:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', resetDealCardConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/custom-form/crm-deal-details-configuration-set.md
+++ b/api-reference/crm/deals/custom-form/crm-deal-details-configuration-set.md
@@ -143,64 +143,151 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.details.configuration.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.details.configuration.set',
-    		{
-    			scope: "P",
-    			userId: 1,
-    			extras: {
-    				dealCategoryId: 32,
-    			},
-    			data: [
-    				{
-    					name: "main",
-    					title: "О сделке",
-    					type: "section",
-    					elements: [
-    						{ name: "TITLE" },
-    						{ name: "OPPORTUNITY_WITH_CURRENCY" },
-    						{ name: "STAGE_ID" },
-    						{ name: "CLOSEDATE" },
-    						{ name: "CLIENT" },
-    					],
-    				},
-    				{
-    					name: "additional",
-    					title: "Дополнительно",
-    					type: "section",
-    					elements: [
-    						{ name: "TYPE_ID" },
-    						{ name: "SOURCE_ID" },
-    						{ name: "SOURCE_DESCRIPTION" },
-    						{ name: "OPENED" },
-    						{ name: "ASSIGNED_BY_ID" },
-    						{ name: "COMMENTS" },
-    					],
-    				},
-    				{
-    					name: "products",
-    					title: "Товары",
-    					type: "section",
-    					elements: [
-    						{ name: "PRODUCT_ROW_SUMMARY" },
-    					],
-    				},
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.details.configuration.set',
+        params: {
+          scope: 'P',
+          userId: 1,
+          extras: {
+            dealCategoryId: 32,
+          },
+          data: [
+            {
+              name: 'main',
+              title: 'About the deal',
+              type: 'section',
+              elements: [
+                { name: 'TITLE' },
+                { name: 'OPPORTUNITY_WITH_CURRENCY' },
+                { name: 'STAGE_ID' },
+                { name: 'CLOSEDATE' },
+                { name: 'CLIENT' },
+              ],
+            },
+            {
+              name: 'additional',
+              title: 'Additional',
+              type: 'section',
+              elements: [
+                { name: 'TYPE_ID' },
+                { name: 'SOURCE_ID' },
+                { name: 'SOURCE_DESCRIPTION' },
+                { name: 'OPENED' },
+                { name: 'ASSIGNED_BY_ID' },
+                { name: 'COMMENTS' },
+              ],
+            },
+            {
+              name: 'products',
+              title: 'Products',
+              type: 'section',
+              elements: [
+                { name: 'PRODUCT_ROW_SUMMARY' },
+              ],
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Configuration saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setDealCardConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.details.configuration.set',
+            params: {
+              scope: 'P',
+              userId: 1,
+              extras: {
+                dealCategoryId: 32,
+              },
+              data: [
+                {
+                  name: 'main',
+                  title: 'About the deal',
+                  type: 'section',
+                  elements: [
+                    { name: 'TITLE' },
+                    { name: 'OPPORTUNITY_WITH_CURRENCY' },
+                    { name: 'STAGE_ID' },
+                    { name: 'CLOSEDATE' },
+                    { name: 'CLIENT' },
+                  ],
+                },
+                {
+                  name: 'additional',
+                  title: 'Additional',
+                  type: 'section',
+                  elements: [
+                    { name: 'TYPE_ID' },
+                    { name: 'SOURCE_ID' },
+                    { name: 'SOURCE_DESCRIPTION' },
+                    { name: 'OPENED' },
+                    { name: 'ASSIGNED_BY_ID' },
+                    { name: 'COMMENTS' },
+                  ],
+                },
+                {
+                  name: 'products',
+                  title: 'Products',
+                  type: 'section',
+                  elements: [
+                    { name: 'PRODUCT_ROW_SUMMARY' },
+                  ],
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Configuration saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setDealCardConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/index.md
+++ b/api-reference/crm/deals/index.md
@@ -82,32 +82,102 @@
     https://**put_your_bitrix24_address**/rest/crm.item.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.item.update',
-            {
-                entityTypeId: 2,
-                id: 233,
-                fields: {
-                    STAGE_ID: 'EXECUTING',
-                    categoryId: 0
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated item with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // crm.item.update (rest-v2) returns the updated element under `item`; fields per
+    // ../universal/crm-item-update.md
+    // Shape of the payload returned in result (the `item` object below)
+    type CrmItemUpdateResult = {
+      item: {
+        id: number
+        entityTypeId: number
+        title: string
+        categoryId: number
+        stageId: string
+        assignedById: number
+        opened: string
+        opportunity: number
+        currencyId: string
+        createdTime: ISODate
+        updatedTime: ISODate
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmItemUpdateResult>({
+        method: 'crm.item.update',
+        params: {
+          entityTypeId: 2,
+          id: 233,
+          fields: {
+            STAGE_ID: 'EXECUTING',
+            categoryId: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated item:', result.item.id, result.item.stageId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDealStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.update',
+            params: {
+              entityTypeId: 2,
+              id: 233,
+              fields: {
+                STAGE_ID: 'EXECUTING',
+                categoryId: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated item:', result.item.id, result.item.stageId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDealStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-add.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-add.md
@@ -133,50 +133,123 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const current = new Date();
-    	const nextMonth = new Date();
-    	const nextYear = new Date();
-    	nextMonth.setMonth(current.getMonth() + 1);
-    	nextYear.setFullYear(current.getFullYear() + 1);
-    
-    	const paddatepart = (part) => (part >= 10 ? part.toString() : `0${part}`);
-    	const date2str = (d) =>
-    		`${d.getFullYear()}-${paddatepart(1 + d.getMonth())}-${paddatepart(d.getDate())}`;
-    
-    	const response = await $b24.callMethod(
-    		'crm.deal.recurring.add',
-    		{
-    			fields: {
-    				DEAL_ID: 45,
-    				CATEGORY_ID: '1',
-    				IS_LIMIT: 'D',
-    				LIMIT_DATE: date2str(nextYear),
-    				START_DATE: date2str(nextMonth),
-    				PARAMS: {
-    					MODE: 'multiple',
-    					MULTIPLE_TYPE: 'month',
-    					MULTIPLE_INTERVAL: 1,
-    					OFFSET_BEGINDATE_TYPE: 'day',
-    					OFFSET_BEGINDATE_VALUE: 1,
-    					OFFSET_CLOSEDATE_TYPE: 'month',
-    					OFFSET_CLOSEDATE_VALUE: 2,
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info('id настройки регулярной сделки:', result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    const current = new Date()
+    const nextMonth = new Date()
+    const nextYear = new Date()
+    nextMonth.setMonth(current.getMonth() + 1)
+    nextYear.setFullYear(current.getFullYear() + 1)
+
+    const padDatePart = (part: number) => (part >= 10 ? part.toString() : `0${part}`)
+    const date2str = (d: Date) =>
+      `${d.getFullYear()}-${padDatePart(1 + d.getMonth())}-${padDatePart(d.getDate())}`
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.deal.recurring.add',
+        params: {
+          fields: {
+            DEAL_ID: 45,
+            CATEGORY_ID: '1',
+            IS_LIMIT: 'D',
+            LIMIT_DATE: date2str(nextYear),
+            START_DATE: date2str(nextMonth),
+            PARAMS: {
+              MODE: 'multiple',
+              MULTIPLE_TYPE: 'month',
+              MULTIPLE_INTERVAL: 1,
+              OFFSET_BEGINDATE_TYPE: 'day',
+              OFFSET_BEGINDATE_VALUE: 1,
+              OFFSET_CLOSEDATE_TYPE: 'month',
+              OFFSET_CLOSEDATE_VALUE: 2,
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recurring deal settings id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRecurringDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const current = new Date()
+          const nextMonth = new Date()
+          const nextYear = new Date()
+          nextMonth.setMonth(current.getMonth() + 1)
+          nextYear.setFullYear(current.getFullYear() + 1)
+
+          const padDatePart = (part) => (part >= 10 ? part.toString() : `0${part}`)
+          const date2str = (d) =>
+            `${d.getFullYear()}-${padDatePart(1 + d.getMonth())}-${padDatePart(d.getDate())}`
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.add',
+            params: {
+              fields: {
+                DEAL_ID: 45,
+                CATEGORY_ID: '1',
+                IS_LIMIT: 'D',
+                LIMIT_DATE: date2str(nextYear),
+                START_DATE: date2str(nextMonth),
+                PARAMS: {
+                  MODE: 'multiple',
+                  MULTIPLE_TYPE: 'month',
+                  MULTIPLE_INTERVAL: 1,
+                  OFFSET_BEGINDATE_TYPE: 'day',
+                  OFFSET_BEGINDATE_VALUE: 1,
+                  OFFSET_CLOSEDATE_TYPE: 'month',
+                  OFFSET_CLOSEDATE_VALUE: 2,
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recurring deal settings id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRecurringDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-delete.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-delete.md
@@ -56,25 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.recurring.delete',
-    		{
-    			id: 15,
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.info('Настройка шаблона удалена:', result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.recurring.delete',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recurring setting deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteRecurringDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.delete',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recurring setting deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteRecurringDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-expose.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-expose.md
@@ -52,26 +52,78 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.expose
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const id = 15;
-    	const response = await $b24.callMethod(
-    		'crm.deal.recurring.expose',
-    		{
-    			id: id,
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealRecurringExposeResult = {
+      DEAL_ID: number
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealRecurringExposeResult>({
+        method: 'crm.deal.recurring.expose',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created deal id:', result.DEAL_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function exposeRecurringDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.expose',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created deal id:', result.DEAL_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', exposeRecurringDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-fields.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-fields.md
@@ -45,23 +45,83 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.recurring.fields',
-    		{}
-    	);
-    
-    	const result = response.getData().result;
-    	console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealRecurringFields = Record<string, CrmDealRecurringFieldDescription>
+
+    type CrmDealRecurringFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      definition?: Record<string, unknown>
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealRecurringFields>({
+        method: 'crm.deal.recurring.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recurring fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRecurringDealFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recurring fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRecurringDealFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-get.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-get.md
@@ -54,25 +54,94 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.recurring.get',
-    		{
-    			id: 15,
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.info('Настройка шаблона:', result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealRecurring = {
+      ID: string
+      DEAL_ID: string
+      BASED_ID: string
+      ACTIVE: string
+      CATEGORY_ID: string
+      IS_LIMIT: string
+      COUNTER_REPEAT: string | null
+      LIMIT_REPEAT: string | null
+      LIMIT_DATE: ISODate | null
+      START_DATE: ISODate | null
+      NEXT_EXECUTION: ISODate | null
+      LAST_EXECUTION: ISODate | null
+      PARAMS: {
+        MODE: string
+        MULTIPLE_TYPE: string
+        MULTIPLE_INTERVAL: number
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealRecurring>({
+        method: 'crm.deal.recurring.get',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recurring template:', result.ID, result.ACTIVE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRecurringDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.get',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recurring template:', result.ID, result.ACTIVE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRecurringDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-list.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-list.md
@@ -109,62 +109,111 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: получает все данные сразу. Подходит для небольших выборок.
-    try {
-      const response = await $b24.callListMethod(
-        'crm.deal.recurring.list',
-        {
-          order: { deal_id: 'ASC' },
-          filter: { '>COUNTER_REPEAT': 0 }
-        }
-      );
-      const items = response.getData() || [];
-      for (const item of items) {
-        console.log(item);
-      }
-    } catch (error) {
-      console.error('Request failed', error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each recurring-deal setting returned in result[]
+    type CrmDealRecurringListItem = {
+      id: string
+      deal_id: string
+      based_id: string
+      ACTIVE: string
+      category_id: string
+      IS_LIMIT: string
+      COUNTER_REPEAT: string
+      LIMIT_REPEAT: string | null
+      LIMIT_DATE: ISODate | null
+      START_DATE: ISODate | null
+      NEXT_EXECUTION: ISODate | null
+      LAST_EXECUTION: ISODate | null
     }
-    
-    // fetchListMethod: выбирает данные по частям (итератор).
+
     try {
-      const iterator = $b24.fetchListMethod(
-        'crm.deal.recurring.list',
-        {
-          order: { deal_id: 'ASC' },
-          filter: { '>COUNTER_REPEAT': 0 }
+      // crm.deal.recurring.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmDealRecurringListItem[]>({
+        method: 'crm.deal.recurring.list',
+        params: {
+          order: {
+            deal_id: 'ASC',
+          },
+          filter: {
+            '>COUNTER_REPEAT': 0,
+          },
+          start: 0,
         },
-        'id'
-      );
-      for await (const page of iterator) {
-        for (const item of page) {
-          console.log(item);
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recurring templates on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listRecurringDeals() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.deal.recurring.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.list',
+            params: {
+              order: {
+                deal_id: 'ASC',
+              },
+              filter: {
+                '>COUNTER_REPEAT': 0,
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recurring templates on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
       }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // callMethod: ручная пагинация через параметр start.
-    try {
-      const response = await $b24.callMethod(
-        'crm.deal.recurring.list',
-        {
-          order: { deal_id: 'ASC' },
-          filter: { '>COUNTER_REPEAT': 0 }
-        },
-        0
-      );
-      const result = response.getData().result || [];
-      for (const item of result) {
-        console.log(item);
-      }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+
+      document.addEventListener('DOMContentLoaded', listRecurringDeals)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/recurring-deals/crm-deal-recurring-update.md
+++ b/api-reference/crm/deals/recurring-deals/crm-deal-recurring-update.md
@@ -142,41 +142,105 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.recurring.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.recurring.update',
-    		{
-    			id: 15,
-    			fields: {
-    				ACTIVE: 'Y',
-    				CATEGORY_ID: '2',
-    				IS_LIMIT: 'D',
-    				LIMIT_DATE: '2027-03-05',
-    				START_DATE: '2026-04-05',
-    				PARAMS: {
-    					MODE: 'multiple',
-    					MULTIPLE_TYPE: 'month',
-    					MULTIPLE_INTERVAL: 1,
-    					OFFSET_BEGINDATE_TYPE: 'day',
-    					OFFSET_BEGINDATE_VALUE: 1,
-    					OFFSET_CLOSEDATE_TYPE: 'month',
-    					OFFSET_CLOSEDATE_VALUE: 2,
-    				}
-    			}
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.info('Шаблон обновлен:', result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.recurring.update',
+        params: {
+          id: 15,
+          fields: {
+            ACTIVE: 'Y',
+            CATEGORY_ID: '2',
+            IS_LIMIT: 'D',
+            LIMIT_DATE: '2027-03-05',
+            START_DATE: '2026-04-05',
+            PARAMS: {
+              MODE: 'multiple',
+              MULTIPLE_TYPE: 'month',
+              MULTIPLE_INTERVAL: 1,
+              OFFSET_BEGINDATE_TYPE: 'day',
+              OFFSET_BEGINDATE_VALUE: 1,
+              OFFSET_CLOSEDATE_TYPE: 'month',
+              OFFSET_CLOSEDATE_VALUE: 2,
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recurring setting updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateRecurringDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.recurring.update',
+            params: {
+              id: 15,
+              fields: {
+                ACTIVE: 'Y',
+                CATEGORY_ID: '2',
+                IS_LIMIT: 'D',
+                LIMIT_DATE: '2027-03-05',
+                START_DATE: '2026-04-05',
+                PARAMS: {
+                  MODE: 'multiple',
+                  MULTIPLE_TYPE: 'month',
+                  MULTIPLE_INTERVAL: 1,
+                  OFFSET_BEGINDATE_TYPE: 'day',
+                  OFFSET_BEGINDATE_VALUE: 1,
+                  OFFSET_CLOSEDATE_TYPE: 'month',
+                  OFFSET_CLOSEDATE_VALUE: 2,
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recurring setting updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateRecurringDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/user-defined-fields/crm-deal-userfield-delete.md
+++ b/api-reference/crm/deals/user-defined-fields/crm-deal-userfield-delete.md
@@ -54,29 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.userfield.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.userfield.delete',
-    		{
-    			id: 432,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.userfield.delete',
+        params: {
+          id: 432,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDealUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.userfield.delete',
+            params: {
+              id: 432,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDealUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/user-defined-fields/crm-deal-userfield-get.md
+++ b/api-reference/crm/deals/user-defined-fields/crm-deal-userfield-get.md
@@ -54,29 +54,89 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.userfield.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.deal.userfield.get',
-    		{
-    			id: 399,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmDealUserfield = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmDealUserfield>({
+        method: 'crm.deal.userfield.get',
+        params: {
+          id: 399,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield:', result.FIELD_NAME, result.USER_TYPE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDealUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.userfield.get',
+            params: {
+              id: 399,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield:', result.FIELD_NAME, result.USER_TYPE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDealUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/deals/user-defined-fields/crm-deal-userfield-list.md
+++ b/api-reference/crm/deals/user-defined-fields/crm-deal-userfield-list.md
@@ -170,74 +170,117 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.userfield.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each userfield returned in result[]
+    type CrmDealUserfieldListItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+    }
+
     try {
-    const response = await $b24.callListMethod(
-        'crm.deal.userfield.list',
-        {
-         filter: {
-            MULTIPLE: "Y",
-            MANDATORY: "Y",
-            LANG: "ru",
-         },
-         order: {
-            USER_TYPE_ID: "ASC",
-            SORT: "ASC",
-         },
+      // crm.deal.userfield.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmDealUserfieldListItem[]>({
+        method: 'crm.deal.userfield.list',
+        params: {
+          filter: {
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            LANG: 'ru',
+          },
+          order: {
+            USER_TYPE_ID: 'ASC',
+            SORT: 'ASC',
+          },
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfields on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-    const generator = $b24.fetchListMethod('crm.deal.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-    const response = await $b24.callMethod('crm.deal.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listDealUserfields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.deal.userfield.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.userfield.list',
+            params: {
+              filter: {
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                LANG: 'ru',
+              },
+              order: {
+                USER_TYPE_ID: 'ASC',
+                SORT: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfields on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listDealUserfields)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start` and link the `callList.make` / `fetchList.make`
  helpers; `getTotal()` (removed in SDK 2.0) is replaced by `.length` + helpers.
- Each example is verified: `tsc --strict` against `@bitrix24/b24jssdk@1`, `node --check`
  on the UMD tab, and a method/field cross-check against the page's cURL endpoint and JSON
  response.
- One section per PR to keep review small.

No breaking changes — documentation examples only.