### PR TITLE
docs(calendar): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/calendar/calendar-event/calendar-accessibility-get.md
+++ b/api-reference/calendar/calendar-event/calendar-accessibility-get.md
@@ -60,29 +60,101 @@
     https://**put_your_bitrix24_address**/rest/calendar.accessibility.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.accessibility.get',
-    		{
-    			from: '2024-06-20',
-    			to: '2024-12-20',
-    			users: [1, 2, 34]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	// Нужная вам логика обработки данных
-    	processResult(result);
+    declare const $b24: B24Frame
+
+    type CalendarEventItem = {
+      ID: string
+      NAME: string
+      DATE_FROM: string
+      DATE_TO: string
+      DATE_FROM_TS_UTC: string
+      DATE_TO_TS_UTC: string
+      '~USER_OFFSET_FROM': number
+      '~USER_OFFSET_TO': number
+      DT_SKIP_TIME: 'Y' | 'N'
+      TZ_FROM: string
+      TZ_TO: string
+      ACCESSIBILITY: 'busy' | 'absent' | 'quest' | 'free'
+      IMPORTANCE: 'high' | 'normal' | 'low'
+      EVENT_TYPE: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AccessibilityGetResult = Record<string, CalendarEventItem[]>
+
+    try {
+      const response = await $b24.actions.v2.call.make<AccessibilityGetResult>({
+        method: 'calendar.accessibility.get',
+        params: {
+          from: '2024-06-20',
+          to: '2024-12-20',
+          users: [1, 2, 34],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        for (const [userId, events] of Object.entries(result)) {
+          console.info(`User ${userId}:`, events.map(e => `${e.NAME} (${e.ACCESSIBILITY})`))
+        }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAccessibility() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.accessibility.get',
+            params: {
+              from: '2024-06-20',
+              to: '2024-12-20',
+              users: [1, 2, 34],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          for (const [userId, events] of Object.entries(result)) {
+            console.info(`User ${userId}:`, events.map(e => `${e.NAME} (${e.ACCESSIBILITY})`))
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAccessibility)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-event/calendar-event-add.md
+++ b/api-reference/calendar/calendar-event/calendar-event-add.md
@@ -251,63 +251,140 @@ Cимвол `#` в цвете необходимо передавать в фо�
     https://**put_your_bitrix24_address**/rest/calendar.event.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.event.add',
-    		{
-    			type: 'user',
-    			ownerId: 2,
-    			name: 'New Event Name',
-    			description: 'Description for event',
-    			from: '2024-06-14',
-    			to: '2024-06-14',
-    			skip_time: 'Y',
-    			section: 5,
-    			color: '#9cbe1c',
-    			text_color: '#283033',
-    			accessibility: 'absent',
-    			importance: 'normal',
-    			is_meeting: 'Y',
-    			private_event: 'N',
-    			remind: [
-    				{
-    					type: 'min',
-    					count: 20
-    				}
-    			],
-    			location: 'London',
-    			attendees: [1, 2, 3],
-    			host: 2,
-    			meeting: {
-    				notify: true,
-    				reinvite: false,
-    				allow_invite: false,
-    				hide_guests: false,
-    			},
-    			rrule: {
-    				FREQ: 'WEEKLY',
-    				BYDAY: ['MO', 'WE'],
-    				COUNT: 10,
-    				INTERVAL: 1,
-    			},
-    			crm_fields: ['C_5', 'L_11']
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Created event with ID:', result);
-    	// Нужная вам логика обработки данных
-    	processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarEventAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarEventAddResult>({
+        method: 'calendar.event.add',
+        params: {
+          type: 'user',
+          ownerId: 2,
+          name: 'New Event Name',
+          description: 'Description for event',
+          from: '2024-06-14',
+          to: '2024-06-14',
+          skip_time: 'Y',
+          section: 5,
+          color: '#9cbe1c',
+          text_color: '#283033',
+          accessibility: 'absent',
+          importance: 'normal',
+          is_meeting: 'Y',
+          private_event: 'N',
+          remind: [
+            { type: 'min', count: 20 },
+          ],
+          location: 'London',
+          attendees: [1, 2, 3],
+          host: 2,
+          meeting: {
+            notify: true,
+            reinvite: false,
+            allow_invite: false,
+            hide_guests: false,
+          },
+          rrule: {
+            FREQ: 'WEEKLY',
+            BYDAY: ['MO', 'WE'],
+            COUNT: 10,
+            INTERVAL: 1,
+          },
+          crm_fields: ['C_5', 'L_11'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created event ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.event.add',
+            params: {
+              type: 'user',
+              ownerId: 2,
+              name: 'New Event Name',
+              description: 'Description for event',
+              from: '2024-06-14',
+              to: '2024-06-14',
+              skip_time: 'Y',
+              section: 5,
+              color: '#9cbe1c',
+              text_color: '#283033',
+              accessibility: 'absent',
+              importance: 'normal',
+              is_meeting: 'Y',
+              private_event: 'N',
+              remind: [
+                { type: 'min', count: 20 },
+              ],
+              location: 'London',
+              attendees: [1, 2, 3],
+              host: 2,
+              meeting: {
+                notify: true,
+                reinvite: false,
+                allow_invite: false,
+                hide_guests: false,
+              },
+              rrule: {
+                FREQ: 'WEEKLY',
+                BYDAY: ['MO', 'WE'],
+                COUNT: 10,
+                INTERVAL: 1,
+              },
+              crm_fields: ['C_5', 'L_11'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created event ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCalendarEvent)
+    </script>
     ```
 
 - PHP
@@ -498,59 +575,142 @@ Cимвол `#` в цвете необходимо передавать в фо�
     https://**put_your_bitrix24_address**/rest/calendar.event.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.event.add',
-    		{
-    			type: 'company_calendar',
-    			ownerId: '',
-    			from: '2025-01-31T18:00:00',
-    			to: '2025-01-31T20:00:00',
-    			section: 1,
-    			name: 'Важная встреча',
-    			skip_time: 'N',
-    			timezone_from: 'Europe/Moscow',
-    			timezone_to: 'Europe/Moscow',
-    			description: 'Описание события',
-    			color: '%23FF0000',
-    			text_color: '%23000000',
-    			accessibility: 'busy',
-    			importance: 'high',
-    			private_event: 'N',
-    			rrule: {
-    				FREQ: 'WEEKLY',
-    				COUNT: 10,
-    				INTERVAL: 1,
-    				BYDAY: ['MO', 'WE', 'FR']
-    			},
-    			is_meeting: 'Y',
-    			location: 'Конференц-зал',
-    			remind: [
-    				{ type: 'min', count: 30 }
-    			],
-    			attendees: [29, 93],
-    			host: 1,
-    			meeting: {
-    				notify: true,
-    				reinvite: false,
-    				allow_invite: true,
-    				hide_guests: false
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Event added successfully', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarEventAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarEventAddResult>({
+        method: 'calendar.event.add',
+        params: {
+          type: 'company_calendar',
+          ownerId: '',
+          from: '2025-01-31T18:00:00',
+          to: '2025-01-31T20:00:00',
+          section: 1,
+          name: 'Important Meeting',
+          skip_time: 'N',
+          timezone_from: 'Europe/Moscow',
+          timezone_to: 'Europe/Moscow',
+          description: 'Event description',
+          color: '%23FF0000',
+          text_color: '%23000000',
+          accessibility: 'busy',
+          importance: 'high',
+          private_event: 'N',
+          rrule: {
+            FREQ: 'WEEKLY',
+            COUNT: 10,
+            INTERVAL: 1,
+            BYDAY: ['MO', 'WE', 'FR'],
+          },
+          is_meeting: 'Y',
+          location: 'Conference room',
+          remind: [
+            { type: 'min', count: 30 },
+          ],
+          attendees: [29, 93],
+          host: 1,
+          meeting: {
+            notify: true,
+            reinvite: false,
+            allow_invite: true,
+            hide_guests: false,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created event ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.event.add',
+            params: {
+              type: 'company_calendar',
+              ownerId: '',
+              from: '2025-01-31T18:00:00',
+              to: '2025-01-31T20:00:00',
+              section: 1,
+              name: 'Important Meeting',
+              skip_time: 'N',
+              timezone_from: 'Europe/Moscow',
+              timezone_to: 'Europe/Moscow',
+              description: 'Event description',
+              color: '%23FF0000',
+              text_color: '%23000000',
+              accessibility: 'busy',
+              importance: 'high',
+              private_event: 'N',
+              rrule: {
+                FREQ: 'WEEKLY',
+                COUNT: 10,
+                INTERVAL: 1,
+                BYDAY: ['MO', 'WE', 'FR'],
+              },
+              is_meeting: 'Y',
+              location: 'Conference room',
+              remind: [
+                { type: 'min', count: 30 },
+              ],
+              attendees: [29, 93],
+              host: 1,
+              meeting: {
+                notify: true,
+                reinvite: false,
+                allow_invite: true,
+                hide_guests: false,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created event ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCalendarEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-event/calendar-event-delete.md
+++ b/api-reference/calendar/calendar-event/calendar-event-delete.md
@@ -54,25 +54,76 @@
     https://**put_your_bitrix24_address**/rest/calendar.event.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.event.delete',
-    		{
-    			id: 698
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarEventDeleteResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarEventDeleteResult>({
+        method: 'calendar.event.delete',
+        params: {
+          id: 698,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.event.delete',
+            params: {
+              id: 698,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCalendarEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-event/calendar-event-get-by-id.md
+++ b/api-reference/calendar/calendar-event/calendar-event-get-by-id.md
@@ -54,26 +54,97 @@
     https://**put_your_bitrix24_address**/rest/calendar.event.getbyid
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.event.getbyid',
-    		{
-    			id: 324
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarEventResult = {
+      ID: string
+      PARENT_ID: string
+      DELETED: string
+      CAL_TYPE: string
+      OWNER_ID: string
+      NAME: string
+      DATE_FROM: string
+      DATE_TO: string
+      DESCRIPTION: string
+      EVENT_TYPE: string
+      TZ_FROM: string
+      TZ_TO: string
+      SECTION_ID: string
+      CREATED_BY: string
+      ACCESSIBILITY: string
+      IMPORTANCE: string
+      IS_MEETING: boolean
+      MEETING_STATUS: string
+      COLOR: string
+      LOCATION: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarEventResult>({
+        method: 'calendar.event.getbyid',
+        params: {
+          id: 324,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event:', result.ID, result.NAME, result.DATE_FROM, result.DATE_TO)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCalendarEventById() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.event.getbyid',
+            params: {
+              id: 324,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event:', result.ID, result.NAME, result.DATE_FROM, result.DATE_TO)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCalendarEventById)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-event/calendar-event-update.md
+++ b/api-reference/calendar/calendar-event/calendar-event-update.md
@@ -247,66 +247,160 @@ Cимвол `#` в цвете необходимо передавать в фо�
     https://**put_your_bitrix24_address**/rest/calendar.event.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.event.update',
-    		{
-    			id: 699,
-    			type: 'user',
-    			ownerId: 2,
-    			name: 'Changed Event Name',
-    			description: 'New description for event',
-    			from: '2024-06-17',
-    			to: '2024-06-17',
-    			skip_time: 'Y',
-    			section: 5,
-    			color: '#9cbe1c',
-    			text_color: '#283033',
-    			accessibility: 'free',
-    			importance: 'normal',
-    			is_meeting: 'Y',
-    			private_event: 'Y',
-    			recurrence_mode: 'next',
-    			current_date_from: '2024-12-04',
-    			remind: [
-    				{
-    					type: 'min',
-    					count: 10
-    				}
-    			],
-    			location: 'London',
-    			attendees: [1, 2, 3],
-    			host: 2,
-    			meeting: {
-    				notify: true,
-    				reinvite: false,
-    				allow_invite: false,
-    				hide_guests: false,
-    			},
-    			rrule: {
-    				FREQ: 'WEEKLY',
-    				BYDAY: ['MO', 'WE'],
-    				COUNT: 10,
-    				INTERVAL: 1,
-    			},
-    			crm_fields: ['C_5', 'L_11']
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Updated event with ID:', result);
-    	// Нужная вам логика обработки данных
-    	processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarEventUpdateResult =
+      | number
+      | {
+          originalDate: string
+          originalDavXmlId: string
+          instanceTz: string
+          recEventId: number
+          id: number
+        }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarEventUpdateResult>({
+        method: 'calendar.event.update',
+        params: {
+          id: 699,
+          type: 'user',
+          ownerId: 2,
+          name: 'Changed Event Name',
+          description: 'New description for event',
+          from: '2024-06-17',
+          to: '2024-06-17',
+          skip_time: 'Y',
+          section: 5,
+          color: '#9cbe1c',
+          text_color: '#283033',
+          accessibility: 'free',
+          importance: 'normal',
+          is_meeting: 'Y',
+          private_event: 'Y',
+          recurrence_mode: 'next',
+          current_date_from: '2024-12-04',
+          remind: [
+            {
+              type: 'min',
+              count: 10,
+            },
+          ],
+          location: 'London',
+          attendees: [1, 2, 3],
+          host: 2,
+          meeting: {
+            notify: true,
+            reinvite: false,
+            allow_invite: false,
+            hide_guests: false,
+          },
+          rrule: {
+            FREQ: 'WEEKLY',
+            BYDAY: ['MO', 'WE'],
+            COUNT: 10,
+            INTERVAL: 1,
+          },
+          crm_fields: ['C_5', 'L_11'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated calendar event:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.event.update',
+            params: {
+              id: 699,
+              type: 'user',
+              ownerId: 2,
+              name: 'Changed Event Name',
+              description: 'New description for event',
+              from: '2024-06-17',
+              to: '2024-06-17',
+              skip_time: 'Y',
+              section: 5,
+              color: '#9cbe1c',
+              text_color: '#283033',
+              accessibility: 'free',
+              importance: 'normal',
+              is_meeting: 'Y',
+              private_event: 'Y',
+              recurrence_mode: 'next',
+              current_date_from: '2024-12-04',
+              remind: [
+                {
+                  type: 'min',
+                  count: 10,
+                },
+              ],
+              location: 'London',
+              attendees: [1, 2, 3],
+              host: 2,
+              meeting: {
+                notify: true,
+                reinvite: false,
+                allow_invite: false,
+                hide_guests: false,
+              },
+              rrule: {
+                FREQ: 'WEEKLY',
+                BYDAY: ['MO', 'WE'],
+                COUNT: 10,
+                INTERVAL: 1,
+              },
+              crm_fields: ['C_5', 'L_11'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated calendar event:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCalendarEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-event/calendar-meeting-status-get.md
+++ b/api-reference/calendar/calendar-event/calendar-meeting-status-get.md
@@ -54,26 +54,76 @@
     https://**put_your_bitrix24_address**/rest/calendar.meeting.status.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.meeting.status.get',
-    		{
-    			eventId: 651
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeetingStatusResult = string
+
+    try {
+      const response = await $b24.actions.v2.call.make<MeetingStatusResult>({
+        method: 'calendar.meeting.status.get',
+        params: {
+          eventId: 651,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Meeting status:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMeetingStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.meeting.status.get',
+            params: {
+              eventId: 651,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Meeting status:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMeetingStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-event/calendar-meeting-status-set.md
+++ b/api-reference/calendar/calendar-event/calendar-meeting-status-set.md
@@ -59,26 +59,78 @@
     https://**put_your_bitrix24_address**/rest/calendar.meeting.status.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.meeting.status.set',
-    		{
-    			eventId: 651,
-    			status: 'Y'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeetingStatusSetResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<MeetingStatusSetResult>({
+        method: 'calendar.meeting.status.set',
+        params: {
+          eventId: 651,
+          status: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Meeting status set successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setMeetingStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.meeting.status.set',
+            params: {
+              eventId: 651,
+              status: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Meeting status set successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setMeetingStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-grid-veiw.md
+++ b/api-reference/calendar/calendar-grid-veiw.md
@@ -19,28 +19,80 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'placement.bind',
-    		{
-    			PLACEMENT: 'CALENDAR_GRIDVIEW',
-    			HANDLER: 'http://your_site/handler.php',
-    			TITLE: 'Custom tab'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PlacementBindResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<PlacementBindResult>({
+        method: 'placement.bind',
+        params: {
+          PLACEMENT: 'CALENDAR_GRIDVIEW',
+          HANDLER: 'http://your_site/handler.php',
+          TITLE: 'Custom tab',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('placement.bind result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindCalendarPlacement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.bind',
+            params: {
+              PLACEMENT: 'CALENDAR_GRIDVIEW',
+              HANDLER: 'http://your_site/handler.php',
+              TITLE: 'Custom tab',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('placement.bind result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindCalendarPlacement)
+    </script>
     ```
 
 - PHP
@@ -126,33 +178,90 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const dateFrom = new Date();
-    	const dateTo = new Date(dateFrom.getTime() + 86400 * 30 * 1000); // Умножаем на 1000, чтобы преобразовать секунды в миллисекунды
-    	dateFrom.setHours(0, 0, 0, 0);
-    	dateTo.setHours(0, 0, 0, 0);
-    
-    	const response = await $b24.callMethod(
-    		'placement.getEvents',
-    		{
-    			dateFrom: dateFrom,
-    			dateTo: dateTo
-    		}
-    	);
-    
-    	const events = response.getData().result;
-    	console.log('getEvents response:');
-    	console.dir(events);
+    declare const $b24: B24Frame
+
+    // Shape of each event returned in result[]
+    type PlacementEvent = {
+      id: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const dateFrom = new Date()
+      const dateTo = new Date(dateFrom.getTime() + 86400 * 30 * 1000) // Multiply by 1000 to convert seconds to milliseconds
+      dateFrom.setHours(0, 0, 0, 0)
+      dateTo.setHours(0, 0, 0, 0)
+
+      const response = await $b24.actions.v2.call.make<PlacementEvent[]>({
+        method: 'placement.getEvents',
+        params: {
+          dateFrom: dateFrom,
+          dateTo: dateTo,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('getEvents response:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCalendarEvents() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const dateFrom = new Date()
+          const dateTo = new Date(dateFrom.getTime() + 86400 * 30 * 1000) // Multiply by 1000 to convert seconds to milliseconds
+          dateFrom.setHours(0, 0, 0, 0)
+          dateTo.setHours(0, 0, 0, 0)
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.getEvents',
+            params: {
+              dateFrom: dateFrom,
+              dateTo: dateTo,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('getEvents response:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCalendarEvents)
+    </script>
     ```
 
 - PHP
@@ -217,26 +326,78 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'placement.call',
-    		{
-    			id: "1431170", // идентификатор события
-    			dateFrom: "11.07.2018" // дата события. Не обязательна, но важна для регулярных событий
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ViewEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<ViewEventResult>({
+        method: 'placement.call',
+        params: {
+          id: '1431170', // event identifier
+          dateFrom: '11.07.2018', // event date; optional but important for recurring events
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('placement.call viewEvent result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function viewCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.call',
+            params: {
+              id: '1431170', // event identifier
+              dateFrom: '11.07.2018', // event date; optional but important for recurring events
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('placement.call viewEvent result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', viewCalendarEvent)
+    </script>
     ```
 
 - PHP
@@ -287,24 +448,72 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'placement.addEvent',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	// Нужная вам логика обработки данных
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddEventResult>({
+        method: 'placement.addEvent',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('placement.addEvent result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.addEvent',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('placement.addEvent result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCalendarEvent)
+    </script>
     ```
 
 - PHP
@@ -345,28 +554,82 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'placement.call',
-    		{
-    			placement: 'editEvent',
-    			params: {
-    				uid: "1431171|19.07.2018"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EditEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<EditEventResult>({
+        method: 'placement.call',
+        params: {
+          placement: 'editEvent',
+          params: {
+            uid: '1431171|19.07.2018',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('placement.call editEvent result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function editCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.call',
+            params: {
+              placement: 'editEvent',
+              params: {
+                uid: '1431171|19.07.2018',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('placement.call editEvent result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', editCalendarEvent)
+    </script>
     ```
 
 - PHP
@@ -415,25 +678,76 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'placement.deleteEvent',
-    		{
-    			id: "1431169"
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteEventResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteEventResult>({
+        method: 'placement.deleteEvent',
+        params: {
+          id: '1431169',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('placement.deleteEvent result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.deleteEvent',
+            params: {
+              id: '1431169',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('placement.deleteEvent result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCalendarEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-section-add.md
+++ b/api-reference/calendar/calendar-section-add.md
@@ -88,37 +88,94 @@
     https://**put_your_bitrix24_address**/rest/calendar.section.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.section.add',
-    		{
-    			type: 'user',
-    			ownerId: 2,
-    			name: 'New Section',
-    			description: 'Description for section',
-    			color: '#9cbeee',
-    			text_color: '#283000',
-    			export: {
-    				ALLOW: false,
-    				SET: '3_9'
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Created element with ID:', result);
-    	// Нужная вам логика обработки данных
-    	processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarSectionAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarSectionAddResult>({
+        method: 'calendar.section.add',
+        params: {
+          type: 'user',
+          ownerId: 2,
+          name: 'New Section',
+          description: 'Description for section',
+          color: '#9cbeee',
+          text_color: '#283000',
+          export: {
+            ALLOW: false,
+            SET: '3_9',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created calendar with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCalendarSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.section.add',
+            params: {
+              type: 'user',
+              ownerId: 2,
+              name: 'New Section',
+              description: 'Description for section',
+              color: '#9cbeee',
+              text_color: '#283000',
+              export: {
+                ALLOW: false,
+                SET: '3_9',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created calendar with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCalendarSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-section-delete.md
+++ b/api-reference/calendar/calendar-section-delete.md
@@ -58,27 +58,80 @@
     https://**put_your_bitrix24_address**/rest/calendar.section.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.section.delete',
-    		{
-    			type: 'user',
-    			ownerId: 2,
-    			id: 521
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarSectionDeleteResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarSectionDeleteResult>({
+        method: 'calendar.section.delete',
+        params: {
+          type: 'user',
+          ownerId: 2,
+          id: 521,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Calendar section deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCalendarSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.section.delete',
+            params: {
+              type: 'user',
+              ownerId: 2,
+              id: 521,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Calendar section deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCalendarSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-section-get.md
+++ b/api-reference/calendar/calendar-section-get.md
@@ -63,27 +63,118 @@
     https://**put_your_bitrix24_address**/rest/calendar.section.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.section.get',
-    		{
-    			type: 'user',
-    			ownerId: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each CalendarSection returned in result[]
+    type CalendarSection = {
+      ID: string
+      NAME: string
+      GAPI_CALENDAR_ID: string | null
+      DESCRIPTION: string
+      COLOR: string
+      TEXT_COLOR: string
+      EXPORT: { ALLOW: boolean }
+      CAL_TYPE: string
+      OWNER_ID: string
+      CREATED_BY: string
+      DATE_CREATE: ISODate | null
+      TIMESTAMP_X: ISODate | null
+      CAL_DAV_CON: string | null
+      SYNC_TOKEN: string | null
+      PAGE_TOKEN: string | null
+      EXTERNAL_TYPE: string
+      ACCESS: Record<string, number>
+      IS_COLLAB: boolean
+      PERM: {
+        view_time: boolean
+        view_title: boolean
+        view_full: boolean
+        add: boolean
+        edit: boolean
+        edit_section: boolean
+        access: boolean
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      // calendar.section.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CalendarSection[]>({
+        method: 'calendar.section.get',
+        params: {
+          type: 'user',
+          ownerId: 1,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sections count:', result.length, 'first section:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCalendarSections() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // calendar.section.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.section.get',
+            params: {
+              type: 'user',
+              ownerId: 1,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sections count:', result.length, 'first section:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCalendarSections)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-section-update.md
+++ b/api-reference/calendar/calendar-section-update.md
@@ -84,39 +84,98 @@
     https://**put_your_bitrix24_address**/rest/calendar.section.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.section.update',
-    		{
-    			id: 325,
-    			type: 'user',
-    			ownerId: 2,
-    			name: 'Changed Section Name',
-    			description: 'New description for section',
-    			color: '#9cbeAA',
-    			text_color: '#283099',
-    			export: [
-    				{
-    					ALLOW: false
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Updated calendar section with ID:', result);
-    	// Нужная вам логика обработки данных
-    	processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarSectionUpdateResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarSectionUpdateResult>({
+        method: 'calendar.section.update',
+        params: {
+          id: 325,
+          type: 'user',
+          ownerId: 2,
+          name: 'Changed Section Name',
+          description: 'New description for section',
+          color: '#9cbeAA',
+          text_color: '#283099',
+          export: [
+            {
+              ALLOW: false,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated calendar section ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCalendarSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.section.update',
+            params: {
+              id: 325,
+              type: 'user',
+              ownerId: 2,
+              name: 'Changed Section Name',
+              description: 'New description for section',
+              color: '#9cbeAA',
+              text_color: '#283099',
+              export: [
+                {
+                  ALLOW: false,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated calendar section ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCalendarSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-settings-get.md
+++ b/api-reference/calendar/calendar-settings-get.md
@@ -43,23 +43,98 @@
     https://**put_your_bitrix24_address**/rest/calendar.settings.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.settings.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarSettingsResult = {
+      work_time_start: string
+      work_time_end: string
+      year_holidays: string
+      year_workdays: string
+      week_holidays: string[]
+      week_start: string
+      user_name_template: string
+      sync_by_push: boolean
+      user_show_login: boolean
+      path_to_user: string
+      path_to_user_calendar: string
+      path_to_group: string
+      path_to_group_calendar: string
+      path_to_vr: string
+      path_to_rm: string
+      rm_iblock_type: string
+      rm_iblock_id: string
+      dep_manager_sub: boolean
+      denied_superpose_types: string[]
+      pathes_for_sites: string
+      forum_id: string
+      rm_for_sites: boolean
+      path_to_type_company_calendar: string
+      path_to_type_location: string
+      path_to_type_open_event: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarSettingsResult>({
+        method: 'calendar.settings.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Calendar settings:', result.work_time_start, result.work_time_end)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCalendarSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.settings.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Calendar settings:', result.work_time_start, result.work_time_end)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCalendarSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-user-settings-get.md
+++ b/api-reference/calendar/calendar-user-settings-get.md
@@ -43,24 +43,97 @@
     https://**put_your_bitrix24_address**/rest/calendar.user.settings.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.user.settings.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Result:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarUserSettingsResult = {
+      view: string
+      meetSection: string
+      crmSection: string
+      showDeclined: boolean
+      denyBusyInvitation: boolean
+      collapseOffHours: string
+      showWeekNumbers: string
+      showTasks: string
+      syncTasks: string
+      showCompletedTasks: string
+      lastUsedSection: string
+      sendFromEmail: string
+      defaultSections: Record<string, string>
+      syncPeriodPast: string
+      syncPeriodFuture: string
+      defaultReminders: {
+        fullDay: Array<{ type: string; count: number }>
+        withTime: Array<{ type: string; count: number }>
+      }
+      timezoneName: string
+      timezoneOffsetUTC: number
+      timezoneDefaultName: string
+      work_time_start: string
+      work_time_end: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarUserSettingsResult>({
+        method: 'calendar.user.settings.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.view, result.timezoneName, result.defaultReminders)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCalendarUserSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.user.settings.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.view, result.timezoneName, result.defaultReminders)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCalendarUserSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/calendar-user-settings-set.md
+++ b/api-reference/calendar/calendar-user-settings-set.md
@@ -137,61 +137,142 @@
     https://**put_your_bitrix24_address**/rest/calendar.user.settings.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.user.settings.set',
-    		{
-    			settings: {
-    				view: 'month',
-    				meetSection: '4',
-    				crmSection: '4',
-    				showDeclined: true,
-    				denyBusyInvitation: false,
-    				collapseOffHours: 'N',
-    				showWeekNumbers: 'N',
-    				showTasks: 'Y',
-    				syncTasks: 'N',
-    				showCompletedTasks: 'N',
-    				lastUsedSection: 'false',
-    				sendFromEmail: '',
-    				defaultSections: {
-    					user1: '4',
-    					group6: '49'
-    				},
-    				syncPeriodPast: '3',
-    				syncPeriodFuture: '12',
-    				defaultReminders: {
-    					fullDay: [
-    						{
-    							type: 'min',
-    							count: 15
-    						}
-    					],
-    					withTime: [
-    						{
-    							type: 'min',
-    							count: 50
-    						}
-    					]
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log('Result:', result);
-    	// Нужная вам логика обработки данных
-    	processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CalendarUserSettingsSetResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<CalendarUserSettingsSetResult>({
+        method: 'calendar.user.settings.set',
+        params: {
+          settings: {
+            view: 'month',
+            meetSection: '4',
+            crmSection: '4',
+            showDeclined: true,
+            denyBusyInvitation: false,
+            collapseOffHours: 'N',
+            showWeekNumbers: 'N',
+            showTasks: 'Y',
+            syncTasks: 'N',
+            showCompletedTasks: 'N',
+            lastUsedSection: 'false',
+            sendFromEmail: '',
+            defaultSections: {
+              user1: '4',
+              group6: '49',
+            },
+            syncPeriodPast: '3',
+            syncPeriodFuture: '12',
+            defaultReminders: {
+              fullDay: [
+                {
+                  type: 'min',
+                  count: 15,
+                },
+              ],
+              withTime: [
+                {
+                  type: 'min',
+                  count: 50,
+                },
+              ],
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Settings saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setCalendarUserSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.user.settings.set',
+            params: {
+              settings: {
+                view: 'month',
+                meetSection: '4',
+                crmSection: '4',
+                showDeclined: true,
+                denyBusyInvitation: false,
+                collapseOffHours: 'N',
+                showWeekNumbers: 'N',
+                showTasks: 'Y',
+                syncTasks: 'N',
+                showCompletedTasks: 'N',
+                lastUsedSection: 'false',
+                sendFromEmail: '',
+                defaultSections: {
+                  user1: '4',
+                  group6: '49',
+                },
+                syncPeriodPast: '3',
+                syncPeriodFuture: '12',
+                defaultReminders: {
+                  fullDay: [
+                    {
+                      type: 'min',
+                      count: 15,
+                    },
+                  ],
+                  withTime: [
+                    {
+                      type: 'min',
+                      count: 50,
+                    },
+                  ],
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Settings saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setCalendarUserSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/resource/calendar-resource-add.md
+++ b/api-reference/calendar/resource/calendar-resource-add.md
@@ -52,25 +52,76 @@
     https://**put_your_bitrix24_address**/rest/calendar.resource.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.resource.add',
-    		{
-    			name: 'My resource title'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceAddResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<ResourceAddResult>({
+        method: 'calendar.resource.add',
+        params: {
+          name: 'My resource title',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created resource ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.resource.add',
+            params: {
+              name: 'My resource title',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created resource ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addResource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/resource/calendar-resource-booking-list.md
+++ b/api-reference/calendar/resource/calendar-resource-booking-list.md
@@ -86,62 +86,127 @@
     https://**put_your_bitrix24_address**/rest/calendar.resource.booking.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each booking returned in result[]
+    type ResourceBooking = {
+      ID: string
+      PARENT_ID: string
+      DELETED: string
+      CAL_TYPE: string
+      OWNER_ID: string
+      NAME: string
+      DATE_FROM: string
+      DATE_TO: string
+      TZ_FROM: string
+      TZ_TO: string
+      TZ_OFFSET_FROM: string
+      TZ_OFFSET_TO: string
+      DATE_FROM_TS_UTC: string
+      DATE_TO_TS_UTC: string
+      DT_SKIP_TIME: string
+      DT_LENGTH: number
+      EVENT_TYPE: string
+      CREATED_BY: string
+      DATE_CREATE: string
+      TIMESTAMP_X: string
+      DESCRIPTION: string
+      IS_MEETING: boolean
+      MEETING_STATUS: string
+      MEETING_HOST: string
+      VERSION: string
+      SECTION_ID: string
+      DATE_FROM_FORMATTED: string
+      DATE_TO_FORMATTED: string
+      SECT_ID: string
+      RESOURCE_BOOKING_ID: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'calendar.resource.booking.list',
-        {
+      // calendar.resource.booking.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ResourceBooking[]>({
+        method: 'calendar.resource.booking.list',
+        params: {
           filter: {
             resourceTypeIdList: [10852, 10888, 10873, 10871, 10853],
             from: '2024-06-20',
             to: '2024-08-20',
-          }
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('calendar.resource.booking.list', {
-        filter: {
-          resourceTypeIdList: [10852, 10888, 10873, 10871, 10853],
-          from: '2024-06-20',
-          to: '2024-08-20',
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bookings on this page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('calendar.resource.booking.list', {
-        filter: {
-          resourceTypeIdList: [10852, 10888, 10873, 10871, 10853],
-          from: '2024-06-20',
-          to: '2024-08-20',
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchResourceBookings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // calendar.resource.booking.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.resource.booking.list',
+            params: {
+              filter: {
+                resourceTypeIdList: [10852, 10888, 10873, 10871, 10853],
+                from: '2024-06-20',
+                to: '2024-08-20',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bookings on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchResourceBookings)
+    </script>
     ```
 
 - PHP
@@ -241,56 +306,123 @@
     https://**put_your_bitrix24_address**/rest/calendar.resource.booking.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'calendar.resource.booking.list',
-        {
-          filter: {
-            resourceIdList: [10, 18, 17]
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each booking returned in result[]
+    type ResourceBooking = {
+      ID: string
+      PARENT_ID: string
+      DELETED: string
+      CAL_TYPE: string
+      OWNER_ID: string
+      NAME: string
+      DATE_FROM: string
+      DATE_TO: string
+      TZ_FROM: string
+      TZ_TO: string
+      TZ_OFFSET_FROM: string
+      TZ_OFFSET_TO: string
+      DATE_FROM_TS_UTC: string
+      DATE_TO_TS_UTC: string
+      DT_SKIP_TIME: string
+      DT_LENGTH: number
+      EVENT_TYPE: string
+      CREATED_BY: string
+      DATE_CREATE: string
+      TIMESTAMP_X: string
+      DESCRIPTION: string
+      IS_MEETING: boolean
+      MEETING_STATUS: string
+      MEETING_HOST: string
+      VERSION: string
+      SECTION_ID: string
+      DATE_FROM_FORMATTED: string
+      DATE_TO_FORMATTED: string
+      SECT_ID: string
+      RESOURCE_BOOKING_ID: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('calendar.resource.booking.list', {
-        filter: {
-          resourceIdList: [10, 18, 17]
-        }
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // calendar.resource.booking.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ResourceBooking[]>({
+        method: 'calendar.resource.booking.list',
+        params: {
+          filter: {
+            resourceIdList: [10, 18, 17],
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bookings on this page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('calendar.resource.booking.list', {
-        filter: {
-          resourceIdList: [10, 18, 17]
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchResourceBookings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // calendar.resource.booking.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.resource.booking.list',
+            params: {
+              filter: {
+                resourceIdList: [10, 18, 17],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bookings on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchResourceBookings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/resource/calendar-resource-delete.md
+++ b/api-reference/calendar/resource/calendar-resource-delete.md
@@ -51,25 +51,76 @@
     https://**put_your_bitrix24_address**/rest/calendar.resource.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.resource.delete',
-    		{
-    			resourceId: 521
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteResourceResult = boolean
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteResourceResult>({
+        method: 'calendar.resource.delete',
+        params: {
+          resourceId: 521,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resource deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.resource.delete',
+            params: {
+              resourceId: 521,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resource deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteResource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/resource/calendar-resource-list.md
+++ b/api-reference/calendar/resource/calendar-resource-list.md
@@ -43,23 +43,90 @@
     https://**put_your_bitrix24_address**/rest/calendar.resource.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.resource.list'
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each resource returned in result[]
+    type CalendarResourceItem = {
+      ID: string
+      NAME: string
+      CREATED_BY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      // calendar.resource.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CalendarResourceItem[]>({
+        method: 'calendar.resource.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resources:', result, 'Count:', result.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCalendarResources() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // calendar.resource.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.resource.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resources:', result, 'Count:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCalendarResources)
+    </script>
     ```
 
 - PHP

--- a/api-reference/calendar/resource/calendar-resource-update.md
+++ b/api-reference/calendar/resource/calendar-resource-update.md
@@ -56,26 +56,78 @@
     https://**put_your_bitrix24_address**/rest/calendar.resource.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'calendar.resource.update',
-    		{
-    			resourceId: 197,
-    			name: 'Changed Resource Name'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceUpdateResult = number
+
+    try {
+      const response = await $b24.actions.v2.call.make<ResourceUpdateResult>({
+        method: 'calendar.resource.update',
+        params: {
+          resourceId: 197,
+          name: 'Changed Resource Name',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated resource ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCalendarResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'calendar.resource.update',
+            params: {
+              resourceId: 197,
+              name: 'Changed Resource Name',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated resource ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCalendarResource)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start` and link the `callList.make` / `fetchList.make`
  helpers; `getTotal()` (removed in SDK 2.0) is replaced by `.length` + helpers.
- Each example is verified: `tsc --strict` against `@bitrix24/b24jssdk@1`, `node --check`
  on the UMD tab, and a method/field cross-check against the page's cURL endpoint and JSON
  response.
- One section per PR to keep review small.

No breaking changes — documentation examples only.