### PR TITLE
docs(telephony): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/telephony/telephony-call-attach-transcription.md
+++ b/api-reference/telephony/telephony-call-attach-transcription.md
@@ -85,30 +85,86 @@
     https://**put_your_bitrix24_address**/rest/telephony.call.attachTranscription
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.call.attachTranscription',
-            {
-                CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
-                MESSAGES: [
-                    { SIDE: 'User', START_TIME: 1, STOP_TIME: 3, MESSAGE: 'Добрый день' },
-                    { SIDE: 'Client', START_TIME: 4, STOP_TIME: 7, MESSAGE: 'Здравствуйте' }
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Transcription attached:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachTranscriptionResult = {
+      TRANSCRIPT_ID: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachTranscriptionResult>({
+        method: 'telephony.call.attachTranscription',
+        params: {
+          CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+          MESSAGES: [
+            { SIDE: 'User', START_TIME: 1, STOP_TIME: 3, MESSAGE: 'Hello' },
+            { SIDE: 'Client', START_TIME: 4, STOP_TIME: 7, MESSAGE: 'Hi there' },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Transcript ID:', result.TRANSCRIPT_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function attachTranscription() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.call.attachTranscription',
+            params: {
+              CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+              MESSAGES: [
+                { SIDE: 'User', START_TIME: 1, STOP_TIME: 3, MESSAGE: 'Hello' },
+                { SIDE: 'Client', START_TIME: 4, STOP_TIME: 7, MESSAGE: 'Hi there' },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Transcript ID:', result.TRANSCRIPT_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', attachTranscription)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-call-attach-record.md
+++ b/api-reference/telephony/telephony-external-call-attach-record.md
@@ -79,28 +79,84 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalCall.attachRecord
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalCall.attachRecord',
-            {
-                CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
-                FILENAME: 'call-001.mp3',
-                FILE_CONTENT: 'SUQzAwAAAAAiVVRJVDI...AAAAAAAAAAAAP8='
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Record attached:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachRecordResult = {
+      FILE_ID?: number
+      uploadUrl?: string
+      fieldName?: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachRecordResult>({
+        method: 'telephony.externalCall.attachRecord',
+        params: {
+          CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+          FILENAME: 'call-001.mp3',
+          FILE_CONTENT: 'SUQzAwAAAAAiVVRJVDI...AAAAAAAAAAAAP8=',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('FILE_ID:', result.FILE_ID, 'uploadUrl:', result.uploadUrl, 'fieldName:', result.fieldName)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function attachRecord() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalCall.attachRecord',
+            params: {
+              CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+              FILENAME: 'call-001.mp3',
+              FILE_CONTENT: 'SUQzAwAAAAAiVVRJVDI...AAAAAAAAAAAAP8=',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('FILE_ID:', result.FILE_ID, 'uploadUrl:', result.uploadUrl, 'fieldName:', result.fieldName)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', attachRecord)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-call-finish.md
+++ b/api-reference/telephony/telephony-external-call-finish.md
@@ -122,31 +122,108 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalCall.finish
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalCall.finish',
-            {
-                CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
-                USER_ID: 1269,
-                DURATION: 95,
-                STATUS_CODE: '200',
-                VOTE: 5,
-                ADD_TO_CHAT: 0
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Call finished:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExternalCallFinishResult = {
+      ID: number
+      CALL_ID: string
+      EXTERNAL_CALL_ID: string | null
+      PORTAL_USER_ID: number
+      PHONE_NUMBER: string
+      PORTAL_NUMBER: string
+      INCOMING: string
+      CALL_DURATION: number
+      CALL_START_DATE: ISODate | null
+      CALL_STATUS: number
+      CALL_VOTE: number
+      COST: number
+      COST_CURRENCY: string
+      CALL_FAILED_CODE: string
+      CALL_FAILED_REASON: string
+      REST_APP_ID: string
+      REST_APP_NAME: string
+      CRM_ACTIVITY_ID: number
+      COMMENT: string | null
+      CRM_ENTITY_TYPE: string
+      CRM_ENTITY_ID: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExternalCallFinishResult>({
+        method: 'telephony.externalCall.finish',
+        params: {
+          CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+          USER_ID: 1269,
+          DURATION: 95,
+          STATUS_CODE: '200',
+          VOTE: 5,
+          ADD_TO_CHAT: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call finished, ID:', result.ID, 'status:', result.CALL_STATUS, 'duration:', result.CALL_DURATION)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function finishExternalCall() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalCall.finish',
+            params: {
+              CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+              USER_ID: 1269,
+              DURATION: 95,
+              STATUS_CODE: '200',
+              VOTE: 5,
+              ADD_TO_CHAT: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call finished, ID:', result.ID, 'status:', result.CALL_STATUS, 'duration:', result.CALL_DURATION)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', finishExternalCall)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-call-hide.md
+++ b/api-reference/telephony/telephony-external-call-hide.md
@@ -56,27 +56,75 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalCall.hide
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalCall.hide',
-            {
-                CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
-                USER_ID: 1269
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Call hidden:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'telephony.externalCall.hide',
+        params: {
+          CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+          USER_ID: 1269,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call hidden:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function hideExternalCall() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalCall.hide',
+            params: {
+              CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+              USER_ID: 1269,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call hidden:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', hideExternalCall)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-call-register.md
+++ b/api-reference/telephony/telephony-external-call-register.md
@@ -163,33 +163,97 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalCall.register
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalCall.register',
-            {
-                USER_ID: 1269,
-                PHONE_NUMBER: '79062195047',
-                TYPE: 2,
-                CRM_ENTITY_TYPE: 'CONTACT',
-                CRM_ENTITY_ID: 797,
-                SHOW: 1,
-                LINE_NUMBER: '3',
-                EXTERNAL_CALL_ID: 'asterisk-1710140185.18441'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Call registered:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExternalCallRegisterResult = {
+      CALL_ID: string
+      CRM_CREATED_LEAD: number | null
+      CRM_CREATED_ENTITIES: { ENTITY_TYPE: string; ENTITY_ID: number }[]
+      CRM_ENTITY_TYPE: string
+      CRM_ENTITY_ID: number
+      LEAD_CREATION_ERROR?: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExternalCallRegisterResult>({
+        method: 'telephony.externalCall.register',
+        params: {
+          USER_ID: 1269,
+          PHONE_NUMBER: '79062195047',
+          TYPE: 2,
+          CRM_ENTITY_TYPE: 'CONTACT',
+          CRM_ENTITY_ID: 797,
+          SHOW: 1,
+          LINE_NUMBER: '3',
+          EXTERNAL_CALL_ID: 'asterisk-1710140185.18441',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.CALL_ID, result.CRM_ENTITY_TYPE, result.CRM_ENTITY_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerExternalCall() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalCall.register',
+            params: {
+              USER_ID: 1269,
+              PHONE_NUMBER: '79062195047',
+              TYPE: 2,
+              CRM_ENTITY_TYPE: 'CONTACT',
+              CRM_ENTITY_ID: 797,
+              SHOW: 1,
+              LINE_NUMBER: '3',
+              EXTERNAL_CALL_ID: 'asterisk-1710140185.18441',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.CALL_ID, result.CRM_ENTITY_TYPE, result.CRM_ENTITY_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerExternalCall)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-call-search-crm-entities.md
+++ b/api-reference/telephony/telephony-external-call-search-crm-entities.md
@@ -52,26 +52,89 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalCall.searchCrmEntities
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalCall.searchCrmEntities',
-            {
-                PHONE_NUMBER: '79062195047'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('CRM entities found:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each CRM entity returned in result[]
+    type CrmEntityResult = {
+      CRM_ENTITY_TYPE: string
+      CRM_ENTITY_ID: number
+      ASSIGNED_BY_ID: number
+      NAME: string
+      ASSIGNED_BY: {
+        ID: string
+        TIMEMAN_STATUS: string
+        USER_PHONE_INNER: string | null
+        WORK_PHONE: string | null
+        PERSONAL_PHONE: string | null
+        PERSONAL_MOBILE: string | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmEntityResult[]>({
+        method: 'telephony.externalCall.searchCrmEntities',
+        params: {
+          PHONE_NUMBER: '79062195047',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('CRM entities found:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchCrmEntities() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalCall.searchCrmEntities',
+            params: {
+              PHONE_NUMBER: '79062195047',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('CRM entities found:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchCrmEntities)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-call-show.md
+++ b/api-reference/telephony/telephony-external-call-show.md
@@ -58,27 +58,75 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalCall.show
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalCall.show',
-            {
-                CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
-                USER_ID: 1269
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Call shown:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'telephony.externalCall.show',
+        params: {
+          CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+          USER_ID: 1269,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call shown successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function showExternalCall() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalCall.show',
+            params: {
+              CALL_ID: 'externalCall.716f1cb73def9700a23842adf9c4c568.1773130779',
+              USER_ID: 1269,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call shown successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', showExternalCall)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-line-add.md
+++ b/api-reference/telephony/telephony-external-line-add.md
@@ -59,29 +59,82 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalLine.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalLine.add',
-            {
-                NUMBER: '74951234567',
-                NAME: 'Основная внешняя линия',
-                CRM_AUTO_CREATE: 'Y'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Added external line with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExternalLineAddResult = {
+      ID: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExternalLineAddResult>({
+        method: 'telephony.externalLine.add',
+        params: {
+          NUMBER: '74951234567',
+          NAME: 'Main external line',
+          CRM_AUTO_CREATE: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added external line with ID:', result.ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addExternalLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalLine.add',
+            params: {
+              NUMBER: '74951234567',
+              NAME: 'Main external line',
+              CRM_AUTO_CREATE: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added external line with ID:', result.ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addExternalLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-line-delete.md
+++ b/api-reference/telephony/telephony-external-line-delete.md
@@ -50,27 +50,73 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalLine.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalLine.delete',
-            {
-                NUMBER: '74951234567',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<never[]>({
+        method: 'telephony.externalLine.delete',
+        params: {
+          NUMBER: '74951234567',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External line deleted successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteExternalLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalLine.delete',
+            params: {
+              NUMBER: '74951234567',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External line deleted successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteExternalLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-line-get.md
+++ b/api-reference/telephony/telephony-external-line-get.md
@@ -41,25 +41,78 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalLine.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalLine.get',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved external lines:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each ExternalLine returned in result[]
+    type ExternalLine = {
+      NUMBER: string
+      NAME: string
+      CRM_AUTO_CREATE: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExternalLine[]>({
+        method: 'telephony.externalLine.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External lines count:', result.length)
+        console.info('External lines:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getExternalLines() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalLine.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External lines count:', result.length)
+          console.info('External lines:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getExternalLines)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/telephony-external-line-update.md
+++ b/api-reference/telephony/telephony-external-line-update.md
@@ -65,29 +65,82 @@
     https://**put_your_bitrix24_address**/rest/telephony.externalLine.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'telephony.externalLine.update',
-            {
-                NUMBER: '74951234567',
-                NAME: 'Линия поддержки',
-                CRM_AUTO_CREATE: 'N'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated external line with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExternalLineUpdateResult = {
+      ID: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExternalLineUpdateResult>({
+        method: 'telephony.externalLine.update',
+        params: {
+          NUMBER: '74951234567',
+          NAME: 'Support line',
+          CRM_AUTO_CREATE: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated external line ID:', result.ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateExternalLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'telephony.externalLine.update',
+            params: {
+              NUMBER: '74951234567',
+              NAME: 'Support line',
+              CRM_AUTO_CREATE: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated external line ID:', result.ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateExternalLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/lines/voximplant-line-get.md
+++ b/api-reference/telephony/voximplant/lines/voximplant-line-get.md
@@ -45,23 +45,72 @@
     https://**put_your_bitrix24_address**/rest/voximplant.line.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.line.get',
-            {}
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type LinesResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<LinesResult>({
+        method: 'voximplant.line.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lines:', Object.keys(result).map(id => `${id}: ${result[id]}`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLines() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.line.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lines:', Object.keys(result).map(id => `${id}: ${result[id]}`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLines)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/lines/voximplant-line-outgoing-get.md
+++ b/api-reference/telephony/voximplant/lines/voximplant-line-outgoing-get.md
@@ -45,23 +45,69 @@
     https://**put_your_bitrix24_address**/rest/voximplant.line.outgoing.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.line.outgoing.get',
-            {}
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'voximplant.line.outgoing.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Current outgoing line ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOutgoingLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.line.outgoing.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Current outgoing line ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOutgoingLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/lines/voximplant-line-outgoing-set.md
+++ b/api-reference/telephony/voximplant/lines/voximplant-line-outgoing-set.md
@@ -60,25 +60,73 @@
     https://**put_your_bitrix24_address**/rest/voximplant.line.outgoing.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.line.outgoing.set',
-            {
-                LINE_ID: 'reg150907'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'voximplant.line.outgoing.set',
+        params: {
+          LINE_ID: 'reg150907',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Set outgoing line result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setOutgoingLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.line.outgoing.set',
+            params: {
+              LINE_ID: 'reg150907',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Set outgoing line result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setOutgoingLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/lines/voximplant-line-outgoing-sip-set.md
+++ b/api-reference/telephony/voximplant/lines/voximplant-line-outgoing-sip-set.md
@@ -54,25 +54,73 @@
     https://**put_your_bitrix24_address**/rest/voximplant.line.outgoing.sip.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.line.outgoing.sip.set',
-            {
-                CONFIG_ID: 9
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'voximplant.line.outgoing.sip.set',
+        params: {
+          CONFIG_ID: 9,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('SIP line set, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setOutgoingSipLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.line.outgoing.sip.set',
+            params: {
+              CONFIG_ID: 9,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('SIP line set, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setOutgoingSipLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/sip/voximplant-sip-add.md
+++ b/api-reference/telephony/voximplant/sip/voximplant-sip-add.md
@@ -84,29 +84,102 @@
     https://**put_your_bitrix24_address**/rest/voximplant.sip.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.sip.add',
-            {
-                TYPE: 'cloud',
-                TITLE: 'SIP line 1',
-                SERVER: 'sip.provider.com',
-                LOGIN: 'sip_user',
-                PASSWORD: 'secret'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SipAddResult = {
+      ID: string
+      TYPE: string
+      CONFIG_ID: string
+      REG_ID?: number
+      TITLE: string
+      SERVER: string
+      LOGIN: string
+      PASSWORD: string
+      AUTH_USER: string | null
+      OUTBOUND_PROXY: string | null
+      DETECT_LINE_NUMBER: string
+      LINE_DETECT_HEADER_ORDER: string
+      REGISTRATION_STATUS_CODE: number | null
+      REGISTRATION_ERROR_MESSAGE: string | null
+      INCOMING_SERVER?: string
+      INCOMING_LOGIN?: string
+      INCOMING_PASSWORD?: string
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SipAddResult>({
+        method: 'voximplant.sip.add',
+        params: {
+          TYPE: 'cloud',
+          TITLE: 'SIP line 1',
+          SERVER: 'sip.provider.com',
+          LOGIN: 'sip_user',
+          PASSWORD: 'secret',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created SIP line:', result.ID, result.TYPE, result.TITLE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSipLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.sip.add',
+            params: {
+              TYPE: 'cloud',
+              TITLE: 'SIP line 1',
+              SERVER: 'sip.provider.com',
+              LOGIN: 'sip_user',
+              PASSWORD: 'secret',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created SIP line:', result.ID, result.TYPE, result.TITLE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSipLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/sip/voximplant-sip-connector-status.md
+++ b/api-reference/telephony/voximplant/sip/voximplant-sip-connector-status.md
@@ -45,25 +45,76 @@
     https://**put_your_bitrix24_address**/rest/voximplant.sip.connector.status
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.sip.connector.status',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConnectorStatusResult = {
+      FREE_MINUTES: number
+      PAID: boolean
+      PAID_DATE_END?: ISODate | null
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConnectorStatusResult>({
+        method: 'voximplant.sip.connector.status',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Free minutes:', result.FREE_MINUTES, '| Paid:', result.PAID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchConnectorStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.sip.connector.status',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Free minutes:', result.FREE_MINUTES, '| Paid:', result.PAID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchConnectorStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/sip/voximplant-sip-delete.md
+++ b/api-reference/telephony/voximplant/sip/voximplant-sip-delete.md
@@ -54,25 +54,73 @@
     https://**put_your_bitrix24_address**/rest/voximplant.sip.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.sip.delete',
-            {
-                CONFIG_ID: 5
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'voximplant.sip.delete',
+        params: {
+          CONFIG_ID: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deletion result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSipLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.sip.delete',
+            params: {
+              CONFIG_ID: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deletion result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSipLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/sip/voximplant-sip-get.md
+++ b/api-reference/telephony/voximplant/sip/voximplant-sip-get.md
@@ -161,30 +161,113 @@
     https://**put_your_bitrix24_address**/rest/voximplant.sip.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.sip.get',
-            {
-                FILTER: {
-                    CONFIG_ID: [3, 7, 9]
-                },
-                SORT: 'CONFIG_ID',
-                ORDER: 'ASC'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Fetched SIP data:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each SIP line item returned in result[]
+    type SipLineItem = {
+      TYPE: string
+      CONFIG_ID: string
+      TITLE: string
+      REG_ID?: string
+      SERVER: string
+      LOGIN: string
+      PASSWORD: string
+      INCOMING_SERVER?: string
+      INCOMING_LOGIN?: string
+      INCOMING_PASSWORD?: string
+      AUTH_USER: string | null
+      OUTBOUND_PROXY: string | null
+      DETECT_LINE_NUMBER: string
+      LINE_DETECT_HEADER_ORDER: string
+      REGISTRATION_STATUS_CODE: string
+      REGISTRATION_ERROR_MESSAGE: string | null
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // voximplant.sip.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SipLineItem[]>({
+        method: 'voximplant.sip.get',
+        params: {
+          FILTER: {
+            CONFIG_ID: [3, 7, 9],
+          },
+          SORT: 'CONFIG_ID',
+          ORDER: 'ASC',
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('SIP lines fetched:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSipLines() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // voximplant.sip.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.sip.get',
+            params: {
+              FILTER: {
+                CONFIG_ID: [3, 7, 9],
+              },
+              SORT: 'CONFIG_ID',
+              ORDER: 'ASC',
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('SIP lines fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSipLines)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/sip/voximplant-sip-status.md
+++ b/api-reference/telephony/voximplant/sip/voximplant-sip-status.md
@@ -54,27 +54,82 @@
     https://**put_your_bitrix24_address**/rest/voximplant.sip.status
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.sip.status',
-            {
-                REG_ID: 150907
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SipStatusResult = {
+      REG_ID: number
+      LAST_UPDATED: string
+      ERROR_MESSAGE: string
+      STATUS_CODE: number
+      STATUS_RESULT: 'success' | 'error' | 'in_progress' | 'wait'
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SipStatusResult>({
+        method: 'voximplant.sip.status',
+        params: {
+          REG_ID: 150907,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.STATUS_RESULT, result.STATUS_CODE, result.ERROR_MESSAGE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSipStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.sip.status',
+            params: {
+              REG_ID: 150907,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.STATUS_RESULT, result.STATUS_CODE, result.ERROR_MESSAGE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSipStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/sip/voximplant-sip-update.md
+++ b/api-reference/telephony/voximplant/sip/voximplant-sip-update.md
@@ -68,26 +68,75 @@
     https://**put_your_bitrix24_address**/rest/voximplant.sip.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.sip.update',
-            {
-                CONFIG_ID: 5,
-                TITLE: 'SIP line 1 (updated)'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'voximplant.sip.update',
+        params: {
+          CONFIG_ID: 5,
+          TITLE: 'SIP line 1 (updated)',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('SIP line updated, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSipLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.sip.update',
+            params: {
+              CONFIG_ID: 5,
+              TITLE: 'SIP line 1 (updated)',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('SIP line updated, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSipLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/users/voximplant-user-activate-phone.md
+++ b/api-reference/telephony/voximplant/users/voximplant-user-activate-phone.md
@@ -55,25 +55,73 @@
     https://**put_your_bitrix24_address**/rest/voximplant.user.activatePhone
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.user.activatePhone',
-            {
-                USER_ID: 1269
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'voximplant.user.activatePhone',
+        params: {
+          USER_ID: 1269,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Phone activated, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function activatePhone() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.user.activatePhone',
+            params: {
+              USER_ID: 1269,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Phone activated, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', activatePhone)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/users/voximplant-user-get.md
+++ b/api-reference/telephony/voximplant/users/voximplant-user-get.md
@@ -56,25 +56,84 @@
     https://**put_your_bitrix24_address**/rest/voximplant.user.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.user.get',
-            {
-                USER_ID: [1269, 1271]
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    // Shape of each user settings entry returned in result[]
+    type VoximplantUserResult = {
+      ID: string
+      DEFAULT_LINE: string | null
+      PHONE_ENABLED: string
+      SIP_SERVER: string
+      SIP_LOGIN: string
+      SIP_PASSWORD: string | null
+      INNER_NUMBER: string | null
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<VoximplantUserResult[]>({
+        method: 'voximplant.user.get',
+        params: {
+          USER_ID: [1269, 1271],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User settings count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.user.get',
+            params: {
+              USER_ID: [1269, 1271],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User settings count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/voximplant-callback-start.md
+++ b/api-reference/telephony/voximplant/voximplant-callback-start.md
@@ -64,28 +64,85 @@
     https://**put_your_bitrix24_address**/rest/voximplant.callback.start
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.callback.start',
-            {
-                FROM_LINE: 'reg151083',
-                TO_NUMBER: '79991234567',
-                TEXT_TO_PRONOUNCE: 'Вам поступил запрос на обратный звонок',
-                VOICE: 'ruinternalfemale'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CallbackStartResult = {
+      RESULT: boolean
+      CALL_ID: string
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CallbackStartResult>({
+        method: 'voximplant.callback.start',
+        params: {
+          FROM_LINE: 'reg151083',
+          TO_NUMBER: '79991234567',
+          TEXT_TO_PRONOUNCE: 'You have received a callback request',
+          VOICE: 'ruinternalfemale',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.CALL_ID, result.RESULT)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startCallback() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.callback.start',
+            params: {
+              FROM_LINE: 'reg151083',
+              TO_NUMBER: '79991234567',
+              TEXT_TO_PRONOUNCE: 'You have received a callback request',
+              VOICE: 'ruinternalfemale',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.CALL_ID, result.RESULT)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startCallback)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/voximplant-infocall-start-with-sound.md
+++ b/api-reference/telephony/voximplant/voximplant-infocall-start-with-sound.md
@@ -58,27 +58,83 @@
     https://**put_your_bitrix24_address**/rest/voximplant.infocall.startwithsound
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.infocall.startwithsound',
-            {
-                FROM_LINE: 'reg151083',
-                TO_NUMBER: '79991234567',
-                URL: 'https://example.com/sound/notice.mp3'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type InfocallStartWithSoundResult = {
+      RESULT: boolean
+      CALL_ID: string
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<InfocallStartWithSoundResult>({
+        method: 'voximplant.infocall.startwithsound',
+        params: {
+          FROM_LINE: 'reg151083',
+          TO_NUMBER: '79991234567',
+          URL: 'https://example.com/sound/notice.mp3',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call started:', result.CALL_ID, 'Success:', result.RESULT)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startInfocallWithSound() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.infocall.startwithsound',
+            params: {
+              FROM_LINE: 'reg151083',
+              TO_NUMBER: '79991234567',
+              URL: 'https://example.com/sound/notice.mp3',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call started:', result.CALL_ID, 'Success:', result.RESULT)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startInfocallWithSound)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/voximplant-infocall-start-with-text.md
+++ b/api-reference/telephony/voximplant/voximplant-infocall-start-with-text.md
@@ -64,27 +64,83 @@
     https://**put_your_bitrix24_address**/rest/voximplant.infocall.startwithtext
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.infocall.startwithtext',
-            {
-                FROM_LINE: 'reg151083',
-                TO_NUMBER: '79991234567',
-                TEXT_TO_PRONOUNCE: 'Добрый день. Напоминаем о записи'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Data:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type InfocallStartWithTextResult = {
+      RESULT: boolean
+      CALL_ID: string
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<InfocallStartWithTextResult>({
+        method: 'voximplant.infocall.startwithtext',
+        params: {
+          FROM_LINE: 'reg151083',
+          TO_NUMBER: '79991234567',
+          TEXT_TO_PRONOUNCE: 'Good afternoon. Reminder about your appointment',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Infocall started:', result.RESULT, 'Call ID:', result.CALL_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startInfocallWithText() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.infocall.startwithtext',
+            params: {
+              FROM_LINE: 'reg151083',
+              TO_NUMBER: '79991234567',
+              TEXT_TO_PRONOUNCE: 'Good afternoon. Reminder about your appointment',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Infocall started:', result.RESULT, 'Call ID:', result.CALL_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startInfocallWithText)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/voximplant-statistic-get.md
+++ b/api-reference/telephony/voximplant/voximplant-statistic-get.md
@@ -196,31 +196,128 @@
     https://**put_your_bitrix24_address**/rest/voximplant.statistic.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.statistic.get',
-            {
-                FILTER: {
-                    ID: [1, 7],
-                    '>=CALL_START_DATE': '2025-01-01T00:00:00+03:00'
-                },
-                SORT: 'ID',
-                ORDER: 'ASC'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Statistics:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each CallStatRecord returned in result[]
+    type CallStatRecord = {
+      ID: string
+      PORTAL_USER_ID: string
+      PORTAL_NUMBER: string
+      PHONE_NUMBER: string
+      CALL_ID: string
+      EXTERNAL_CALL_ID: string | null
+      CALL_CATEGORY: string
+      CALL_LOG: string | null
+      CALL_DURATION: string
+      CALL_START_DATE: ISODate
+      CALL_RECORD_URL: string | null
+      CALL_VOTE: string | null
+      COST: string
+      COST_CURRENCY: string
+      CALL_FAILED_CODE: string
+      CALL_FAILED_REASON: string
+      CRM_ENTITY_TYPE: string
+      CRM_ENTITY_ID: string
+      CRM_ACTIVITY_ID: string
+      REST_APP_ID: string | null
+      REST_APP_NAME: string | null
+      TRANSCRIPT_ID: string | null
+      TRANSCRIPT_PENDING: string
+      SESSION_ID: string | null
+      REDIAL_ATTEMPT: string | null
+      COMMENT: string | null
+      RECORD_DURATION: string | null
+      RECORD_FILE_ID: number | null
+      CALL_TYPE: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // voximplant.statistic.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CallStatRecord[]>({
+        method: 'voximplant.statistic.get',
+        params: {
+          FILTER: {
+            ID: [1, 7],
+            '>=CALL_START_DATE': '2025-01-01T00:00:00+03:00',
+          },
+          SORT: 'ID',
+          ORDER: 'ASC',
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fetched call statistics:', result.length, 'records', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCallStatistics() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // voximplant.statistic.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.statistic.get',
+            params: {
+              FILTER: {
+                ID: [1, 7],
+                '>=CALL_START_DATE': '2025-01-01T00:00:00+03:00',
+              },
+              SORT: 'ID',
+              ORDER: 'ASC',
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fetched call statistics:', result.length, 'records', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCallStatistics)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/voximplant-tts-voices-get.md
+++ b/api-reference/telephony/voximplant/voximplant-tts-voices-get.md
@@ -45,25 +45,74 @@
     https://**put_your_bitrix24_address**/rest/voximplant.tts.voices.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.tts.voices.get',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type VoicesResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<VoicesResult>({
+        method: 'voximplant.tts.voices.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available TTS voices:', result)
+        console.info('Total voices:', Object.keys(result).length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getVoices() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.tts.voices.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available TTS voices:', result)
+          console.info('Total voices:', Object.keys(result).length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getVoices)
+    </script>
     ```
 
 - PHP

--- a/api-reference/telephony/voximplant/voximplant-url-get.md
+++ b/api-reference/telephony/voximplant/voximplant-url-get.md
@@ -45,25 +45,77 @@
     https://**put_your_bitrix24_address**/rest/voximplant.url.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'voximplant.url.get',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UrlGetResult = {
+      detail_statistics: string
+      buy_connector: string
+      edit_config: string
+      lines: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UrlGetResult>({
+        method: 'voximplant.url.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.detail_statistics, result.buy_connector, result.edit_config, result.lines)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getVoximplantUrls() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'voximplant.url.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.detail_statistics, result.buy_connector, result.edit_config, result.lines)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getVoximplantUrls)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.