### PR TITLE
docs(crm/currency): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/currency/crm-currency-add.md
+++ b/api-reference/crm/currency/crm-currency-add.md
@@ -141,56 +141,121 @@ fields: {
         https://**put_your_bitrix24_address**/rest/crm.currency.add
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.currency.add",
-            {
-                fields: {
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<string>({
+            method: 'crm.currency.add',
+            params: {
+              fields: {
+                CURRENCY: 'CNY',
+                BASE: 'N',
+                AMOUNT: 12.2251,
+                AMOUNT_CNT: 1,
+                SORT: 9000,
+                LANG: {
+                  ru: {
+                    DECIMALS: 2,
+                    DEC_POINT: '.',
+                    FORMAT_STRING: '# CNY',
+                    FULL_NAME: 'Yuan',
+                    HIDE_ZERO: 'Y',
+                    THOUSANDS_VARIANT: 'S',
+                  },
+                  en: {
+                    DECIMALS: 2,
+                    DEC_POINT: ',',
+                    FORMAT_STRING: '# CNY',
+                    FULL_NAME: 'Yuan',
+                    HIDE_ZERO: 'Y',
+                    THOUSANDS_SEP: '.',
+                  },
+                },
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Created currency id:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function addCurrency() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.currency.add',
+                params: {
+                  fields: {
                     CURRENCY: 'CNY',
                     BASE: 'N',
                     AMOUNT: 12.2251,
                     AMOUNT_CNT: 1,
                     SORT: 9000,
                     LANG: {
-                        ru: {
-                            DECIMALS: 2,
-                            DEC_POINT: '.',
-                            FORMAT_STRING: '# CNY',
-                            FULL_NAME: 'юань',
-                            HIDE_ZERO: 'Y',
-                            THOUSANDS_VARIANT: 'S',
-                        },
-                        en: {
-                            DECIMALS: 2,
-                            DEC_POINT: ',',
-                            FORMAT_STRING: '# CNY',
-                            FULL_NAME: 'yuan',
-                            HIDE_ZERO: 'Y',
-                            THOUSANDS_SEP: '.',
-                        },
+                      ru: {
+                        DECIMALS: 2,
+                        DEC_POINT: '.',
+                        FORMAT_STRING: '# CNY',
+                        FULL_NAME: 'Yuan',
+                        HIDE_ZERO: 'Y',
+                        THOUSANDS_VARIANT: 'S',
+                      },
+                      en: {
+                        DECIMALS: 2,
+                        DEC_POINT: ',',
+                        FORMAT_STRING: '# CNY',
+                        FULL_NAME: 'Yuan',
+                        HIDE_ZERO: 'Y',
+                        THOUSANDS_SEP: '.',
+                      },
                     },
-                }
-            },
-        )
-        .then(
-            function(result)
-            {
-                if (result.error())
-                {
-                    console.error(result.error());
-                }
-                else
-                {
-                    console.log(result);
-                }
-            },
-            function(error)
-            {
-                console.info(error);
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Created currency id:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        ); 
+          }
+
+          document.addEventListener('DOMContentLoaded', addCurrency)
+        </script>
         ```
 
     - PHP
@@ -250,7 +315,7 @@ fields: {
         curl -X POST \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
-        -d '{"fields":{"CURRENCY":"IDR","AMOUNT":54.8738,"AMOUNT_CNT":10000,"SORT":8000,"LANG":{"ru":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"Rp#","FULL_NAME":"рупия","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"},"en":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"# CNY","FULL_NAME":"rupee","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"}}}}' \
+        -d '{"fields":{"CURRENCY":"IDR","AMOUNT":54.8738,"AMOUNT_CNT":10000,"SORT":8000,"LANG":{"ru":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"Rp#","FULL_NAME":"рупия","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"},"en":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"Rp#","FULL_NAME":"rupee","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"}}}}' \
         https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/crm.currency.add
         ```
 
@@ -260,59 +325,123 @@ fields: {
         curl -X POST \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
-        -d '{"fields":{"CURRENCY":"IDR","AMOUNT":54.8738,"AMOUNT_CNT":10000,"SORT":8000,"LANG":{"ru":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"Rp#","FULL_NAME":"рупия","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"},"en":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"# CNY","FULL_NAME":"rupee","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"}}},"auth":"**put_access_token_here**"}' \
+        -d '{"fields":{"CURRENCY":"IDR","AMOUNT":54.8738,"AMOUNT_CNT":10000,"SORT":8000,"LANG":{"ru":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"Rp#","FULL_NAME":"рупия","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"},"en":{"DECIMALS":2,"DEC_POINT":".","FORMAT_STRING":"Rp#","FULL_NAME":"rupee","HIDE_ZERO":"Y","THOUSANDS_VARIANT":"C"}}},"auth":"**put_access_token_here**"}' \
         https://**put_your_bitrix24_address**/rest/crm.currency.add
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.currency.add",
-            {
-                fields: {
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<string>({
+            method: 'crm.currency.add',
+            params: {
+              fields: {
+                CURRENCY: 'IDR',
+                AMOUNT: 54.8738,
+                AMOUNT_CNT: 10000,
+                SORT: 8000,
+                LANG: {
+                  ru: {
+                    DECIMALS: 2,
+                    DEC_POINT: '.',
+                    FORMAT_STRING: 'Rp#',
+                    FULL_NAME: 'Rupee',
+                    HIDE_ZERO: 'Y',
+                    THOUSANDS_VARIANT: 'C',
+                  },
+                  en: {
+                    DECIMALS: 2,
+                    DEC_POINT: '.',
+                    FORMAT_STRING: 'Rp#',
+                    FULL_NAME: 'Rupee',
+                    HIDE_ZERO: 'Y',
+                    THOUSANDS_VARIANT: 'C',
+                  },
+                },
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Created currency id:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function addCurrency() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.currency.add',
+                params: {
+                  fields: {
                     CURRENCY: 'IDR',
                     AMOUNT: 54.8738,
                     AMOUNT_CNT: 10000,
                     SORT: 8000,
                     LANG: {
-                        ru: {
-                            DECIMALS: 2,
-                            DEC_POINT: '.',
-                            FORMAT_STRING: 'Rp#',
-                            FULL_NAME: 'рупия',
-                            HIDE_ZERO: 'Y',
-                            THOUSANDS_VARIANT: 'C'
-                        },
-                        en: {
-                            DECIMALS: 2,
-                            DEC_POINT: '.',
-                            FORMAT_STRING: '# CNY',
-                            FULL_NAME: 'rupee',
-                            HIDE_ZERO: 'Y',
-                            THOUSANDS_VARIANT: 'C'
-                        }
-                    }
-                }
-            },
-        )
-        .then(
-            function(result)
-            {
-                if (result.error())
-                {
-                    console.error(result.error());
-                }
-                else
-                {
-                    console.log(result);
-                }
-            },
-            function(error)
-            {
-                console.info(error);
+                      ru: {
+                        DECIMALS: 2,
+                        DEC_POINT: '.',
+                        FORMAT_STRING: 'Rp#',
+                        FULL_NAME: 'Rupee',
+                        HIDE_ZERO: 'Y',
+                        THOUSANDS_VARIANT: 'C',
+                      },
+                      en: {
+                        DECIMALS: 2,
+                        DEC_POINT: '.',
+                        FORMAT_STRING: 'Rp#',
+                        FULL_NAME: 'Rupee',
+                        HIDE_ZERO: 'Y',
+                        THOUSANDS_VARIANT: 'C',
+                      },
+                    },
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Created currency id:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', addCurrency)
+        </script>
         ```
 
     - PHP
@@ -340,7 +469,7 @@ fields: {
                         'en' => [
                             'DECIMALS' => 2,
                             'DEC_POINT' => '.',
-                            'FORMAT_STRING' => '# CNY',
+                            'FORMAT_STRING' => 'Rp#',
                             'FULL_NAME' => 'rupee',
                             'HIDE_ZERO' => 'Y',
                             'THOUSANDS_VARIANT' => 'C',

--- a/api-reference/crm/currency/crm-currency-base-get.md
+++ b/api-reference/crm/currency/crm-currency-base-get.md
@@ -43,24 +43,69 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.base.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.currency.base.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'crm.currency.base.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Base currency:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBaseCurrency() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.base.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Base currency:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBaseCurrency)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/crm-currency-base-set.md
+++ b/api-reference/crm/currency/crm-currency-base-set.md
@@ -61,26 +61,73 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.base.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.currency.base.set",
-    		{
-    			id: 'RUB'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.currency.base.set',
+        params: {
+          id: 'RUB',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Base currency set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setBaseCurrency() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.base.set',
+            params: {
+              id: 'RUB',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Base currency set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setBaseCurrency)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/crm-currency-delete.md
+++ b/api-reference/crm/currency/crm-currency-delete.md
@@ -57,26 +57,73 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.currency.delete",
-    		{
-    			id: 'IDR'
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.currency.delete',
+        params: {
+          id: 'IDR',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Currency deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCurrency() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.delete',
+            params: {
+              id: 'IDR',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Currency deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCurrency)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/crm-currency-fields.md
+++ b/api-reference/crm/currency/crm-currency-fields.md
@@ -43,24 +43,82 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.fields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.currency.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCurrencyFields = Record<string, CrmCurrencyFieldDescription>
+
+    type CrmCurrencyFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCurrencyFields>({
+        method: 'crm.currency.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Currency fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCurrencyFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Currency fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCurrencyFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/crm-currency-get.md
+++ b/api-reference/crm/currency/crm-currency-get.md
@@ -63,26 +63,100 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.currency.get",
-    		{
-    			id: "RUB"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCurrencyResult = {
+      CURRENCY: string
+      AMOUNT_CNT: string
+      AMOUNT: string
+      SORT: string
+      BASE: string
+      FULL_NAME: string
+      LID: string
+      FORMAT_STRING: string
+      DEC_POINT: string
+      THOUSANDS_SEP: string | null
+      DECIMALS: string
+      DATE_UPDATE: ISODate | null
+      LANG: Record<string, CrmCurrencyLang>
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    type CrmCurrencyLang = {
+      FORMAT_STRING: string
+      FULL_NAME: string
+      DEC_POINT: string
+      THOUSANDS_SEP: string | null
+      DECIMALS: string
+      THOUSANDS_VARIANT: string
+      HIDE_ZERO: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCurrencyResult>({
+        method: 'crm.currency.get',
+        params: {
+          id: 'RUB',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Currency:', result.CURRENCY, result.FULL_NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCurrency() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.get',
+            params: {
+              id: 'RUB',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Currency:', result.CURRENCY, result.FULL_NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCurrency)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/crm-currency-list.md
+++ b/api-reference/crm/currency/crm-currency-list.md
@@ -63,64 +63,107 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each currency object returned in result[]
+    type CrmCurrencyListItem = {
+      CURRENCY: string
+      AMOUNT_CNT: string
+      AMOUNT: string
+      SORT: string
+      BASE: string
+      FULL_NAME: string
+      LID: string
+      FORMAT_STRING: string
+      DEC_POINT: string
+      THOUSANDS_SEP: string | null
+      DECIMALS: string
+      DATE_UPDATE: ISODate | null
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.currency.list',
-        {
+      // crm.currency.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmCurrencyListItem[]>({
+        method: 'crm.currency.list',
+        params: {
           order: {
             sort: 'asc',
             currency: 'asc',
           },
-        }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) {
-        console.log('Entity:', entity);
-      }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.currency.list', {
-        order: {
-          sort: 'asc',
-          currency: 'asc',
+          start: 0,
         },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) {
-          console.log('Entity:', entity);
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Currencies on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listCurrencies() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.currency.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.list',
+            params: {
+              order: {
+                sort: 'asc',
+                currency: 'asc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Currencies on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
       }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.currency.list', {
-        order: {
-          sort: 'asc',
-          currency: 'asc',
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) {
-        console.log('Entity:', entity);
-      }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+
+      document.addEventListener('DOMContentLoaded', listCurrencies)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/crm-currency-update.md
+++ b/api-reference/crm/currency/crm-currency-update.md
@@ -145,35 +145,79 @@ fields: {
         https://**put_your_bitrix24_address**/rest/crm.currency.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.currency.update",
-            {
-                ID: 'CNY',
-                fields: {
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.currency.update',
+            params: {
+              ID: 'CNY',
+              fields: {
+                AMOUNT: 15.3449,
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Currency updated:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateCurrency() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.currency.update',
+                params: {
+                  ID: 'CNY',
+                  fields: {
                     AMOUNT: 15.3449,
-                }
-            },
-        )
-        .then(
-            function(result)
-            {
-                if (result.error())
-                {
-                    console.error(result.error());
-                }
-                else
-                {
-                    console.log(result);
-                }
-            },
-            function(error)
-            {
-                console.info(error);
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Currency updated:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', updateCurrency)
+        </script>
         ```
 
     - PHP
@@ -228,52 +272,113 @@ fields: {
         https://**put_your_bitrix24_address**/rest/crm.currency.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.currency.update",
-            {
-                ID: 'USD',
-                fields: {
-                    LANG: {
-                        en: {
-                            DECIMALS: 2,
-                            DEC_POINT: '.',
-                            FORMAT_STRING: '$#',
-                            FULL_NAME: 'доллар США',
-                            HIDE_ZERO: 'Y',
-                            THOUSANDS_VARIANT: 'S'
-                        },
-                        de: {
-                            DECIMALS: 2,
-                            DEC_POINT: '.',
-                            FORMAT_STRING: '# $',
-                            FULL_NAME: 'US-Dollar',
-                            HIDE_ZERO: 'Y',
-                            THOUSANDS_VARIANT: 'C'
-                        }
-                    }
-                }
-            }
-        )
-        .then(
-            function(result)
-            {
-                if (result.error())
-                {
-                    console.error(result.error());
-                }
-                else
-                {
-                    console.log(result);
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        try {
+          const response = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.currency.update',
+            params: {
+              ID: 'USD',
+              fields: {
+                LANG: {
+                  en: {
+                    DECIMALS: 2,
+                    DEC_POINT: '.',
+                    FORMAT_STRING: '$#',
+                    FULL_NAME: 'US Dollar',
+                    HIDE_ZERO: 'Y',
+                    THOUSANDS_VARIANT: 'S',
+                  },
+                  de: {
+                    DECIMALS: 2,
+                    DEC_POINT: '.',
+                    FORMAT_STRING: '# $',
+                    FULL_NAME: 'US-Dollar',
+                    HIDE_ZERO: 'Y',
+                    THOUSANDS_VARIANT: 'C',
+                  },
+                },
+              },
             },
-            function(error)
-            {
-                console.info(error);
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Currency updated:', result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateCurrency() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.currency.update',
+                params: {
+                  ID: 'USD',
+                  fields: {
+                    LANG: {
+                      en: {
+                        DECIMALS: 2,
+                        DEC_POINT: '.',
+                        FORMAT_STRING: '$#',
+                        FULL_NAME: 'US Dollar',
+                        HIDE_ZERO: 'Y',
+                        THOUSANDS_VARIANT: 'S',
+                      },
+                      de: {
+                        DECIMALS: 2,
+                        DEC_POINT: '.',
+                        FORMAT_STRING: '# $',
+                        FULL_NAME: 'US-Dollar',
+                        HIDE_ZERO: 'Y',
+                        THOUSANDS_VARIANT: 'C',
+                      },
+                    },
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Currency updated:', result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', updateCurrency)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/currency/localizations/crm-currency-localizations-delete.md
+++ b/api-reference/crm/currency/localizations/crm-currency-localizations-delete.md
@@ -45,8 +45,8 @@
     curl -X POST \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"id":5}' \
-    https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/crm.automatedsolution.delete
+    -d '{"id":"CLF","lids":["en","de"]}' \
+    https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/crm.currency.localizations.delete
     ```
 
 - cURL (OAuth)
@@ -55,34 +55,79 @@
     curl -X POST \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"id":5,"auth":"**put_access_token_here**"}' \
-    https://**put_your_bitrix24_address**/rest/crm.automatedsolution.delete
+    -d '{"id":"CLF","lids":["en","de"],"auth":"**put_access_token_here**"}' \
+    https://**put_your_bitrix24_address**/rest/crm.currency.localizations.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.currency.localizations.delete",
-    		{
-    			id: 'CLF',
-    			lids: [
-    				'en',
-    				'de'
-    			]
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.currency.localizations.delete',
+        params: {
+          id: 'CLF',
+          lids: ['en', 'de'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Localizations deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCurrencyLocalizations() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.localizations.delete',
+            params: {
+              id: 'CLF',
+              lids: ['en', 'de'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Localizations deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCurrencyLocalizations)
+    </script>
     ```
 
 - PHP
@@ -153,9 +198,13 @@
     require_once('crest.php');
 
     $result = CRest::call(
-        'crm.automatedsolution.delete',
+        'crm.currency.localizations.delete',
         [
-            'id' => 5
+            'id'   => 'CLF',
+            'lids' => [
+                'en',
+                'de'
+            ]
         ]
     );
 

--- a/api-reference/crm/currency/localizations/crm-currency-localizations-fields.md
+++ b/api-reference/crm/currency/localizations/crm-currency-localizations-fields.md
@@ -43,24 +43,82 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.localizations.fields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.currency.localizations.fields",
-    		{}
-    	);
-    
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCurrencyLocalizationFields = Record<string, CrmCurrencyFieldDescription>
+
+    type CrmCurrencyFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCurrencyLocalizationFields>({
+        method: 'crm.currency.localizations.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Localization fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCurrencyLocalizationFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.localizations.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Localization fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCurrencyLocalizationFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/localizations/crm-currency-localizations-get.md
+++ b/api-reference/crm/currency/localizations/crm-currency-localizations-get.md
@@ -55,26 +55,86 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.localizations.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.currency.localizations.get',
-    		{
-    			id: 'RUB'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmCurrencyLocalizations = Record<string, CrmCurrencyLocalization>
+
+    type CrmCurrencyLocalization = {
+      FORMAT_STRING: string
+      FULL_NAME: string
+      DEC_POINT: string
+      THOUSANDS_SEP: string | null
+      DECIMALS: string
+      THOUSANDS_VARIANT: string
+      HIDE_ZERO: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmCurrencyLocalizations>({
+        method: 'crm.currency.localizations.get',
+        params: {
+          id: 'RUB',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Localization languages:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCurrencyLocalizations() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.localizations.get',
+            params: {
+              id: 'RUB',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Localization languages:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCurrencyLocalizations)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/currency/localizations/crm-currency-localizations-set.md
+++ b/api-reference/crm/currency/localizations/crm-currency-localizations-set.md
@@ -63,42 +63,105 @@
     https://**put_your_bitrix24_address**/rest/crm.currency.localizations.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.currency.localizations.set",
-    		{
-    			id: 'CLF',
-    			localizations: {
-    				en: {
-    					FULL_NAME: 'Unidad de Fomento',
-    					FORMAT_STRING: 'CLF#VALUE#',
-    					DEC_POINT: '.',
-    					THOUSANDS_VARIANT: 'C',
-    					DECIMALS: 4,
-    				},
-    				ru: {
-    					FULL_NAME: 'Единица развития',
-    					FORMAT_STRING: '#VALUE# CLF',
-    					DEC_POINT: '.',
-    					THOUSANDS_VARIANT: 'B',
-    					DECIMALS: 4,
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.currency.localizations.set',
+        params: {
+          id: 'CLF',
+          localizations: {
+            en: {
+              FULL_NAME: 'Unidad de Fomento',
+              FORMAT_STRING: 'CLF#VALUE#',
+              DEC_POINT: '.',
+              THOUSANDS_VARIANT: 'C',
+              DECIMALS: 4,
+            },
+            ru: {
+              FULL_NAME: 'Unit of Account',
+              FORMAT_STRING: '#VALUE# CLF',
+              DEC_POINT: '.',
+              THOUSANDS_VARIANT: 'B',
+              DECIMALS: 4,
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Localizations set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setCurrencyLocalizations() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.currency.localizations.set',
+            params: {
+              id: 'CLF',
+              localizations: {
+                en: {
+                  FULL_NAME: 'Unidad de Fomento',
+                  FORMAT_STRING: 'CLF#VALUE#',
+                  DEC_POINT: '.',
+                  THOUSANDS_VARIANT: 'C',
+                  DECIMALS: 4,
+                },
+                ru: {
+                  FULL_NAME: 'Unit of Account',
+                  FORMAT_STRING: '#VALUE# CLF',
+                  DEC_POINT: '.',
+                  THOUSANDS_VARIANT: 'B',
+                  DECIMALS: 4,
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Localizations set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setCurrencyLocalizations)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start` and link the `callList.make` / `fetchList.make`
  helpers; `getTotal()` (removed in SDK 2.0) is replaced by `.length` + helpers.
- Each example is verified: `tsc --strict` against `@bitrix24/b24jssdk@1`, `node --check`
  on the UMD tab, and a method/field cross-check against the page's cURL endpoint and JSON
  response.
- One section per PR to keep review small.

No breaking changes — documentation examples only.
