### PR TITLE
docs(crm/companies): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/companies/contacts/crm-company-contact-add.md
+++ b/api-reference/crm/companies/contacts/crm-company-contact-add.md
@@ -97,34 +97,83 @@
     https://**put_your_bitrix24_address**/rest/crm.company.contact.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.contact.add',
-    		{
-    			id: 32,
-    			fields: {
-    				CONTACT_ID: 54,
-    				IS_PRIMARY: "Y",
-    				SORT: 1000,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.contact.add',
+        params: {
+          id: 32,
+          fields: {
+            CONTACT_ID: 54,
+            IS_PRIMARY: 'Y',
+            SORT: 1000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact added to company:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCompanyContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.contact.add',
+            params: {
+              id: 32,
+              fields: {
+                CONTACT_ID: 54,
+                IS_PRIMARY: 'Y',
+                SORT: 1000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact added to company:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCompanyContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/contacts/crm-company-contact-delete.md
+++ b/api-reference/crm/companies/contacts/crm-company-contact-delete.md
@@ -66,32 +66,79 @@
     https://**put_your_bitrix24_address**/rest/crm.company.contact.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.contact.delete',
-    		{
-    			id: 32,
-    			fields: {
-    				CONTACT_ID: 54,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.contact.delete',
+        params: {
+          id: 32,
+          fields: {
+            CONTACT_ID: 54,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact removed from company:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCompanyContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.contact.delete',
+            params: {
+              id: 32,
+              fields: {
+                CONTACT_ID: 54,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact removed from company:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCompanyContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/contacts/crm-company-contact-fields.md
+++ b/api-reference/crm/companies/contacts/crm-company-contact-fields.md
@@ -45,27 +45,82 @@
     https://**put_your_bitrix24_address**/rest/crm.company.contact.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.contact.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCompanyContactFields = Record<string, CrmCompanyContactFieldDescription>
+
+    type CrmCompanyContactFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCompanyContactFields>({
+        method: 'crm.company.contact.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company-contact link fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCompanyContactFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.contact.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company-contact link fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCompanyContactFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/contacts/crm-company-contact-items-delete.md
+++ b/api-reference/crm/companies/contacts/crm-company-contact-items-delete.md
@@ -54,29 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.company.contact.items.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.contact.items.delete',
-    		{
-    			id: 32,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.contact.items.delete',
+        params: {
+          id: 32,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company contacts cleared:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCompanyContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.contact.items.delete',
+            params: {
+              id: 32,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company contacts cleared:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCompanyContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/contacts/crm-company-contact-items-get.md
+++ b/api-reference/crm/companies/contacts/crm-company-contact-items-get.md
@@ -54,29 +54,81 @@
     https://**put_your_bitrix24_address**/rest/crm.company.contact.items.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.contact.items.get',
-    		{
-    			id: 32,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of each company-contact binding returned in result[]
+    type CrmCompanyContactBinding = {
+      CONTACT_ID: number
+      SORT: number
+      ROLE_ID: number
+      IS_PRIMARY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCompanyContactBinding[]>({
+        method: 'crm.company.contact.items.get',
+        params: {
+          id: 32,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company contacts:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCompanyContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.contact.items.get',
+            params: {
+              id: 32,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company contacts:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCompanyContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/contacts/crm-company-contact-items-set.md
+++ b/api-reference/crm/companies/contacts/crm-company-contact-items-set.md
@@ -85,44 +85,103 @@
     https://**put_your_bitrix24_address**/rest/crm.company.contact.items.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.contact.items.set',
-    		{
-    			id: 32,
-    			items: [
-    				{
-    					CONTACT_ID: 8,
-    					IS_PRIMARY: "Y",
-    					SORT: 100,
-    				},
-    				{
-    					CONTACT_ID: 9,
-    					SORT: 200,
-    				},
-    				{
-    					CONTACT_ID: 10,
-    					SORT: 400,
-    				}
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.contact.items.set',
+        params: {
+          id: 32,
+          items: [
+            {
+              CONTACT_ID: 8,
+              IS_PRIMARY: 'Y',
+              SORT: 100,
+            },
+            {
+              CONTACT_ID: 9,
+              SORT: 200,
+            },
+            {
+              CONTACT_ID: 10,
+              SORT: 400,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company contacts set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setCompanyContactItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.contact.items.set',
+            params: {
+              id: 32,
+              items: [
+                {
+                  CONTACT_ID: 8,
+                  IS_PRIMARY: 'Y',
+                  SORT: 100,
+                },
+                {
+                  CONTACT_ID: 9,
+                  SORT: 200,
+                },
+                {
+                  CONTACT_ID: 10,
+                  SORT: 400,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company contacts set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setCompanyContactItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/crm-company-add.md
+++ b/api-reference/crm/companies/crm-company-add.md
@@ -210,38 +210,97 @@
     https://**put_your_bitrix24_address**/rest/crm.company.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.company.add",
-    		{
-    			fields:
-    			{
-    				"TITLE": "ИП Титов",
-    				"COMPANY_TYPE": "CUSTOMER",
-    				"INDUSTRY": "MANUFACTURING",
-    				"EMPLOYEES": "EMPLOYEES_2",
-    				"CURRENCY_ID": "RUB",
-    				"REVENUE" : 3000000,
-    				"LOGO": { "fileData": document.getElementById('logo') },
-    				"OPENED": "Y",
-    				"ASSIGNED_BY_ID": 1,
-    				"PHONE": [ { "VALUE": "555888", "VALUE_TYPE": "WORK" } ]     
-    			},
-    			params: { "REGISTER_SONET_EVENT": "Y" }        
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("Создана компания с ID " + result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.company.add',
+        params: {
+          fields: {
+            TITLE: 'Titov Sole Proprietor',
+            COMPANY_TYPE: 'CUSTOMER',
+            INDUSTRY: 'MANUFACTURING',
+            EMPLOYEES: 'EMPLOYEES_2',
+            CURRENCY_ID: 'RUB',
+            REVENUE: 3000000,
+            LOGO: { fileData: document.getElementById('logo') },
+            OPENED: 'Y',
+            ASSIGNED_BY_ID: 1,
+            PHONE: [{ VALUE: '555888', VALUE_TYPE: 'WORK' }],
+          },
+          params: { REGISTER_SONET_EVENT: 'Y' },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created company id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCompany() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.add',
+            params: {
+              fields: {
+                TITLE: 'Titov Sole Proprietor',
+                COMPANY_TYPE: 'CUSTOMER',
+                INDUSTRY: 'MANUFACTURING',
+                EMPLOYEES: 'EMPLOYEES_2',
+                CURRENCY_ID: 'RUB',
+                REVENUE: 3000000,
+                LOGO: { fileData: document.getElementById('logo') },
+                OPENED: 'Y',
+                ASSIGNED_BY_ID: 1,
+                PHONE: [{ VALUE: '555888', VALUE_TYPE: 'WORK' }],
+              },
+              params: { REGISTER_SONET_EVENT: 'Y' },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created company id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCompany)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/crm-company-delete.md
+++ b/api-reference/crm/companies/crm-company-delete.md
@@ -58,27 +58,73 @@
     https://**put_your_bitrix24_address**/rest/crm.company.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const id = prompt("Введите ID");
-    	const response = await $b24.callMethod(
-    		"crm.company.delete",
-    		{ id: id }
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.delete',
+        params: {
+          id: 50,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCompany() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.delete',
+            params: {
+              id: 50,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCompany)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/crm-company-fields.md
+++ b/api-reference/crm/companies/crm-company-fields.md
@@ -51,30 +51,82 @@
     https://**put_your_bitrix24_address**/rest/crm.company.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCompanyFields = Record<string, CrmCompanyFieldDescription>
+
+    type CrmCompanyFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCompanyFields>({
+        method: 'crm.company.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCompanyFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCompanyFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/crm-company-get.md
+++ b/api-reference/crm/companies/crm-company-get.md
@@ -58,24 +58,86 @@
     https://**put_your_bitrix24_address**/rest/crm.company.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const id = prompt("Введите ID");
-    	const response = await $b24.callMethod(
-    		"crm.company.get",
-    		{ id: id }
-    	);
-    
-    	const result = response.getData().result;
-    	console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCompanyResult = {
+      ID: string
+      TITLE: string
+      COMPANY_TYPE: string
+      ASSIGNED_BY_ID: string
+      OPENED: string
+      CURRENCY_ID: string
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+      LAST_ACTIVITY_TIME: ISODate | null
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCompanyResult>({
+        method: 'crm.company.get',
+        params: {
+          id: 12,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company:', result.ID, result.TITLE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCompany() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.get',
+            params: {
+              id: 12,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company:', result.ID, result.TITLE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCompany)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/crm-company-list.md
+++ b/api-reference/crm/companies/crm-company-list.md
@@ -146,60 +146,104 @@
     https://**put_your_bitrix24_address**/rest/crm.company.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each company object returned in result[]
+    type CrmCompanyListItem = {
+      ID: string
+      TITLE: string
+      ASSIGNED_BY_ID: string
+      PHONE?: CrmCompanyPhone[]
+    }
+
+    type CrmCompanyPhone = {
+      ID: string
+      VALUE_TYPE: string
+      VALUE: string
+      TYPE_ID: string
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'crm.company.list',
-        {
-        order: { "DATE_CREATE": "ASC" },
-        filter: { "COMPANY_TYPE": "CUSTOMER", ">=DATE_CREATE": "2025-01-01" },
-        select: [ "TITLE", "ASSIGNED_BY_ID", "PHONE" ]
+      // crm.company.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmCompanyListItem[]>({
+        method: 'crm.company.list',
+        params: {
+          order: { DATE_CREATE: 'ASC' },
+          filter: { COMPANY_TYPE: 'CUSTOMER', '>=DATE_CREATE': '2025-01-01' },
+          select: ['TITLE', 'ASSIGNED_BY_ID', 'PHONE'],
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
-
-    try {
-    const generator = $b24.fetchListMethod('crm.company.list', {
-        order: { "DATE_CREATE": "ASC" },
-        filter: { "COMPANY_TYPE": "CUSTOMER", ">=DATE_CREATE": "2025-01-01" },
-        select: [ "TITLE", "ASSIGNED_BY_ID", "PHONE" ]
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Companies on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
+- JS (UMD)
 
-    try {
-    const response = await $b24.callMethod('crm.company.list', {
-        order: { "DATE_CREATE": "ASC" },
-        filter: { "COMPANY_TYPE": "CUSTOMER", ">=DATE_CREATE": "2025-01-01" },
-        select: [ "TITLE", "ASSIGNED_BY_ID", "PHONE" ]
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listCompanies() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.company.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.list',
+            params: {
+              order: { DATE_CREATE: 'ASC' },
+              filter: { COMPANY_TYPE: 'CUSTOMER', '>=DATE_CREATE': '2025-01-01' },
+              select: ['TITLE', 'ASSIGNED_BY_ID', 'PHONE'],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Companies on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listCompanies)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/crm-company-update.md
+++ b/api-reference/crm/companies/crm-company-update.md
@@ -159,40 +159,85 @@
     https://**put_your_bitrix24_address**/rest/crm.company.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const id = prompt("Введите ID");
-    	const response = await $b24.callMethod(
-    		"crm.company.update",
-    		{
-    			id: id,
-    			fields:
-    			{
-    				"CURRENCY_ID": "RUB",
-    				"REVENUE" : 500000,
-    				"EMPLOYEES": "EMPLOYEES_3"
-    			},
-    			params: { "REGISTER_SONET_EVENT": "Y" }
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.info(result);
-    	}
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.update',
+        params: {
+          id: 43,
+          fields: {
+            CURRENCY_ID: 'RUB',
+            REVENUE: 500000,
+            EMPLOYEES: 'EMPLOYEES_3',
+          },
+          params: { REGISTER_SONET_EVENT: 'Y' },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCompany() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.update',
+            params: {
+              id: 43,
+              fields: {
+                CURRENCY_ID: 'RUB',
+                REVENUE: 500000,
+                EMPLOYEES: 'EMPLOYEES_3',
+              },
+              params: { REGISTER_SONET_EVENT: 'Y' },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCompany)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/custom-form/crm-company-details-configuration-force-common-scope-for-all.md
+++ b/api-reference/crm/companies/custom-form/crm-company-details-configuration-force-common-scope-for-all.md
@@ -51,23 +51,69 @@
     https://**put_your_bitrix24_address**/rest/crm.company.details.configuration.forceCommonScopeForAll
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.company.details.configuration.forceCommonScopeForAll",
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.details.configuration.forceCommonScopeForAll',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Common card forced for all users:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function forceCommonScopeForAll() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.details.configuration.forceCommonScopeForAll',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Common card forced for all users:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', forceCommonScopeForAll)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/custom-form/crm-company-details-configuration-get.md
+++ b/api-reference/crm/companies/custom-form/crm-company-details-configuration-get.md
@@ -74,27 +74,92 @@
         https://**put_your_bitrix24_address**/rest/crm.company.details.configuration.get
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-            const response = await $b24.callMethod(
-                'crm.company.details.configuration.get',
-                {
-                    scope: 'P',
-                    userId: 6,
-                }
-            );
-            
-            const result = response.getData().result;
-            console.log('Data:', result);
-            processResult(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of each section returned in result[] (result is null when no configuration exists)
+        type CrmCompanyDetailsSection = {
+          name: string
+          title: string
+          type: string
+          elements: CrmCompanyDetailsSectionElement[]
         }
-        catch( error )
-        {
-            console.error('Error:', error);
+
+        type CrmCompanyDetailsSectionElement = {
+          name: string
+          optionFlags?: string
+          options?: {
+            defaultCountry?: string
+            defaultAddressType?: number
+          }
         }
+
+        try {
+          const response = await $b24.actions.v2.call.make<CrmCompanyDetailsSection[] | null>({
+            method: 'crm.company.details.configuration.get',
+            params: {
+              scope: 'P',
+              userId: 6,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Card sections:', result?.length ?? 0, result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getCompanyDetailsConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.company.details.configuration.get',
+                params: {
+                  scope: 'P',
+                  userId: 6,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Card sections:', result?.length ?? 0, result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getCompanyDetailsConfiguration)
+        </script>
         ```
 
     - PHP
@@ -186,27 +251,90 @@
         https://**put_your_bitrix24_address**/rest/crm.company.details.configuration.get
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-            const response = await $b24.callMethod(
-                'crm.company.details.configuration.get',
-                {
-                    scope: 'C',
-                }
-            );
-            
-            const result = response.getData().result;
-            console.log('Configuration details:', result);
-            
-            processResult(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of each section returned in result[] (result is null when no configuration exists)
+        type CrmCompanyDetailsSection = {
+          name: string
+          title: string
+          type: string
+          elements: CrmCompanyDetailsSectionElement[]
         }
-        catch( error )
-        {
-            console.error('Error:', error);
+
+        type CrmCompanyDetailsSectionElement = {
+          name: string
+          optionFlags?: string
+          options?: {
+            defaultCountry?: string
+            defaultAddressType?: number
+          }
         }
+
+        try {
+          const response = await $b24.actions.v2.call.make<CrmCompanyDetailsSection[] | null>({
+            method: 'crm.company.details.configuration.get',
+            params: {
+              scope: 'C',
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Card sections:', result?.length ?? 0, result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getCompanyDetailsConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.company.details.configuration.get',
+                params: {
+                  scope: 'C',
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Card sections:', result?.length ?? 0, result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getCompanyDetailsConfiguration)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/companies/custom-form/crm-company-details-configuration-reset.md
+++ b/api-reference/crm/companies/custom-form/crm-company-details-configuration-reset.md
@@ -74,26 +74,75 @@
         https://**put_your_bitrix24_address**/rest/crm.company.details.configuration.reset
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-        	const response = await $b24.callMethod(
-        		"crm.company.details.configuration.reset",
-        		{
-        			scope: "P",
-        			userId: 1
-        		}
-        	);
-        	
-        	const result = response.getData().result;
-        	console.dir(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.company.details.configuration.reset',
+            params: {
+              scope: 'P',
+              userId: 1,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Configuration reset:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-        catch(error)
-        {
-        	console.error(error);
-        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function resetCompanyDetailsConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.company.details.configuration.reset',
+                params: {
+                  scope: 'P',
+                  userId: 1,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Configuration reset:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', resetCompanyDetailsConfiguration)
+        </script>
         ```
 
     - PHP
@@ -189,25 +238,73 @@
         https://**put_your_bitrix24_address**/rest/crm.company.details.configuration.reset
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-        	const response = await $b24.callMethod(
-        		"crm.company.details.configuration.reset",
-        		{
-        			scope: "C"
-        		}
-        	);
-        	
-        	const result = response.getData().result;
-        	console.dir(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.company.details.configuration.reset',
+            params: {
+              scope: 'C',
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Configuration reset:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-        catch(error)
-        {
-        	console.error(error);
-        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function resetCompanyDetailsConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.company.details.configuration.reset',
+                params: {
+                  scope: 'C',
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Configuration reset:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', resetCompanyDetailsConfiguration)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/companies/custom-form/crm-company-details-configuration-set.md
+++ b/api-reference/crm/companies/custom-form/crm-company-details-configuration-set.md
@@ -160,63 +160,137 @@
     https://**put_your_bitrix24_address**/rest/crm.company.details.configuration.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.company.details.configuration.set",
-    		{
-    			userId: 1,
-    			data:
-    			[
-    				{
-    					name: "main",
-    					title: "О компании",
-    					type: "section",
-    					elements:
-    					[
-    						{ name: "TITLE" },
-    						{ name: "LOGO" },
-    						{ name: "COMPANY_TYPE" },
-    						{ name: "POST" },
-    					{
-    						name: "PHONE",
-    						options: {
-    							defaultCountry: "RU",
-    						},
-    					},
-    						{ name: "EMAIL" },
-    						{ name: "CONTACT" }
-    					]
-    				},
-    				{
-    					name: "additional",
-    					title: "Дополнительно",
-    					type: "section",
-    					elements:
-    					[
-    						{ name: "INDUSTRY" },
-    						{ name: "OPENED" },
-    						{ name: "ASSIGNED_BY_ID" },
-    						{ name: "COMMENTS" }
-    					]
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.details.configuration.set',
+        params: {
+          userId: 1,
+          data: [
+            {
+              name: 'main',
+              title: 'About company',
+              type: 'section',
+              elements: [
+                { name: 'TITLE' },
+                { name: 'LOGO' },
+                { name: 'COMPANY_TYPE' },
+                { name: 'POST' },
+                {
+                  name: 'PHONE',
+                  options: {
+                    defaultCountry: 'RU',
+                  },
+                },
+                { name: 'EMAIL' },
+                { name: 'CONTACT' },
+              ],
+            },
+            {
+              name: 'additional',
+              title: 'Additional',
+              type: 'section',
+              elements: [
+                { name: 'INDUSTRY' },
+                { name: 'OPENED' },
+                { name: 'ASSIGNED_BY_ID' },
+                { name: 'COMMENTS' },
+              ],
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Configuration saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setCompanyDetailsConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.details.configuration.set',
+            params: {
+              userId: 1,
+              data: [
+                {
+                  name: 'main',
+                  title: 'About company',
+                  type: 'section',
+                  elements: [
+                    { name: 'TITLE' },
+                    { name: 'LOGO' },
+                    { name: 'COMPANY_TYPE' },
+                    { name: 'POST' },
+                    {
+                      name: 'PHONE',
+                      options: {
+                        defaultCountry: 'RU',
+                      },
+                    },
+                    { name: 'EMAIL' },
+                    { name: 'CONTACT' },
+                  ],
+                },
+                {
+                  name: 'additional',
+                  title: 'Additional',
+                  type: 'section',
+                  elements: [
+                    { name: 'INDUSTRY' },
+                    { name: 'OPENED' },
+                    { name: 'ASSIGNED_BY_ID' },
+                    { name: 'COMMENTS' },
+                  ],
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Configuration saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setCompanyDetailsConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/userfields/crm-company-userfield-add.md
+++ b/api-reference/crm/companies/userfields/crm-company-userfield-add.md
@@ -420,58 +420,141 @@
     https://**put_your_bitrix24_address**/rest/crm.company.userfield.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.company.userfield.add',
-            {
-                fields: {
-                    LABEL: 'Поле Привет, мир!',
-                    USER_TYPE_ID: 'string',
-                    FIELD_NAME: 'HELLO_WORLD',
-                    MULTIPLE: 'Y',
-                    MANDATORY: 'Y',
-                    SHOW_FILTER: 'Y',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Привет, мир! Значение по умолчанию',
-                        ROWS: 3,
-                    },
-                    SORT: 1000,
-                    EDIT_IN_LIST: 'Y',
-                    LIST_FILTER_LABEL: 'Привет, мир! Фильтр',
-                    LIST_COLUMN_LABEL: {
-                        en: 'Hello, World! Column',
-                        ru: 'Привет, мир! Колонка',
-                        de: 'Hallo, Welt! Spalte',
-                    },
-                    EDIT_FORM_LABEL: {
-                        en: 'Hello, World! Edit',
-                        ru: 'Привет, мир! Редактировать',
-                        de: 'Hallo, Welt! Bearbeiten',
-                    },
-                    ERROR_MESSAGE: {
-                        en: 'Hello, World! Error',
-                        ru: 'Привет, мир! Ошибка',
-                        de: 'Hallo, Welt! Fehler',
-                    },
-                    HELP_MESSAGE: {
-                        en: 'Hello, World! Help',
-                        ru: 'Привет, мир! Помощь',
-                        de: 'Hallo, Welt! Hilfe',
-                    },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.company.userfield.add',
+        params: {
+          fields: {
+            LABEL: 'Hello, World! field',
+            USER_TYPE_ID: 'string',
+            FIELD_NAME: 'HELLO_WORLD',
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            SHOW_FILTER: 'Y',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Hello, World! default value',
+              ROWS: 3,
+            },
+            SORT: 1000,
+            EDIT_IN_LIST: 'Y',
+            LIST_FILTER_LABEL: 'Hello, World! filter',
+            LIST_COLUMN_LABEL: {
+              en: 'Hello, World! Column',
+              ru: 'Привет, мир! Колонка',
+              de: 'Hallo, Welt! Spalte',
+            },
+            EDIT_FORM_LABEL: {
+              en: 'Hello, World! Edit',
+              ru: 'Привет, мир! Редактировать',
+              de: 'Hallo, Welt! Bearbeiten',
+            },
+            ERROR_MESSAGE: {
+              en: 'Hello, World! Error',
+              ru: 'Привет, мир! Ошибка',
+              de: 'Hallo, Welt! Fehler',
+            },
+            HELP_MESSAGE: {
+              en: 'Hello, World! Help',
+              ru: 'Привет, мир! Помощь',
+              de: 'Hallo, Welt! Hilfe',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created userfield id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCompanyUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.userfield.add',
+            params: {
+              fields: {
+                LABEL: 'Hello, World! field',
+                USER_TYPE_ID: 'string',
+                FIELD_NAME: 'HELLO_WORLD',
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                SHOW_FILTER: 'Y',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Hello, World! default value',
+                  ROWS: 3,
                 },
-            }
-        );
+                SORT: 1000,
+                EDIT_IN_LIST: 'Y',
+                LIST_FILTER_LABEL: 'Hello, World! filter',
+                LIST_COLUMN_LABEL: {
+                  en: 'Hello, World! Column',
+                  ru: 'Привет, мир! Колонка',
+                  de: 'Hallo, Welt! Spalte',
+                },
+                EDIT_FORM_LABEL: {
+                  en: 'Hello, World! Edit',
+                  ru: 'Привет, мир! Редактировать',
+                  de: 'Hallo, Welt! Bearbeiten',
+                },
+                ERROR_MESSAGE: {
+                  en: 'Hello, World! Error',
+                  ru: 'Привет, мир! Ошибка',
+                  de: 'Hallo, Welt! Fehler',
+                },
+                HELP_MESSAGE: {
+                  en: 'Hello, World! Help',
+                  ru: 'Привет, мир! Помощь',
+                  de: 'Hallo, Welt! Hilfe',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created userfield id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCompanyUserfield)
+    </script>
     ```
 
 - PHP
@@ -609,42 +692,109 @@
     https://**put_your_bitrix24_address**/rest/crm.company.userfield.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.company.userfield.add',
-            {
-                fields: {
-                    LABEL: 'Пользовательское поле (список)',
-                    USER_TYPE_ID: 'enumeration',
-                    FIELD_NAME: 'ENUMERATION_EXAMPLE',
-                    MULTIPLE: 'N',
-                    MANDATORY: 'N',
-                    SHOW_FILTER: 'Y',
-                    LIST: [
-                        { VALUE: 'Элемент списка #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
-                        { VALUE: 'Элемент списка #2', XML_ID: 'XML_ID_2', SORT: 200 },
-                        { VALUE: 'Элемент списка #3', XML_ID: 'XML_ID_3', SORT: 300 },
-                        { VALUE: 'Элемент списка #4', XML_ID: 'XML_ID_4', SORT: 400 },
-                    ],
-                    SETTINGS: {
-                        DISPLAY: 'UI',
-                        LIST_HEIGHT: 2,
-                    },
-                    SORT: 2000,
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.company.userfield.add',
+        params: {
+          fields: {
+            LABEL: 'Custom field (list)',
+            USER_TYPE_ID: 'enumeration',
+            FIELD_NAME: 'ENUMERATION_EXAMPLE',
+            MULTIPLE: 'N',
+            MANDATORY: 'N',
+            SHOW_FILTER: 'Y',
+            LIST: [
+              { VALUE: 'List item #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
+              { VALUE: 'List item #2', XML_ID: 'XML_ID_2', SORT: 200 },
+              { VALUE: 'List item #3', XML_ID: 'XML_ID_3', SORT: 300 },
+              { VALUE: 'List item #4', XML_ID: 'XML_ID_4', SORT: 400 },
+            ],
+            SETTINGS: {
+              DISPLAY: 'UI',
+              LIST_HEIGHT: 2,
+            },
+            SORT: 2000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created userfield id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCompanyUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.userfield.add',
+            params: {
+              fields: {
+                LABEL: 'Custom field (list)',
+                USER_TYPE_ID: 'enumeration',
+                FIELD_NAME: 'ENUMERATION_EXAMPLE',
+                MULTIPLE: 'N',
+                MANDATORY: 'N',
+                SHOW_FILTER: 'Y',
+                LIST: [
+                  { VALUE: 'List item #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
+                  { VALUE: 'List item #2', XML_ID: 'XML_ID_2', SORT: 200 },
+                  { VALUE: 'List item #3', XML_ID: 'XML_ID_3', SORT: 300 },
+                  { VALUE: 'List item #4', XML_ID: 'XML_ID_4', SORT: 400 },
+                ],
+                SETTINGS: {
+                  DISPLAY: 'UI',
+                  LIST_HEIGHT: 2,
                 },
-            }
-        );
+                SORT: 2000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created userfield id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCompanyUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/userfields/crm-company-userfield-delete.md
+++ b/api-reference/crm/companies/userfields/crm-company-userfield-delete.md
@@ -54,28 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.company.userfield.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.userfield.delete',
-    		{
-    			id: 432,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.userfield.delete',
+        params: {
+          id: 432,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCompanyUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.userfield.delete',
+            params: {
+              id: 432,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCompanyUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/userfields/crm-company-userfield-get.md
+++ b/api-reference/crm/companies/userfields/crm-company-userfield-get.md
@@ -54,28 +54,85 @@
     https://**put_your_bitrix24_address**/rest/crm.company.userfield.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.company.userfield.get',
-    		{
-    			id: 399,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCompanyUserfield = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCompanyUserfield>({
+        method: 'crm.company.userfield.get',
+        params: {
+          id: 399,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield:', result.ID, result.FIELD_NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCompanyUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.userfield.get',
+            params: {
+              id: 399,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield:', result.ID, result.FIELD_NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCompanyUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/userfields/crm-company-userfield-list.md
+++ b/api-reference/crm/companies/userfields/crm-company-userfield-list.md
@@ -170,73 +170,115 @@
     https://**put_your_bitrix24_address**/rest/crm.company.userfield.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each userfield object returned in result[]
+    type CrmCompanyUserfieldListItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      EDIT_FORM_LABEL: string
+      LIST_COLUMN_LABEL: string
+    }
+
     try {
-    const response = await $b24.callListMethod(
-        'crm.company.userfield.list',
-        {
-         filter: {
-            MULTIPLE: "Y",
-            MANDATORY: "Y",
-            LANG: "ru",
-         },
-         order: {
-            USER_TYPE_ID: "ASC",
-            SORT: "ASC",
-         },
+      // crm.company.userfield.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmCompanyUserfieldListItem[]>({
+        method: 'crm.company.userfield.list',
+        params: {
+          filter: {
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            LANG: 'ru',
+          },
+          order: {
+            USER_TYPE_ID: 'ASC',
+            SORT: 'ASC',
+          },
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfields on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-    const generator = $b24.fetchListMethod('crm.company.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-    const response = await $b24.callMethod('crm.company.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listCompanyUserfields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.company.userfield.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.userfield.list',
+            params: {
+              filter: {
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                LANG: 'ru',
+              },
+              order: {
+                USER_TYPE_ID: 'ASC',
+                SORT: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfields on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listCompanyUserfields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/companies/userfields/crm-company-userfield-update.md
+++ b/api-reference/crm/companies/userfields/crm-company-userfield-update.md
@@ -326,55 +326,135 @@
     https://**put_your_bitrix24_address**/rest/crm.company.userfield.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.company.userfield.update',
-            {
-                id: 536,
-                fields: {
-                    MANDATORY: 'N',
-                    SHOW_FILTER: 'N',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Привет, мир! Значение по умолчанию (изменено)',
-                        ROWS: 10,
-                    },
-                    SORT: 2000,
-                    EDIT_IN_LIST: 'N',
-                    LIST_FILTER_LABEL: 'Привет, мир! Фильтр (изменено)',
-                    LIST_COLUMN_LABEL: {
-                        en: 'Hello, World! Column (changed)',
-                        ru: 'Привет, мир! Колонка (изменено)',
-                        de: 'Hallo, Welt! Spalte (geändert)',
-                    },
-                    EDIT_FORM_LABEL: {
-                        en: 'Hello, World! Edit (changed)',
-                        ru: 'Привет, мир! Редактировать (изменено)',
-                        de: 'Hallo, Welt! Bearbeiten (geändert)',
-                    },
-                    ERROR_MESSAGE: {
-                        en: 'Hello, World! Error (changed)',
-                        ru: 'Привет, мир! Ошибка (изменено)',
-                        de: 'Hallo, Welt! Fehler (geändert)',
-                    },
-                    HELP_MESSAGE: {
-                        en: 'Hello, World! Help (changed)',
-                        ru: 'Привет, мир! Помощь (изменено)',
-                        de: 'Hallo, Welt! Hilfe (geändert)',
-                    },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.company.userfield.update',
+        params: {
+          id: 536,
+          fields: {
+            MANDATORY: 'N',
+            SHOW_FILTER: 'N',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Hello, World! default value (changed)',
+              ROWS: 10,
+            },
+            SORT: 2000,
+            EDIT_IN_LIST: 'N',
+            LIST_FILTER_LABEL: 'Hello, World! filter (changed)',
+            LIST_COLUMN_LABEL: {
+              en: 'Hello, World! Column (changed)',
+              ru: 'Привет, мир! Колонка (изменено)',
+              de: 'Hallo, Welt! Spalte (geändert)',
+            },
+            EDIT_FORM_LABEL: {
+              en: 'Hello, World! Edit (changed)',
+              ru: 'Привет, мир! Редактировать (изменено)',
+              de: 'Hallo, Welt! Bearbeiten (geändert)',
+            },
+            ERROR_MESSAGE: {
+              en: 'Hello, World! Error (changed)',
+              ru: 'Привет, мир! Ошибка (изменено)',
+              de: 'Hallo, Welt! Fehler (geändert)',
+            },
+            HELP_MESSAGE: {
+              en: 'Hello, World! Help (changed)',
+              ru: 'Привет, мир! Помощь (изменено)',
+              de: 'Hallo, Welt! Hilfe (geändert)',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCompanyUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.company.userfield.update',
+            params: {
+              id: 536,
+              fields: {
+                MANDATORY: 'N',
+                SHOW_FILTER: 'N',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Hello, World! default value (changed)',
+                  ROWS: 10,
                 },
-            }
-        );
+                SORT: 2000,
+                EDIT_IN_LIST: 'N',
+                LIST_FILTER_LABEL: 'Hello, World! filter (changed)',
+                LIST_COLUMN_LABEL: {
+                  en: 'Hello, World! Column (changed)',
+                  ru: 'Привет, мир! Колонка (изменено)',
+                  de: 'Hallo, Welt! Spalte (geändert)',
+                },
+                EDIT_FORM_LABEL: {
+                  en: 'Hello, World! Edit (changed)',
+                  ru: 'Привет, мир! Редактировать (изменено)',
+                  de: 'Hallo, Welt! Bearbeiten (geändert)',
+                },
+                ERROR_MESSAGE: {
+                  en: 'Hello, World! Error (changed)',
+                  ru: 'Привет, мир! Ошибка (изменено)',
+                  de: 'Hallo, Welt! Fehler (geändert)',
+                },
+                HELP_MESSAGE: {
+                  en: 'Hello, World! Help (changed)',
+                  ru: 'Привет, мир! Помощь (изменено)',
+                  de: 'Hallo, Welt! Hilfe (geändert)',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCompanyUserfield)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start` and link the `callList.make` / `fetchList.make`
  helpers; `getTotal()` (removed in SDK 2.0) is replaced by `.length` + helpers.
- Each example is verified: `tsc --strict` against `@bitrix24/b24jssdk@1`, `node --check`
  on the UMD tab, and a method/field cross-check against the page's cURL endpoint and JSON
  response.
- One section per PR to keep review small.

No breaking changes — documentation examples only.