### PR TITLE
docs(crm/contacts): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/contacts/company/crm-contact-company-add.md
+++ b/api-reference/crm/contacts/company/crm-contact-company-add.md
@@ -102,34 +102,83 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.company.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.company.add',
-    		{
-    			id: 54,
-    			fields: {
-    				COMPANY_ID: 32,
-    				IS_PRIMARY: "Y",
-    				SORT: 1000,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.company.add',
+        params: {
+          id: 54,
+          fields: {
+            COMPANY_ID: 32,
+            IS_PRIMARY: 'Y',
+            SORT: 1000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company added to contact:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addContactCompany() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.company.add',
+            params: {
+              id: 54,
+              fields: {
+                COMPANY_ID: 32,
+                IS_PRIMARY: 'Y',
+                SORT: 1000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company added to contact:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addContactCompany)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/company/crm-contact-company-delete.md
+++ b/api-reference/crm/contacts/company/crm-contact-company-delete.md
@@ -70,32 +70,79 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.company.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.company.delete',
-    		{
-    			id: 54,
-    			fields: {
-    				COMPANY_ID: 32,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.company.delete',
+        params: {
+          id: 54,
+          fields: {
+            COMPANY_ID: 32,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Company removed from contact:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteContactCompany() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.company.delete',
+            params: {
+              id: 54,
+              fields: {
+                COMPANY_ID: 32,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Company removed from contact:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteContactCompany)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/company/crm-contact-company-fields.md
+++ b/api-reference/crm/contacts/company/crm-contact-company-fields.md
@@ -45,27 +45,82 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.company.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.company.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmContactCompanyFields = Record<string, CrmContactCompanyFieldDescription>
+
+    type CrmContactCompanyFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmContactCompanyFields>({
+        method: 'crm.contact.company.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact-company link fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getContactCompanyFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.company.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact-company link fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getContactCompanyFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/company/crm-contact-company-items-delete.md
+++ b/api-reference/crm/contacts/company/crm-contact-company-items-delete.md
@@ -56,29 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.company.items.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.company.items.delete',
-    		{
-    			id: 54,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.company.items.delete',
+        params: {
+          id: 54,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact companies cleared:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteContactCompanyItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.company.items.delete',
+            params: {
+              id: 54,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact companies cleared:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteContactCompanyItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/company/crm-contact-company-items-get.md
+++ b/api-reference/crm/contacts/company/crm-contact-company-items-get.md
@@ -56,29 +56,81 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.company.items.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.company.items.get',
-    		{
-    			id: 54,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of each contact-company binding returned in result[]
+    type CrmContactCompanyBinding = {
+      COMPANY_ID: number
+      SORT: number
+      ROLE_ID: number
+      IS_PRIMARY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmContactCompanyBinding[]>({
+        method: 'crm.contact.company.items.get',
+        params: {
+          id: 54,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact companies:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getContactCompanyItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.company.items.get',
+            params: {
+              id: 54,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact companies:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getContactCompanyItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/company/crm-contact-company-items-set.md
+++ b/api-reference/crm/contacts/company/crm-contact-company-items-set.md
@@ -90,44 +90,103 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.company.items.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.company.items.set',
-    		{
-    			id: 82,
-    			items: [
-    				{
-    					COMPANY_ID: 8,
-    					IS_PRIMARY: "Y",
-    					SORT: 100,
-    				},
-    				{
-    					COMPANY_ID: 9,
-    					SORT: 200,
-    				},
-    				{
-    					COMPANY_ID: 10,
-    					SORT: 400,
-    				}
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.company.items.set',
+        params: {
+          id: 82,
+          items: [
+            {
+              COMPANY_ID: 8,
+              IS_PRIMARY: 'Y',
+              SORT: 100,
+            },
+            {
+              COMPANY_ID: 9,
+              SORT: 200,
+            },
+            {
+              COMPANY_ID: 10,
+              SORT: 400,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact companies set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setContactCompanyItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.company.items.set',
+            params: {
+              id: 82,
+              items: [
+                {
+                  COMPANY_ID: 8,
+                  IS_PRIMARY: 'Y',
+                  SORT: 100,
+                },
+                {
+                  COMPANY_ID: 9,
+                  SORT: 200,
+                },
+                {
+                  COMPANY_ID: 10,
+                  SORT: 400,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact companies set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setContactCompanyItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/crm-contact-add.md
+++ b/api-reference/crm/contacts/crm-contact-add.md
@@ -270,95 +270,205 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.contact.add',
-            {
-                fields: {
-                    HONORIFIC: "HNR_RU_1",
-                    NAME: "Иван",
-                    SECOND_NAME: "Иванович",
-                    LAST_NAME: "Иванов",
-                    PHOTO: {
-                        fileData: document.getElementById('photo'),
-                    },
-                    BIRTHDATE: '11.11.2001',
-                    TYPE_ID: "PARTNER",
-                    SOURCE_ID: "WEB",
-                    SOURCE_DESCRIPTION: "*Дополнительно об источнике*",
-                    POST: "Администратор",
-                    COMMENTS: `
-                        Пример комментария внутри контакта
+    declare const $b24: B24Frame
 
-                        [B]Жирный текст[/B]
-                        [I]Курсив[/I]
-                        [U]Подчеркнутый[/U]
-                        [S]Зачеркнутый[/S]
-                        [B][I][U][S]Микс[/S][/U][/I][/B]
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.contact.add',
+        params: {
+          fields: {
+            HONORIFIC: 'HNR_RU_1',
+            NAME: 'Ivan',
+            SECOND_NAME: 'Ivanovich',
+            LAST_NAME: 'Ivanov',
+            PHOTO: {
+              fileData: document.getElementById('photo'),
+            },
+            BIRTHDATE: '11.11.2001',
+            TYPE_ID: 'PARTNER',
+            SOURCE_ID: 'WEB',
+            SOURCE_DESCRIPTION: '*Additional source details*',
+            POST: 'Administrator',
+            COMMENTS: `
+              Example comment inside the contact
 
-                        [LIST]
-                        [*]Элемент списка #1
-                        [*]Элемент списка #2
-                        [*]Элемент списка #3
-                        [/LIST]
+              [B]Bold text[/B]
+              [I]Italic[/I]
+              [U]Underlined[/U]
+              [S]Strikethrough[/S]
+              [B][I][U][S]Mix[/S][/U][/I][/B]
 
-                        [LIST=1]
-                        [*]Нумерованный элемент списка #1
-                        [*]Нумерованный элемент списка #2
-                        [*]Нумерованный элемент списка #3
-                        [/LIST]
-                    `,
-                    OPENED: "Y",
-                    EXPORT: "N",
-                    ASSIGNED_BY_ID: 6,
-                    COMPANY_ID: 12,
-                    COMPANY_IDS: [12, 13, 15],
-                    UTM_SOURCE: "yandex",
-                    UTM_MEDIUM: "CPC",
-                    UTM_CAMPAIGN: "summer_sale",
-                    UTM_CONTENT: "header_banner",
-                    UTM_TERM: "discount",
-                    PHONE: [
-                        {
-                            VALUE: "+7333333555",
-                            VALUE_TYPE: "WORK",
-                        },
-                        {
-                            VALUE: "+35599888666",
-                            VALUE_TYPE: "HOME",
-                        }
-                    ],
-                    EMAIL: [
-                        {
-                            VALUE: "ivanov@example.mailing",
-                            VALUE_TYPE: "MAILING",
-                        },
-                        {
-                            VALUE: "ivanov@example.work",
-                            VALUE_TYPE: "WORK",
-                        }
-                    ],
-                    UF_CRM_1720697698689: "Пример значения пользовательского поля с типом \"Строка\"",
-                    PARENT_ID_1224: 12,
+              [LIST]
+              [*]List item #1
+              [*]List item #2
+              [*]List item #3
+              [/LIST]
+
+              [LIST=1]
+              [*]Numbered list item #1
+              [*]Numbered list item #2
+              [*]Numbered list item #3
+              [/LIST]
+            `,
+            OPENED: 'Y',
+            EXPORT: 'N',
+            ASSIGNED_BY_ID: 6,
+            COMPANY_ID: 12,
+            COMPANY_IDS: [12, 13, 15],
+            UTM_SOURCE: 'yandex',
+            UTM_MEDIUM: 'CPC',
+            UTM_CAMPAIGN: 'summer_sale',
+            UTM_CONTENT: 'header_banner',
+            UTM_TERM: 'discount',
+            PHONE: [
+              {
+                VALUE: '+7333333555',
+                VALUE_TYPE: 'WORK',
+              },
+              {
+                VALUE: '+35599888666',
+                VALUE_TYPE: 'HOME',
+              },
+            ],
+            EMAIL: [
+              {
+                VALUE: 'ivanov@example.mailing',
+                VALUE_TYPE: 'MAILING',
+              },
+              {
+                VALUE: 'ivanov@example.work',
+                VALUE_TYPE: 'WORK',
+              },
+            ],
+            UF_CRM_1720697698689: 'Example value of a custom field of type "String"',
+            PARENT_ID_1224: 12,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created contact id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.add',
+            params: {
+              fields: {
+                HONORIFIC: 'HNR_RU_1',
+                NAME: 'Ivan',
+                SECOND_NAME: 'Ivanovich',
+                LAST_NAME: 'Ivanov',
+                PHOTO: {
+                  fileData: document.getElementById('photo'),
                 },
-            }
-        );
-        
-        const result = response.getData().result;
-        result.error()
-            ? console.error(result.error())
-            : console.info(result)
-        ;
-    }
-    catch( error )
-    {
-        console.error(error);
-    }
+                BIRTHDATE: '11.11.2001',
+                TYPE_ID: 'PARTNER',
+                SOURCE_ID: 'WEB',
+                SOURCE_DESCRIPTION: '*Additional source details*',
+                POST: 'Administrator',
+                COMMENTS: `
+                  Example comment inside the contact
+
+                  [B]Bold text[/B]
+                  [I]Italic[/I]
+                  [U]Underlined[/U]
+                  [S]Strikethrough[/S]
+                  [B][I][U][S]Mix[/S][/U][/I][/B]
+
+                  [LIST]
+                  [*]List item #1
+                  [*]List item #2
+                  [*]List item #3
+                  [/LIST]
+
+                  [LIST=1]
+                  [*]Numbered list item #1
+                  [*]Numbered list item #2
+                  [*]Numbered list item #3
+                  [/LIST]
+                `,
+                OPENED: 'Y',
+                EXPORT: 'N',
+                ASSIGNED_BY_ID: 6,
+                COMPANY_ID: 12,
+                COMPANY_IDS: [12, 13, 15],
+                UTM_SOURCE: 'yandex',
+                UTM_MEDIUM: 'CPC',
+                UTM_CAMPAIGN: 'summer_sale',
+                UTM_CONTENT: 'header_banner',
+                UTM_TERM: 'discount',
+                PHONE: [
+                  {
+                    VALUE: '+7333333555',
+                    VALUE_TYPE: 'WORK',
+                  },
+                  {
+                    VALUE: '+35599888666',
+                    VALUE_TYPE: 'HOME',
+                  },
+                ],
+                EMAIL: [
+                  {
+                    VALUE: 'ivanov@example.mailing',
+                    VALUE_TYPE: 'MAILING',
+                  },
+                  {
+                    VALUE: 'ivanov@example.work',
+                    VALUE_TYPE: 'WORK',
+                  },
+                ],
+                UF_CRM_1720697698689: 'Example value of a custom field of type "String"',
+                PARENT_ID_1224: 12,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created contact id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/crm-contact-delete.md
+++ b/api-reference/crm/contacts/crm-contact-delete.md
@@ -62,29 +62,73 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.delete',
-    		{
-    			id: 50,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.delete',
+        params: {
+          id: 50,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.delete',
+            params: {
+              id: 50,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/crm-contact-fields.md
+++ b/api-reference/crm/contacts/crm-contact-fields.md
@@ -50,24 +50,82 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info('Поля контакта', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmContactFields = Record<string, CrmContactFieldDescription>
+
+    type CrmContactFieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmContactFields>({
+        method: 'crm.contact.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getContactFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getContactFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/crm-contact-get.md
+++ b/api-reference/crm/contacts/crm-contact-get.md
@@ -62,29 +62,89 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.get',
-    		{
-    			id: 23,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmContactResult = {
+      ID: string
+      NAME: string
+      LAST_NAME: string
+      TYPE_ID: string
+      SOURCE_ID: string
+      COMPANY_ID: string
+      ASSIGNED_BY_ID: string
+      OPENED: string
+      BIRTHDATE: ISODate | null
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+      LAST_ACTIVITY_TIME: ISODate | null
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmContactResult>({
+        method: 'crm.contact.get',
+        params: {
+          id: 23,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact:', result.ID, result.NAME, result.LAST_NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.get',
+            params: {
+              id: 23,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact:', result.ID, result.NAME, result.LAST_NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/crm-contact-list.md
+++ b/api-reference/crm/contacts/crm-contact-list.md
@@ -163,134 +163,155 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const sixMonthAgo = new Date();
-    sixMonthAgo.setMonth(new Date().getMonth() - 6);
-    
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each contact object returned in result[]
+    type CrmContactListItem = {
+      ID: string
+      NAME: string
+      LAST_NAME: string
+      EXPORT: string
+      ASSIGNED_BY_ID: string
+      DATE_CREATE: ISODate | null
+      EMAIL?: CrmContactEmail[]
+    }
+
+    type CrmContactEmail = {
+      ID: string
+      VALUE_TYPE: string
+      VALUE: string
+      TYPE_ID: string
+    }
+
+    const sixMonthAgo = new Date()
+    sixMonthAgo.setMonth(new Date().getMonth() - 6)
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.contact.list',
-        {
+      // crm.contact.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmContactListItem[]>({
+        method: 'crm.contact.list',
+        params: {
           filter: {
-            "SOURCE_ID": "CRM_FORM",
-            "!=NAME": "",
-            "!=LAST_NAME": "",
-            "=%NAME": "И%",
-            "=%LAST_NAME": "И%",
-            "EMAIL": "special-for@example.com",
-            "@ASSIGNED_BY_ID": [1, 6],
-            "IMPORT": "Y",
-            ">=DATE_CREATE": sixMonthAgo.toISOString(),
+            SOURCE_ID: 'CRM_FORM',
+            '!=NAME': '',
+            '!=LAST_NAME': '',
+            '=%NAME': 'И%',
+            '=%LAST_NAME': 'И%',
+            EMAIL: 'special-for@example.com',
+            '@ASSIGNED_BY_ID': [1, 6],
+            IMPORT: 'Y',
+            '>=DATE_CREATE': sixMonthAgo.toISOString(),
           },
           order: {
-            LAST_NAME: "ASC",
-            NAME: "ASC",
+            LAST_NAME: 'ASC',
+            NAME: 'ASC',
           },
           select: [
-            "ID",
-            "NAME",
-            "LAST_NAME",
-            "EMAIL",
-            "EXPORT",
-            "ASSIGNED_BY_ID",
-            "DATE_CREATE",
+            'ID',
+            'NAME',
+            'LAST_NAME',
+            'EMAIL',
+            'EXPORT',
+            'ASSIGNED_BY_ID',
+            'DATE_CREATE',
           ],
+          start: 0,
         },
-        (result) => {
-          result.error()
-            ? console.error(result.error())
-            : console.info(result.data())
-          ;
-        }
-      );
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const sixMonthAgo = new Date();
-    sixMonthAgo.setMonth(new Date().getMonth() - 6);
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.contact.list', {
-        filter: {
-          "SOURCE_ID": "CRM_FORM",
-          "!=NAME": "",
-          "!=LAST_NAME": "",
-          "=%NAME": "И%",
-          "=%LAST_NAME": "И%",
-          "EMAIL": "special-for@example.com",
-          "@ASSIGNED_BY_ID": [1, 6],
-          "IMPORT": "Y",
-          ">=DATE_CREATE": sixMonthAgo.toISOString(),
-        },
-        order: {
-          LAST_NAME: "ASC",
-          NAME: "ASC",
-        },
-        select: [
-          "ID",
-          "NAME",
-          "LAST_NAME",
-          "EMAIL",
-          "EXPORT",
-          "ASSIGNED_BY_ID",
-          "DATE_CREATE",
-        ],
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) {
-          console.log('Entity:', entity);
-        }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contacts on this page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const sixMonthAgo = new Date();
-    sixMonthAgo.setMonth(new Date().getMonth() - 6);
-    
-    try {
-      const response = await $b24.callMethod('crm.contact.list', {
-        filter: {
-          "SOURCE_ID": "CRM_FORM",
-          "!=NAME": "",
-          "!=LAST_NAME": "",
-          "=%NAME": "И%",
-          "=%LAST_NAME": "И%",
-          "EMAIL": "special-for@example.com",
-          "@ASSIGNED_BY_ID": [1, 6],
-          "IMPORT": "Y",
-          ">=DATE_CREATE": sixMonthAgo.toISOString(),
-        },
-        order: {
-          LAST_NAME: "ASC",
-          NAME: "ASC",
-        },
-        select: [
-          "ID",
-          "NAME",
-          "LAST_NAME",
-          "EMAIL",
-          "EXPORT",
-          "ASSIGNED_BY_ID",
-          "DATE_CREATE",
-        ],
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) {
-        console.log('Entity:', entity);
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listContacts() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const sixMonthAgo = new Date()
+          sixMonthAgo.setMonth(new Date().getMonth() - 6)
+
+          // crm.contact.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.list',
+            params: {
+              filter: {
+                SOURCE_ID: 'CRM_FORM',
+                '!=NAME': '',
+                '!=LAST_NAME': '',
+                '=%NAME': 'И%',
+                '=%LAST_NAME': 'И%',
+                EMAIL: 'special-for@example.com',
+                '@ASSIGNED_BY_ID': [1, 6],
+                IMPORT: 'Y',
+                '>=DATE_CREATE': sixMonthAgo.toISOString(),
+              },
+              order: {
+                LAST_NAME: 'ASC',
+                NAME: 'ASC',
+              },
+              select: [
+                'ID',
+                'NAME',
+                'LAST_NAME',
+                'EMAIL',
+                'EXPORT',
+                'ASSIGNED_BY_ID',
+                'DATE_CREATE',
+              ],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contacts on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
       }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+
+      document.addEventListener('DOMContentLoaded', listContacts)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/crm-contact-update.md
+++ b/api-reference/crm/contacts/crm-contact-update.md
@@ -241,48 +241,111 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.update',
-    		{
-    			id: 43,
-    			fields: {
-    				NAME: "Сергей",
-    				BIRTHDATE: '11.11.1999',
-    				TYPE_ID: "RECOMMENDATION",
-    				SOURCE_ID: "WEB",
-    				POST: "Администратор компьютерных сетей",
-    				COMMENTS: "Новый комментарий",
-    				OPENED: "N",
-    				EXPORT: "Y",
-    				ASSIGNED_BY_ID: 1,
-    				COMPANY_ID: 12,
-    				COMPANY_IDS: [13, 15],
-    				UF_CRM_1720697698689: "Пример нового значения пользовательского поля с типом \"Строка\"",
-    				PARENT_ID_1224: 14,
-    			},
-    			params: {
-    				REGISTER_SONET_EVENT: "N",
-    				REGISTER_HISTORY_EVENT: "N",
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.update',
+        params: {
+          id: 43,
+          fields: {
+            NAME: 'Sergey',
+            BIRTHDATE: '11.11.1999',
+            TYPE_ID: 'RECOMMENDATION',
+            SOURCE_ID: 'WEB',
+            POST: 'Computer network administrator',
+            COMMENTS: 'New comment',
+            OPENED: 'N',
+            EXPORT: 'Y',
+            ASSIGNED_BY_ID: 1,
+            COMPANY_ID: 12,
+            COMPANY_IDS: [13, 15],
+            UF_CRM_1720697698689: 'Example new value of a custom field of type "String"',
+            PARENT_ID_1224: 14,
+          },
+          params: {
+            REGISTER_SONET_EVENT: 'N',
+            REGISTER_HISTORY_EVENT: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contact updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateContact() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.update',
+            params: {
+              id: 43,
+              fields: {
+                NAME: 'Sergey',
+                BIRTHDATE: '11.11.1999',
+                TYPE_ID: 'RECOMMENDATION',
+                SOURCE_ID: 'WEB',
+                POST: 'Computer network administrator',
+                COMMENTS: 'New comment',
+                OPENED: 'N',
+                EXPORT: 'Y',
+                ASSIGNED_BY_ID: 1,
+                COMPANY_ID: 12,
+                COMPANY_IDS: [13, 15],
+                UF_CRM_1720697698689: 'Example new value of a custom field of type "String"',
+                PARENT_ID_1224: 14,
+              },
+              params: {
+                REGISTER_SONET_EVENT: 'N',
+                REGISTER_HISTORY_EVENT: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contact updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateContact)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/custom-form/crm-contact-details-configuration-force-common-scope-for-all.md
+++ b/api-reference/crm/contacts/custom-form/crm-contact-details-configuration-force-common-scope-for-all.md
@@ -49,27 +49,69 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.details.configuration.forceCommonScopeForAll
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.details.configuration.forceCommonScopeForAll',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.details.configuration.forceCommonScopeForAll',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Common card forced for all users:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function forceCommonScopeForAll() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.details.configuration.forceCommonScopeForAll',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Common card forced for all users:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', forceCommonScopeForAll)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/custom-form/crm-contact-details-configuration-set.md
+++ b/api-reference/crm/contacts/custom-form/crm-contact-details-configuration-set.md
@@ -185,86 +185,187 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.details.configuration.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.details.configuration.set',
-    		{
-    			userId: 1,
-    			data: [
-    				{
-    					name: "section_1",
-    					title: "Личные данные",
-    					type: "section",
-    					elements: [
-    						{
-    							name: "NAME",
-    							optionFlags: 1,
-    						},
-    						{
-    							name: "LAST_NAME",
-    							optionFlags: 1,
-    						},
-    						{
-    							name: "SECOND_NAME",
-    						},
-    						{
-    							name: "BIRTHDATE",
-    						},
-    						{
-    							name: "PHONE",
-    							optionFlags: 1,
-    							options: {
-    								defaultCountry: "GB",
-    							},
-    						},
-    						{
-    							name: "ADDRESS",
-    							optionFlags: 1,
-    							options: {
-    								defaultAddressType: 4,
-    							},
-    						},
-    					],
-    				},
-    				{
-    					name: "section_2",
-    					title: "Основная информация",
-    					type: "section",
-    					elements: [
-    						{ name: "TYPE_ID" },
-    						{ name: "SOURCE_ID" },
-    						{ name: "POST" },
-    					],
-    				},
-    				{
-    					name: "section_3",
-    					title: "Дополнительная информация",
-    					type: "section",
-    					elements: [
-    						{ name: "PHOTO" },
-    						{ name: "COMMENTS" },
-    						{ name: "UF_CRM_1720697698689" },
-    					],
-    				},
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.details.configuration.set',
+        params: {
+          userId: 1,
+          data: [
+            {
+              name: 'section_1',
+              title: 'Personal data',
+              type: 'section',
+              elements: [
+                {
+                  name: 'NAME',
+                  optionFlags: 1,
+                },
+                {
+                  name: 'LAST_NAME',
+                  optionFlags: 1,
+                },
+                {
+                  name: 'SECOND_NAME',
+                },
+                {
+                  name: 'BIRTHDATE',
+                },
+                {
+                  name: 'PHONE',
+                  optionFlags: 1,
+                  options: {
+                    defaultCountry: 'GB',
+                  },
+                },
+                {
+                  name: 'ADDRESS',
+                  optionFlags: 1,
+                  options: {
+                    defaultAddressType: 4,
+                  },
+                },
+              ],
+            },
+            {
+              name: 'section_2',
+              title: 'Main information',
+              type: 'section',
+              elements: [
+                { name: 'TYPE_ID' },
+                { name: 'SOURCE_ID' },
+                { name: 'POST' },
+              ],
+            },
+            {
+              name: 'section_3',
+              title: 'Additional information',
+              type: 'section',
+              elements: [
+                { name: 'PHOTO' },
+                { name: 'COMMENTS' },
+                { name: 'UF_CRM_1720697698689' },
+              ],
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Configuration saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setContactDetailsConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.details.configuration.set',
+            params: {
+              userId: 1,
+              data: [
+                {
+                  name: 'section_1',
+                  title: 'Personal data',
+                  type: 'section',
+                  elements: [
+                    {
+                      name: 'NAME',
+                      optionFlags: 1,
+                    },
+                    {
+                      name: 'LAST_NAME',
+                      optionFlags: 1,
+                    },
+                    {
+                      name: 'SECOND_NAME',
+                    },
+                    {
+                      name: 'BIRTHDATE',
+                    },
+                    {
+                      name: 'PHONE',
+                      optionFlags: 1,
+                      options: {
+                        defaultCountry: 'GB',
+                      },
+                    },
+                    {
+                      name: 'ADDRESS',
+                      optionFlags: 1,
+                      options: {
+                        defaultAddressType: 4,
+                      },
+                    },
+                  ],
+                },
+                {
+                  name: 'section_2',
+                  title: 'Main information',
+                  type: 'section',
+                  elements: [
+                    { name: 'TYPE_ID' },
+                    { name: 'SOURCE_ID' },
+                    { name: 'POST' },
+                  ],
+                },
+                {
+                  name: 'section_3',
+                  title: 'Additional information',
+                  type: 'section',
+                  elements: [
+                    { name: 'PHOTO' },
+                    { name: 'COMMENTS' },
+                    { name: 'UF_CRM_1720697698689' },
+                  ],
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Configuration saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setContactDetailsConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/userfield/crm-contact-userfield-delete.md
+++ b/api-reference/crm/contacts/userfield/crm-contact-userfield-delete.md
@@ -56,29 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.userfield.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.userfield.delete',
-    		{
-    			id: 432,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.contact.userfield.delete',
+        params: {
+          id: 432,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteContactUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.userfield.delete',
+            params: {
+              id: 432,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteContactUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/userfield/crm-contact-userfield-get.md
+++ b/api-reference/crm/contacts/userfield/crm-contact-userfield-get.md
@@ -56,29 +56,85 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.userfield.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.contact.userfield.get',
-    		{
-    			id: 399,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmContactUserfield = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmContactUserfield>({
+        method: 'crm.contact.userfield.get',
+        params: {
+          id: 399,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield:', result.ID, result.FIELD_NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getContactUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.userfield.get',
+            params: {
+              id: 399,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield:', result.ID, result.FIELD_NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getContactUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/contacts/userfield/crm-contact-userfield-list.md
+++ b/api-reference/crm/contacts/userfield/crm-contact-userfield-list.md
@@ -174,79 +174,115 @@
     https://**put_your_bitrix24_address**/rest/crm.contact.userfield.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each userfield object returned in result[]
+    type CrmContactUserfieldListItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      EDIT_FORM_LABEL: string
+      LIST_COLUMN_LABEL: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.contact.userfield.list',
-        {
+      // crm.contact.userfield.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmContactUserfieldListItem[]>({
+        method: 'crm.contact.userfield.list',
+        params: {
           filter: {
-            MULTIPLE: "Y",
-            MANDATORY: "Y",
-            LANG: "ru",
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            LANG: 'ru',
           },
           order: {
-            USER_TYPE_ID: "ASC",
-            SORT: "ASC",
+            USER_TYPE_ID: 'ASC',
+            SORT: 'ASC',
           },
+          start: 0,
         },
-        (progress) => { 
-          result.error()
-            ? console.error(result.error())
-            : console.info(result.data())
-          ;
-        }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.contact.userfield.list', {
-        filter: {
-          MULTIPLE: "Y",
-          MANDATORY: "Y",
-          LANG: "ru",
-        },
-        order: {
-          USER_TYPE_ID: "ASC",
-          SORT: "ASC",
-        },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfields on this page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.contact.userfield.list', {
-        filter: {
-          MULTIPLE: "Y",
-          MANDATORY: "Y",
-          LANG: "ru",
-        },
-        order: {
-          USER_TYPE_ID: "ASC",
-          SORT: "ASC",
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listContactUserfields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.contact.userfield.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.contact.userfield.list',
+            params: {
+              filter: {
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                LANG: 'ru',
+              },
+              order: {
+                USER_TYPE_ID: 'ASC',
+                SORT: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfields on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listContactUserfields)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.