### PR TITLE
docs(crm/leads): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/leads/crm-lead-add.md
+++ b/api-reference/crm/leads/crm-lead-add.md
@@ -224,52 +224,123 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.add',
-    		{
-    			fields:
-    			{
-    				TITLE: 'ИП Титов',
-    				NAME: 'Глеб',
-    				SECOND_NAME: 'Егорович',
-    				LAST_NAME: 'Титов',
-    				STATUS_ID: 'NEW',
-    				OPENED: 'Y',
-    				ASSIGNED_BY_ID: 1,
-    				CURRENCY_ID: 'USD',
-    				OPPORTUNITY: 12500,
-    				PHONE: [
-    					{ 
-    						VALUE: '555888',
-    						VALUE_TYPE: 'WORK',
-    					},
-    				],
-    				WEB: [
-    					{
-    						VALUE: 'www.mysite.com',
-    						VALUE_TYPE: 'WORK',
-    					}
-    				],
-    			},
-    			params: {
-    				REGISTER_SONET_EVENT: 'Y',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(`Создан лид с ID ${result}`);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.lead.add',
+        params: {
+          fields: {
+            TITLE: 'Sole proprietor Titov',
+            NAME: 'Gleb',
+            SECOND_NAME: 'Egorovich',
+            LAST_NAME: 'Titov',
+            STATUS_ID: 'NEW',
+            OPENED: 'Y',
+            ASSIGNED_BY_ID: 1,
+            CURRENCY_ID: 'USD',
+            OPPORTUNITY: 12500,
+            PHONE: [
+              {
+                VALUE: '555888',
+                VALUE_TYPE: 'WORK',
+              },
+            ],
+            WEB: [
+              {
+                VALUE: 'www.mysite.com',
+                VALUE_TYPE: 'WORK',
+              },
+            ],
+          },
+          params: {
+            REGISTER_SONET_EVENT: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created lead id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addLead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.add',
+            params: {
+              fields: {
+                TITLE: 'Sole proprietor Titov',
+                NAME: 'Gleb',
+                SECOND_NAME: 'Egorovich',
+                LAST_NAME: 'Titov',
+                STATUS_ID: 'NEW',
+                OPENED: 'Y',
+                ASSIGNED_BY_ID: 1,
+                CURRENCY_ID: 'USD',
+                OPPORTUNITY: 12500,
+                PHONE: [
+                  {
+                    VALUE: '555888',
+                    VALUE_TYPE: 'WORK',
+                  },
+                ],
+                WEB: [
+                  {
+                    VALUE: 'www.mysite.com',
+                    VALUE_TYPE: 'WORK',
+                  },
+                ],
+              },
+              params: {
+                REGISTER_SONET_EVENT: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created lead id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addLead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-delete.md
+++ b/api-reference/crm/leads/crm-lead-delete.md
@@ -62,31 +62,73 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const id = prompt("Введите ID");
-    	const response = await $b24.callMethod(
-    		'crm.lead.delete',
-    		{ id }
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    		return;
-    	}
-    	
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.delete',
+        params: {
+          id: 123,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteLead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.delete',
+            params: {
+              id: 123,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteLead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-fields.md
+++ b/api-reference/crm/leads/crm-lead-fields.md
@@ -53,24 +53,82 @@
     ```
   
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmLeadFields = Record<string, CrmLeadFieldDescription>
+
+    type CrmLeadFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmLeadFields>({
+        method: 'crm.lead.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLeadFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLeadFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-get.md
+++ b/api-reference/crm/leads/crm-lead-get.md
@@ -60,24 +60,97 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.get',
-    		{ id: 123 }
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type CrmLeadMultifield = {
+      ID: string
+      VALUE_TYPE: string
+      VALUE: string
+      TYPE_ID: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (a representative subset of the documented lead fields)
+    type CrmLead = {
+      ID: string
+      TITLE: string
+      NAME: string | null
+      LAST_NAME: string | null
+      STATUS_ID: string
+      SOURCE_ID: string
+      CURRENCY_ID: string
+      OPPORTUNITY: string
+      ASSIGNED_BY_ID: string
+      OPENED: string
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+      PHONE?: CrmLeadMultifield[]
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmLead>({
+        method: 'crm.lead.get',
+        params: {
+          id: 123,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead title:', result.TITLE, 'status:', result.STATUS_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.get',
+            params: {
+              id: 123,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead title:', result.TITLE, 'status:', result.STATUS_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-list.md
+++ b/api-reference/crm/leads/crm-lead-list.md
@@ -114,16 +114,41 @@
   https://**put_your_bitrix24_address**/rest/crm.lead.list
   ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each lead object returned in result[]
+    type CrmLeadListItem = {
+      ID: string
+      TITLE: string
+      NAME: string | null
+      LAST_NAME: string | null
+      STATUS_ID: string
+      SOURCE_ID: string
+      CURRENCY_ID: string
+      OPPORTUNITY: string
+      ASSIGNED_BY_ID: string
+      OPENED: string
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.lead.list',
-        {
+      // crm.lead.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmLeadListItem[]>({
+        method: 'crm.lead.list',
+        params: {
           select: ['*', 'UF_*'],
           filter: {
             '=OPPORTUNITY': 15000,
@@ -131,51 +156,71 @@
           order: {
             STATUS_ID: 'ASC',
           },
+          start: 50,
         },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.lead.list', {
-        select: ['*', 'UF_*'],
-        filter: {
-          '=OPPORTUNITY': 15000,
-        },
-        order: {
-          STATUS_ID: 'ASC',
-        },
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Leads on this page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.lead.list', {
-        select: ['*', 'UF_*'],
-        filter: {
-          '=OPPORTUNITY': 15000,
-        },
-        order: {
-          STATUS_ID: 'ASC',
-        },
-      }, 50)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listLeads() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.lead.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.list',
+            params: {
+              select: ['*', 'UF_*'],
+              filter: {
+                '=OPPORTUNITY': 15000,
+              },
+              order: {
+                STATUS_ID: 'ASC',
+              },
+              start: 50,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Leads on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listLeads)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-productrows-get.md
+++ b/api-reference/crm/leads/crm-lead-productrows-get.md
@@ -60,29 +60,93 @@
 	https://**put_your_bitrix24_address**/rest/crm.lead.productrows.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.productrows.get',
-    		{
-    			id: 5,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of each product row returned in result[]
+    type CrmLeadProductRow = {
+      ID: string
+      OWNER_ID: string
+      OWNER_TYPE: string
+      PRODUCT_ID: number
+      PRODUCT_NAME: string
+      PRICE: number
+      QUANTITY: number
+      DISCOUNT_TYPE_ID: number
+      DISCOUNT_RATE: number
+      DISCOUNT_SUM: number
+      TAX_RATE: number | null
+      TAX_INCLUDED: string
+      MEASURE_CODE: number
+      MEASURE_NAME: string
+      SORT: number
+      DATE_RESERVE_END: ISODate | null
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmLeadProductRow[]>({
+        method: 'crm.lead.productrows.get',
+        params: {
+          id: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product rows:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLeadProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.productrows.get',
+            params: {
+              id: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product rows:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLeadProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-productrows-set.md
+++ b/api-reference/crm/leads/crm-lead-productrows-set.md
@@ -155,53 +155,121 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.productrows.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.productrows.set',
-    		{
-    			id: 5,
-    			rows: [
-    				{
-    					PRODUCT_ID: 456,
-    					PRICE: 1000,
-    					QUANTITY: 10,
-    					DISCOUNT_TYPE_ID: 1,
-    					DISCOUNT_SUM: 100,
-    					TAX_RATE: 13,
-    					MEASURE_CODE: 796,
-    					MEASURE_NAME: "шт",
-    					SORT: 10,
-    				},
-    				{
-    					PRODUCT_NAME: "Товар #2",
-    					PRICE: 500,
-    					QUANTITY: 5,
-    					DISCOUNT_TYPE_ID: 2,
-    					DISCOUNT_RATE: 10,
-    					TAX_RATE: 10,
-    					MEASURE_CODE: 166,
-    					MEASURE_NAME: "кг",
-    					SORT: 20,
-    				},
-    			],
-    		}
-    	);
+    declare const $b24: B24Frame
 
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.productrows.set',
+        params: {
+          id: 5,
+          rows: [
+            {
+              PRODUCT_ID: 456,
+              PRICE: 1000,
+              QUANTITY: 10,
+              DISCOUNT_TYPE_ID: 1,
+              DISCOUNT_SUM: 100,
+              TAX_RATE: 13,
+              MEASURE_CODE: 796,
+              MEASURE_NAME: 'pcs',
+              SORT: 10,
+            },
+            {
+              PRODUCT_NAME: 'Product #2',
+              PRICE: 500,
+              QUANTITY: 5,
+              DISCOUNT_TYPE_ID: 2,
+              DISCOUNT_RATE: 10,
+              TAX_RATE: 10,
+              MEASURE_CODE: 166,
+              MEASURE_NAME: 'kg',
+              SORT: 20,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product rows set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setLeadProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.productrows.set',
+            params: {
+              id: 5,
+              rows: [
+                {
+                  PRODUCT_ID: 456,
+                  PRICE: 1000,
+                  QUANTITY: 10,
+                  DISCOUNT_TYPE_ID: 1,
+                  DISCOUNT_SUM: 100,
+                  TAX_RATE: 13,
+                  MEASURE_CODE: 796,
+                  MEASURE_NAME: 'pcs',
+                  SORT: 10,
+                },
+                {
+                  PRODUCT_NAME: 'Product #2',
+                  PRICE: 500,
+                  QUANTITY: 5,
+                  DISCOUNT_TYPE_ID: 2,
+                  DISCOUNT_RATE: 10,
+                  TAX_RATE: 10,
+                  MEASURE_CODE: 166,
+                  MEASURE_NAME: 'kg',
+                  SORT: 20,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product rows set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setLeadProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/crm-lead-update.md
+++ b/api-reference/crm/leads/crm-lead-update.md
@@ -241,53 +241,125 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.lead.update",
-    		{
-    			id: 1608,
-    			fields:
-    			{
-    				TITLE: "ИП Титов",
-    				NAME: "Глеб",
-    				SECOND_NAME: "Егорович",
-    				LAST_NAME: "Титов",
-    				STATUS_ID: "NEW",
-    				OPENED: "Y",
-    				ASSIGNED_BY_ID: 1,
-    				CURRENCY_ID: "USD",
-    				OPPORTUNITY: 12500,
-    				PHONE: [
-    					{
-    						VALUE: "555888",
-    						VALUE_TYPE: "WORK",
-    					},
-    				],
-    				WEB: [
-    					{
-    						VALUE: "www.mysite.com",
-    						VALUE_TYPE: "WORK",
-    					}
-    				],
-    			},
-    			params: {
-    				REGISTER_SONET_EVENT: "Y",
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.update',
+        params: {
+          id: 1608,
+          fields: {
+            TITLE: 'Sole proprietor Titov',
+            NAME: 'Gleb',
+            SECOND_NAME: 'Egorovich',
+            LAST_NAME: 'Titov',
+            STATUS_ID: 'NEW',
+            OPENED: 'Y',
+            ASSIGNED_BY_ID: 1,
+            CURRENCY_ID: 'USD',
+            OPPORTUNITY: 12500,
+            PHONE: [
+              {
+                VALUE: '555888',
+                VALUE_TYPE: 'WORK',
+              },
+            ],
+            WEB: [
+              {
+                VALUE: 'www.mysite.com',
+                VALUE_TYPE: 'WORK',
+              },
+            ],
+          },
+          params: {
+            REGISTER_SONET_EVENT: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateLead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.update',
+            params: {
+              id: 1608,
+              fields: {
+                TITLE: 'Sole proprietor Titov',
+                NAME: 'Gleb',
+                SECOND_NAME: 'Egorovich',
+                LAST_NAME: 'Titov',
+                STATUS_ID: 'NEW',
+                OPENED: 'Y',
+                ASSIGNED_BY_ID: 1,
+                CURRENCY_ID: 'USD',
+                OPPORTUNITY: 12500,
+                PHONE: [
+                  {
+                    VALUE: '555888',
+                    VALUE_TYPE: 'WORK',
+                  },
+                ],
+                WEB: [
+                  {
+                    VALUE: 'www.mysite.com',
+                    VALUE_TYPE: 'WORK',
+                  },
+                ],
+              },
+              params: {
+                REGISTER_SONET_EVENT: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateLead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/custom-form/crm-lead-details-configuration-force-common-scope-for-all.md
+++ b/api-reference/crm/leads/custom-form/crm-lead-details-configuration-force-common-scope-for-all.md
@@ -75,28 +75,78 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.details.configuration.forceCommonScopeForAll
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'crm.lead.details.configuration.forceCommonScopeForAll',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.details.configuration.forceCommonScopeForAll',
+        params: {
+          extras: {
+            leadCustomerType: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Common card forced for all users:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function forceCommonScopeForAll() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.details.configuration.forceCommonScopeForAll',
+            params: {
               extras: {
-                  leadCustomerType: 2,
+                leadCustomerType: 2,
               },
-          }
-      );
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.info(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Common card forced for all users:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', forceCommonScopeForAll)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/crm/leads/custom-form/crm-lead-details-configuration-get.md
+++ b/api-reference/crm/leads/custom-form/crm-lead-details-configuration-get.md
@@ -91,27 +91,88 @@
         https://**put_your_bitrix24_address**/rest/crm.lead.details.configuration.get
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-            const response = await $b24.callMethod(
-                'crm.lead.details.configuration.get',
-                {
-                    scope: 'P',
-                    userId: 1,
-                }
-            );
-            
-            const result = response.getData().result;
-            console.log('Data:', result);
-            processResult(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type CrmLeadCardSectionElement = {
+          name: string
+          optionFlags: string
         }
-        catch( error )
-        {
-            console.error('Error:', error);
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type CrmLeadCardSection = {
+          name: string
+          title: string
+          type: string
+          elements: CrmLeadCardSectionElement[]
         }
+
+        try {
+          const response = await $b24.actions.v2.call.make<CrmLeadCardSection[] | null>({
+            method: 'crm.lead.details.configuration.get',
+            params: {
+              scope: 'P',
+              userId: 1,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Card sections:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getLeadCardConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.lead.details.configuration.get',
+                params: {
+                  scope: 'P',
+                  userId: 1,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Card sections:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getLeadCardConfiguration)
+        </script>
         ```
 
     - PHP
@@ -233,27 +294,86 @@
         https://**put_your_bitrix24_address**/rest/crm.lead.details.configuration.get
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-            const response = await $b24.callMethod(
-                'crm.lead.details.configuration.get',
-                {
-                    scope: 'C',
-                }
-            );
-            
-            const result = response.getData().result;
-            console.log('Configuration details:', result);
-            
-            processResult(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type CrmLeadCardSectionElement = {
+          name: string
+          optionFlags: string
         }
-        catch( error )
-        {
-            console.error('Error:', error);
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type CrmLeadCardSection = {
+          name: string
+          title: string
+          type: string
+          elements: CrmLeadCardSectionElement[]
         }
+
+        try {
+          const response = await $b24.actions.v2.call.make<CrmLeadCardSection[] | null>({
+            method: 'crm.lead.details.configuration.get',
+            params: {
+              scope: 'C',
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Card sections:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getLeadCardConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.lead.details.configuration.get',
+                params: {
+                  scope: 'C',
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Card sections:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getLeadCardConfiguration)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/leads/custom-form/crm-lead-details-configuration-reset.md
+++ b/api-reference/crm/leads/custom-form/crm-lead-details-configuration-reset.md
@@ -91,26 +91,75 @@
         https://**put_your_bitrix24_address**/rest/crm.lead.details.configuration.reset
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-            const response = await $b24.callMethod(
-                'crm.lead.details.configuration.reset',
-                {
-                    scope: 'P',
-                    userId: 1
-                }
-            );
-            
-            const result = response.getData().result;
-            console.dir(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.lead.details.configuration.reset',
+            params: {
+              scope: 'P',
+              userId: 1,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Configuration reset:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-        catch(error)
-        {
-            console.error(error);
-        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function resetLeadCardConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.lead.details.configuration.reset',
+                params: {
+                  scope: 'P',
+                  userId: 1,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Configuration reset:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', resetLeadCardConfiguration)
+        </script>
         ```
 
     - PHP
@@ -236,25 +285,73 @@
         https://**put_your_bitrix24_address**/rest/crm.lead.details.configuration.reset
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-        	const response = await $b24.callMethod(
-        		"crm.lead.details.configuration.reset",
-        		{
-        			scope: "C"
-        		}
-        	);
-        	
-        	const result = response.getData().result;
-        	console.dir(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.lead.details.configuration.reset',
+            params: {
+              scope: 'C',
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Configuration reset:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-        catch(error)
-        {
-        	console.error(error);
-        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function resetLeadCardConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.lead.details.configuration.reset',
+                params: {
+                  scope: 'C',
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Configuration reset:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', resetLeadCardConfiguration)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/leads/custom-form/crm-lead-details-configuration-set.md
+++ b/api-reference/crm/leads/custom-form/crm-lead-details-configuration-set.md
@@ -123,52 +123,127 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.details.configuration.set
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'crm.lead.details.configuration.set',
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
+
+  declare const $b24: B24Frame
+
+  try {
+    const response = await $b24.actions.v2.call.make<boolean>({
+      method: 'crm.lead.details.configuration.set',
+      params: {
+        scope: 'P',
+        userId: 1,
+        extras: {
+          leadCustomerType: 2,
+        },
+        data: [
           {
-              scope: 'P',
-              userId: 1,
-              extras: {
-                  leadCustomerType: 2,
-              },
-              data: [
-                  {
-                      name: 'main',
-                      title: 'О лиде',
-                      type: 'section',
-                      elements: [
-                          { name: 'TITLE' },
-                          { name: 'STATUS_ID' },
-                          { name: 'SOURCE_ID' },
-                          { name: 'NAME' },
-                          { name: 'PHONE', optionFlags: 1 },
-                      ],
-                  },
-                  {
-                      name: 'additional',
-                      title: 'Дополнительно',
-                      type: 'section',
-                      elements: [
-                          { name: 'ASSIGNED_BY_ID' },
-                          { name: 'COMMENTS' },
-                      ],
-                  },
-              ],
-          }
-      );
+            name: 'main',
+            title: 'About lead',
+            type: 'section',
+            elements: [
+              { name: 'TITLE' },
+              { name: 'STATUS_ID' },
+              { name: 'SOURCE_ID' },
+              { name: 'NAME' },
+              { name: 'PHONE', optionFlags: 1 },
+            ],
+          },
+          {
+            name: 'additional',
+            title: 'Additional',
+            type: 'section',
+            elements: [
+              { name: 'ASSIGNED_BY_ID' },
+              { name: 'COMMENTS' },
+            ],
+          },
+        ],
+      },
+      requestId: Text.getUuidRfc4122()
+    })
 
-      const result = response.getData().result;
-      console.info(result);
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info('Configuration saved:', result)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
-  catch (error)
-  {
-      console.error(error);
-  }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function setLeadCardConfiguration() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'crm.lead.details.configuration.set',
+          params: {
+            scope: 'P',
+            userId: 1,
+            extras: {
+              leadCustomerType: 2,
+            },
+            data: [
+              {
+                name: 'main',
+                title: 'About lead',
+                type: 'section',
+                elements: [
+                  { name: 'TITLE' },
+                  { name: 'STATUS_ID' },
+                  { name: 'SOURCE_ID' },
+                  { name: 'NAME' },
+                  { name: 'PHONE', optionFlags: 1 },
+                ],
+              },
+              {
+                name: 'additional',
+                title: 'Additional',
+                type: 'section',
+                elements: [
+                  { name: 'ASSIGNED_BY_ID' },
+                  { name: 'COMMENTS' },
+                ],
+              },
+            ],
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info('Configuration saved:', result)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', setLeadCardConfiguration)
+  </script>
   ```
 
 - PHP

--- a/api-reference/crm/leads/management-communication/crm-lead-contact-add.md
+++ b/api-reference/crm/leads/management-communication/crm-lead-contact-add.md
@@ -84,38 +84,83 @@ fields:
     https://**put_your_bitrix24_address**/rest/crm.lead.contact.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.contact.add',
-    		{
-    			id: 1,
-    			fields: {
-    				'CONTACT_ID': 1010,
-    				'SORT': 10,
-    				'IS_PRIMARY': 'Y'
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.contact.add',
+        params: {
+          id: 1,
+          fields: {
+            CONTACT_ID: 1010,
+            SORT: 10,
+            IS_PRIMARY: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact linked to lead:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addLeadContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.contact.add',
+            params: {
+              id: 1,
+              fields: {
+                CONTACT_ID: 1010,
+                SORT: 10,
+                IS_PRIMARY: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact linked to lead:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addLeadContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/management-communication/crm-lead-contact-delete.md
+++ b/api-reference/crm/leads/management-communication/crm-lead-contact-delete.md
@@ -73,32 +73,79 @@ fields:
     https://**put_your_bitrix24_address**/rest/crm.lead.contact.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.contact.delete',
-    		{
-    			id: 1,
-    			fields: {
-    				'CONTACT_ID': 1010
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.contact.delete',
+        params: {
+          id: 1,
+          fields: {
+            CONTACT_ID: 1010,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact unlinked from lead:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteLeadContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.contact.delete',
+            params: {
+              id: 1,
+              fields: {
+                CONTACT_ID: 1010,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact unlinked from lead:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteLeadContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/management-communication/crm-lead-contact-fields.md
+++ b/api-reference/crm/leads/management-communication/crm-lead-contact-fields.md
@@ -43,23 +43,82 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.contact.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.contact.fields'
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmLeadContactFields = Record<string, CrmLeadContactFieldDescription>
+
+    type CrmLeadContactFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmLeadContactFields>({
+        method: 'crm.lead.contact.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead-contact link fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLeadContactFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.contact.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead-contact link fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLeadContactFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/management-communication/crm-lead-contact-items-delete.md
+++ b/api-reference/crm/leads/management-communication/crm-lead-contact-items-delete.md
@@ -52,33 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.contact.items.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.lead.contact.items.delete",
-    		{
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.contact.items.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead contacts cleared:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteLeadContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.contact.items.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead contacts cleared:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteLeadContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/management-communication/crm-lead-contact-items-get.md
+++ b/api-reference/crm/leads/management-communication/crm-lead-contact-items-get.md
@@ -52,29 +52,81 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.contact.items.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.lead.contact.items.get",
-    		{
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of each linked contact returned in result[]
+    type CrmLeadContactItem = {
+      CONTACT_ID: number
+      SORT: number
+      ROLE_ID: number
+      IS_PRIMARY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmLeadContactItem[]>({
+        method: 'crm.lead.contact.items.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Linked contacts:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLeadContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.contact.items.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Linked contacts:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLeadContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/management-communication/crm-lead-contact-items-set.md
+++ b/api-reference/crm/leads/management-communication/crm-lead-contact-items-set.md
@@ -59,41 +59,97 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.contact.items.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.lead.contact.items.set",
-    		{
-    			id: 1,
-    			items: [
-    				{
-    					"CONTACT_ID": 1010,
-    					"SORT": 10,
-    					"IS_PRIMARY": "Y"
-    				},
-    				{
-    					"CONTACT_ID": 1020,
-    					"SORT": 20,
-    					"IS_PRIMARY": "N"
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.contact.items.set',
+        params: {
+          id: 1,
+          items: [
+            {
+              CONTACT_ID: 1010,
+              SORT: 10,
+              IS_PRIMARY: 'Y',
+            },
+            {
+              CONTACT_ID: 1020,
+              SORT: 20,
+              IS_PRIMARY: 'N',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead contacts set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setLeadContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.contact.items.set',
+            params: {
+              id: 1,
+              items: [
+                {
+                  CONTACT_ID: 1010,
+                  SORT: 10,
+                  IS_PRIMARY: 'Y',
+                },
+                {
+                  CONTACT_ID: 1020,
+                  SORT: 20,
+                  IS_PRIMARY: 'N',
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead contacts set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setLeadContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/userfield/crm-lead-userfield-add.md
+++ b/api-reference/crm/leads/userfield/crm-lead-userfield-add.md
@@ -466,58 +466,141 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.userfield.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.lead.userfield.add',
-            {
-                fields: {
-                    LABEL: 'Поле Привет, мир!',
-                    USER_TYPE_ID: 'string',
-                    FIELD_NAME: 'HELLO_WORLD',
-                    MULTIPLE: 'Y',
-                    MANDATORY: 'Y',
-                    SHOW_FILTER: 'Y',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Привет, мир! Значение по умолчанию',
-                        ROWS: 3,
-                    },
-                    SORT: 1000,
-                    EDIT_IN_LIST: 'Y',
-                    LIST_FILTER_LABEL: 'Привет, мир! Фильтр',
-                    LIST_COLUMN_LABEL: {
-                        en: 'Hello, World! Column',
-                        ru: 'Привет, мир! Колонка',
-                        de: 'Hallo, Welt! Spalte',
-                    },
-                    EDIT_FORM_LABEL: {
-                        en: 'Hello, World! Edit',
-                        ru: 'Привет, мир! Редактировать',
-                        de: 'Hallo, Welt! Bearbeiten',
-                    },
-                    ERROR_MESSAGE: {
-                        en: 'Hello, World! Error',
-                        ru: 'Привет, мир! Ошибка',
-                        de: 'Hallo, Welt! Fehler',
-                    },
-                    HELP_MESSAGE: {
-                        en: 'Hello, World! Help',
-                        ru: 'Привет, мир! Помощь',
-                        de: 'Hallo, Welt! Hilfe',
-                    },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.lead.userfield.add',
+        params: {
+          fields: {
+            LABEL: 'Hello World field',
+            USER_TYPE_ID: 'string',
+            FIELD_NAME: 'HELLO_WORLD',
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            SHOW_FILTER: 'Y',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Hello, World! Default value',
+              ROWS: 3,
+            },
+            SORT: 1000,
+            EDIT_IN_LIST: 'Y',
+            LIST_FILTER_LABEL: 'Hello, World! Filter',
+            LIST_COLUMN_LABEL: {
+              en: 'Hello, World! Column',
+              ru: 'Привет, мир! Колонка',
+              de: 'Hallo, Welt! Spalte',
+            },
+            EDIT_FORM_LABEL: {
+              en: 'Hello, World! Edit',
+              ru: 'Привет, мир! Редактировать',
+              de: 'Hallo, Welt! Bearbeiten',
+            },
+            ERROR_MESSAGE: {
+              en: 'Hello, World! Error',
+              ru: 'Привет, мир! Ошибка',
+              de: 'Hallo, Welt! Fehler',
+            },
+            HELP_MESSAGE: {
+              en: 'Hello, World! Help',
+              ru: 'Привет, мир! Помощь',
+              de: 'Hallo, Welt! Hilfe',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created user field id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addLeadUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.userfield.add',
+            params: {
+              fields: {
+                LABEL: 'Hello World field',
+                USER_TYPE_ID: 'string',
+                FIELD_NAME: 'HELLO_WORLD',
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                SHOW_FILTER: 'Y',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Hello, World! Default value',
+                  ROWS: 3,
                 },
-            }
-        );
+                SORT: 1000,
+                EDIT_IN_LIST: 'Y',
+                LIST_FILTER_LABEL: 'Hello, World! Filter',
+                LIST_COLUMN_LABEL: {
+                  en: 'Hello, World! Column',
+                  ru: 'Привет, мир! Колонка',
+                  de: 'Hallo, Welt! Spalte',
+                },
+                EDIT_FORM_LABEL: {
+                  en: 'Hello, World! Edit',
+                  ru: 'Привет, мир! Редактировать',
+                  de: 'Hallo, Welt! Bearbeiten',
+                },
+                ERROR_MESSAGE: {
+                  en: 'Hello, World! Error',
+                  ru: 'Привет, мир! Ошибка',
+                  de: 'Hallo, Welt! Fehler',
+                },
+                HELP_MESSAGE: {
+                  en: 'Hello, World! Help',
+                  ru: 'Привет, мир! Помощь',
+                  de: 'Hallo, Welt! Hilfe',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created user field id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addLeadUserField)
+    </script>
     ```
 
 - PHP
@@ -655,42 +738,109 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.userfield.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.lead.userfield.add',
-            {
-                fields: {
-                    LABEL: 'Пользовательское поле (список)',
-                    USER_TYPE_ID: 'enumeration',
-                    FIELD_NAME: 'ENUMERATION_EXAMPLE',
-                    MULTIPLE: 'N',
-                    MANDATORY: 'N',
-                    SHOW_FILTER: 'Y',
-                    LIST: [
-                        { VALUE: 'Элемент списка #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
-                        { VALUE: 'Элемент списка #2', XML_ID: 'XML_ID_2', SORT: 200 },
-                        { VALUE: 'Элемент списка #3', XML_ID: 'XML_ID_3', SORT: 300 },
-                        { VALUE: 'Элемент списка #4', XML_ID: 'XML_ID_4', SORT: 400 },
-                    ],
-                    SETTINGS: {
-                        DISPLAY: 'UI',
-                        LIST_HEIGHT: 2,
-                    },
-                    SORT: 2000,
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.lead.userfield.add',
+        params: {
+          fields: {
+            LABEL: 'Custom field (list)',
+            USER_TYPE_ID: 'enumeration',
+            FIELD_NAME: 'ENUMERATION_EXAMPLE',
+            MULTIPLE: 'N',
+            MANDATORY: 'N',
+            SHOW_FILTER: 'Y',
+            LIST: [
+              { VALUE: 'List item #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
+              { VALUE: 'List item #2', XML_ID: 'XML_ID_2', SORT: 200 },
+              { VALUE: 'List item #3', XML_ID: 'XML_ID_3', SORT: 300 },
+              { VALUE: 'List item #4', XML_ID: 'XML_ID_4', SORT: 400 },
+            ],
+            SETTINGS: {
+              DISPLAY: 'UI',
+              LIST_HEIGHT: 2,
+            },
+            SORT: 2000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created user field id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addLeadUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.userfield.add',
+            params: {
+              fields: {
+                LABEL: 'Custom field (list)',
+                USER_TYPE_ID: 'enumeration',
+                FIELD_NAME: 'ENUMERATION_EXAMPLE',
+                MULTIPLE: 'N',
+                MANDATORY: 'N',
+                SHOW_FILTER: 'Y',
+                LIST: [
+                  { VALUE: 'List item #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
+                  { VALUE: 'List item #2', XML_ID: 'XML_ID_2', SORT: 200 },
+                  { VALUE: 'List item #3', XML_ID: 'XML_ID_3', SORT: 300 },
+                  { VALUE: 'List item #4', XML_ID: 'XML_ID_4', SORT: 400 },
+                ],
+                SETTINGS: {
+                  DISPLAY: 'UI',
+                  LIST_HEIGHT: 2,
                 },
-            }
-        );
+                SORT: 2000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created user field id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addLeadUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/userfield/crm-lead-userfield-delete.md
+++ b/api-reference/crm/leads/userfield/crm-lead-userfield-delete.md
@@ -54,28 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.userfield.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.userfield.delete',
-    		{
-    			id: 432,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.userfield.delete',
+        params: {
+          id: 432,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteLeadUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.userfield.delete',
+            params: {
+              id: 432,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteLeadUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/userfield/crm-lead-userfield-get.md
+++ b/api-reference/crm/leads/userfield/crm-lead-userfield-get.md
@@ -54,28 +54,88 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.userfield.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.lead.userfield.get',
-    		{
-    			id: 399,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (a representative subset of the user field properties)
+    type CrmLeadUserField = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_IN_LIST: string
+      EDIT_FORM_LABEL: Record<string, string>
+      LIST_COLUMN_LABEL: Record<string, string>
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmLeadUserField>({
+        method: 'crm.lead.userfield.get',
+        params: {
+          id: 399,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field:', result.FIELD_NAME, result.USER_TYPE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLeadUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.userfield.get',
+            params: {
+              id: 399,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field:', result.FIELD_NAME, result.USER_TYPE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLeadUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/userfield/crm-lead-userfield-list.md
+++ b/api-reference/crm/leads/userfield/crm-lead-userfield-list.md
@@ -170,73 +170,116 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.userfield.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-    const response = await $b24.callListMethod(
-        'crm.lead.userfield.list',
-        {
-         filter: {
-            MULTIPLE: "Y",
-            MANDATORY: "Y",
-            LANG: "ru",
-         },
-         order: {
-            USER_TYPE_ID: "ASC",
-            SORT: "ASC",
-         },
-        },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each user field returned in result[] (with filter.LANG the label fields are strings)
+    type CrmLeadUserFieldListItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_IN_LIST: string
+      EDIT_FORM_LABEL: string
+      LIST_COLUMN_LABEL: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-    const generator = $b24.fetchListMethod('crm.lead.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
 
     try {
-    const response = await $b24.callMethod('crm.lead.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
+      // crm.lead.userfield.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmLeadUserFieldListItem[]>({
+        method: 'crm.lead.userfield.list',
+        params: {
+          filter: {
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            LANG: 'ru',
+          },
+          order: {
+            USER_TYPE_ID: 'ASC',
+            SORT: 'ASC',
+          },
+          start: 0,
         },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User fields on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listLeadUserFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.lead.userfield.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.userfield.list',
+            params: {
+              filter: {
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                LANG: 'ru',
+              },
+              order: {
+                USER_TYPE_ID: 'ASC',
+                SORT: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User fields on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listLeadUserFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/leads/userfield/crm-lead-userfield-update.md
+++ b/api-reference/crm/leads/userfield/crm-lead-userfield-update.md
@@ -373,55 +373,135 @@
     https://**put_your_bitrix24_address**/rest/crm.lead.userfield.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.lead.userfield.update',
-            {
-                id: 536,
-                fields: {
-                    MANDATORY: 'N',
-                    SHOW_FILTER: 'N',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Привет, мир! Значение по умолчанию (изменено)',
-                        ROWS: 10,
-                    },
-                    SORT: 2000,
-                    EDIT_IN_LIST: 'N',
-                    LIST_FILTER_LABEL: 'Привет, мир! Фильтр (изменено)',
-                    LIST_COLUMN_LABEL: {
-                        en: 'Hello, World! Column (changed)',
-                        ru: 'Привет, мир! Колонка (изменено)',
-                        de: 'Hallo, Welt! Spalte (geändert)',
-                    },
-                    EDIT_FORM_LABEL: {
-                        en: 'Hello, World! Edit (changed)',
-                        ru: 'Привет, мир! Редактировать (изменено)',
-                        de: 'Hallo, Welt! Bearbeiten (geändert)',
-                    },
-                    ERROR_MESSAGE: {
-                        en: 'Hello, World! Error (changed)',
-                        ru: 'Привет, мир! Ошибка (изменено)',
-                        de: 'Hallo, Welt! Fehler (geändert)',
-                    },
-                    HELP_MESSAGE: {
-                        en: 'Hello, World! Help (changed)',
-                        ru: 'Привет, мир! Помощь (изменено)',
-                        de: 'Hallo, Welt! Hilfe (geändert)',
-                    },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.lead.userfield.update',
+        params: {
+          id: 536,
+          fields: {
+            MANDATORY: 'N',
+            SHOW_FILTER: 'N',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Hello, World! Default value (changed)',
+              ROWS: 10,
+            },
+            SORT: 2000,
+            EDIT_IN_LIST: 'N',
+            LIST_FILTER_LABEL: 'Hello, World! Filter (changed)',
+            LIST_COLUMN_LABEL: {
+              en: 'Hello, World! Column (changed)',
+              ru: 'Привет, мир! Колонка (изменено)',
+              de: 'Hallo, Welt! Spalte (geändert)',
+            },
+            EDIT_FORM_LABEL: {
+              en: 'Hello, World! Edit (changed)',
+              ru: 'Привет, мир! Редактировать (изменено)',
+              de: 'Hallo, Welt! Bearbeiten (geändert)',
+            },
+            ERROR_MESSAGE: {
+              en: 'Hello, World! Error (changed)',
+              ru: 'Привет, мир! Ошибка (изменено)',
+              de: 'Hallo, Welt! Fehler (geändert)',
+            },
+            HELP_MESSAGE: {
+              en: 'Hello, World! Help (changed)',
+              ru: 'Привет, мир! Помощь (изменено)',
+              de: 'Hallo, Welt! Hilfe (geändert)',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateLeadUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.lead.userfield.update',
+            params: {
+              id: 536,
+              fields: {
+                MANDATORY: 'N',
+                SHOW_FILTER: 'N',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Hello, World! Default value (changed)',
+                  ROWS: 10,
                 },
-            }
-        );
+                SORT: 2000,
+                EDIT_IN_LIST: 'N',
+                LIST_FILTER_LABEL: 'Hello, World! Filter (changed)',
+                LIST_COLUMN_LABEL: {
+                  en: 'Hello, World! Column (changed)',
+                  ru: 'Привет, мир! Колонка (изменено)',
+                  de: 'Hallo, Welt! Spalte (geändert)',
+                },
+                EDIT_FORM_LABEL: {
+                  en: 'Hello, World! Edit (changed)',
+                  ru: 'Привет, мир! Редактировать (изменено)',
+                  de: 'Hallo, Welt! Bearbeiten (geändert)',
+                },
+                ERROR_MESSAGE: {
+                  en: 'Hello, World! Error (changed)',
+                  ru: 'Привет, мир! Ошибка (изменено)',
+                  de: 'Hallo, Welt! Fehler (geändert)',
+                },
+                HELP_MESSAGE: {
+                  en: 'Hello, World! Help (changed)',
+                  ru: 'Привет, мир! Помощь (изменено)',
+                  de: 'Hallo, Welt! Hilfe (geändert)',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateLeadUserField)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start` and link the `callList.make` / `fetchList.make`
  helpers; `getTotal()` (removed in SDK 2.0) is replaced by `.length` + helpers.
- Each example is verified: `tsc --strict` against `@bitrix24/b24jssdk@1`, `node --check`
  on the UMD tab, and a method/field cross-check against the page's cURL endpoint and JSON
  response.
- One section per PR to keep review small.

No breaking changes — documentation examples only.