### PR TITLE
docs(disk): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/disk/attached-object/disk-attached-object-get.md
+++ b/api-reference/disk/attached-object/disk-attached-object-get.md
@@ -55,27 +55,87 @@
     https://**put_your_bitrix24_address**/rest/disk.attachedObject.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.attachedObject.get',
-            {
-                id: 495,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved object:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachedObjectResult = {
+      ID: string
+      OBJECT_ID: string
+      MODULE_ID: string
+      ENTITY_TYPE: string
+      ENTITY_ID: string
+      CREATE_TIME: ISODate | null
+      CREATED_BY: string
+      DOWNLOAD_URL: string
+      NAME: string
+      SIZE: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachedObjectResult>({
+        method: 'disk.attachedObject.get',
+        params: {
+          id: 495,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Attached file:', result.NAME, 'size:', result.SIZE, 'entity:', result.ENTITY_TYPE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAttachedObject() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.attachedObject.get',
+            params: {
+              id: 495,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Attached file:', result.NAME, 'size:', result.SIZE, 'entity:', result.ENTITY_TYPE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAttachedObject)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-copy-to.md
+++ b/api-reference/disk/file/disk-file-copy-to.md
@@ -60,28 +60,97 @@
     https://**put_your_bitrix24_address**/rest/disk.file.copyto
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.copyto',
-            {
-                id: 9035,
-                targetFolderId: 8930,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Copied file with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFileCopyToResult = {
+      ID: number
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: number
+      GLOBAL_CONTENT_VERSION: number
+      FILE_ID: number
+      SIZE: string
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFileCopyToResult>({
+        method: 'disk.file.copyto',
+        params: {
+          id: 9035,
+          targetFolderId: 8930,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Copied file:', result.ID, result.NAME, result.DOWNLOAD_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function copyFileTo() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.copyto',
+            params: {
+              id: 9035,
+              targetFolderId: 8930,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Copied file:', result.ID, result.NAME, result.DOWNLOAD_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', copyFileTo)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-delete.md
+++ b/api-reference/disk/file/disk-file-delete.md
@@ -57,27 +57,73 @@
     https://**put_your_bitrix24_address**/rest/disk.file.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.delete',
-            {
-                id: 9035,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted file with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'disk.file.delete',
+        params: {
+          id: 9035,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.delete',
+            params: {
+              id: 9035,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-get-external-link.md
+++ b/api-reference/disk/file/disk-file-get-external-link.md
@@ -54,27 +54,73 @@
     https://**put_your_bitrix24_address**/rest/disk.file.getExternalLink
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.getExternalLink',
-            {
-                id: 8964,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('External link:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'disk.file.getExternalLink',
+        params: {
+          id: 8964,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External link:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getExternalLink() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.getExternalLink',
+            params: {
+              id: 8964,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External link:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getExternalLink)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-get-fields.md
+++ b/api-reference/disk/file/disk-file-get-fields.md
@@ -45,25 +45,78 @@
     https://**put_your_bitrix24_address**/rest/disk.file.getfields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.getfields',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('File fields:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      TYPE: string
+      USE_IN_FILTER: boolean
+      USE_IN_SHOW: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFileFieldsResult = Record<string, FieldItem>
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFileFieldsResult>({
+        method: 'disk.file.getfields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDiskFileFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.getfields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDiskFileFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-get-versions.md
+++ b/api-reference/disk/file/disk-file-get-versions.md
@@ -108,30 +108,103 @@
     https://**put_your_bitrix24_address**/rest/disk.file.getVersions
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.getVersions',
-            {
-                id: 9043,
-                filter: {
-                    NAME: '%тест%',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Fetched file versions:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each FileVersion returned in result[]
+    type FileVersion = {
+      ID: string
+      OBJECT_ID: string
+      SIZE: string
+      NAME: string
+      GLOBAL_CONTENT_VERSION: string
+      CREATE_TIME: ISODate | null
+      CREATED_BY: string
+      DOWNLOAD_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // disk.file.getVersions returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<FileVersion[]>({
+        method: 'disk.file.getVersions',
+        params: {
+          id: 9043,
+          filter: {
+            NAME: '%test%',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File versions:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFileVersions() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // disk.file.getVersions returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.getVersions',
+            params: {
+              id: 9043,
+              filter: {
+                NAME: '%test%',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File versions:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFileVersions)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-get.md
+++ b/api-reference/disk/file/disk-file-get.md
@@ -55,27 +55,95 @@
     https://**put_your_bitrix24_address**/rest/disk.file.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.get',
-            {
-                id: 9043,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved file data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFileGetResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION: string
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFileGetResult>({
+        method: 'disk.file.get',
+        params: {
+          id: 9043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.SIZE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDiskFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.get',
+            params: {
+              id: 9043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.SIZE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDiskFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-mark-deleted.md
+++ b/api-reference/disk/file/disk-file-mark-deleted.md
@@ -61,27 +61,95 @@
     https://**put_your_bitrix24_address**/rest/disk.file.markdeleted
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.markdeleted',
-            {
-                id: 9037,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('File marked as deleted:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MarkDeletedResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION: string
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MarkDeletedResult>({
+        method: 'disk.file.markdeleted',
+        params: {
+          id: 9037,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File moved to trash:', result.ID, result.NAME, 'DELETED_TYPE:', result.DELETED_TYPE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markFileDeleted() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.markdeleted',
+            params: {
+              id: 9037,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File moved to trash:', result.ID, result.NAME, 'DELETED_TYPE:', result.DELETED_TYPE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markFileDeleted)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-move-to.md
+++ b/api-reference/disk/file/disk-file-move-to.md
@@ -66,28 +66,97 @@
     https://**put_your_bitrix24_address**/rest/disk.file.moveto
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.moveto',
-            {
-                id: 8964,
-                targetFolderId: 9023
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Moved file with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveFileResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: number
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION: string
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MoveFileResult>({
+        method: 'disk.file.moveto',
+        params: {
+          id: 8964,
+          targetFolderId: 9023,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File moved:', result.NAME, '→ folder', result.PARENT_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveFileTo() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.moveto',
+            params: {
+              id: 8964,
+              targetFolderId: 9023,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File moved:', result.NAME, '→ folder', result.PARENT_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveFileTo)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-rename.md
+++ b/api-reference/disk/file/disk-file-rename.md
@@ -58,28 +58,97 @@
     https://**put_your_bitrix24_address**/rest/disk.file.rename
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.rename',
-            {
-                id: 8964,
-                newName: 'Новое имя файла.png'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Renamed file with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFileRenameResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION: string
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFileRenameResult>({
+        method: 'disk.file.rename',
+        params: {
+          id: 8964,
+          newName: 'New file name.png',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Renamed file:', result.ID, result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renameFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.rename',
+            params: {
+              id: 8964,
+              newName: 'New file name.png',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Renamed file:', result.ID, result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renameFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-restore-from-version.md
+++ b/api-reference/disk/file/disk-file-restore-from-version.md
@@ -58,28 +58,97 @@
     https://**put_your_bitrix24_address**/rest/disk.file.restoreFromVersion
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.restoreFromVersion',
-            {
-                id: 9043,
-                versionId: 7199
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Restored file from version with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FileInfo = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION: number
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FileInfo>({
+        method: 'disk.file.restoreFromVersion',
+        params: {
+          id: 9043,
+          versionId: 7199,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.UPDATE_TIME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function restoreFileFromVersion() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.restoreFromVersion',
+            params: {
+              id: 9043,
+              versionId: 7199,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.UPDATE_TIME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', restoreFileFromVersion)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-restore.md
+++ b/api-reference/disk/file/disk-file-restore.md
@@ -61,27 +61,95 @@
     https://**put_your_bitrix24_address**/rest/disk.file.restore
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.restore',
-            {
-                id: 9037,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('File restored:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFileRestoreResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: number
+      GLOBAL_CONTENT_VERSION: string
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFileRestoreResult>({
+        method: 'disk.file.restore',
+        params: {
+          id: 9037,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.NAME, result.ID, result.DOWNLOAD_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function restoreFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.restore',
+            params: {
+              id: 9037,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.NAME, result.ID, result.DOWNLOAD_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', restoreFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/file/disk-file-upload-version.md
+++ b/api-reference/disk/file/disk-file-upload-version.md
@@ -56,31 +56,103 @@
     https://**put_your_bitrix24_address**/rest/disk.file.uploadversion
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.file.uploadversion',
-            {
-                id: 9043,
-                fileContent: [
-                    'Тест №2.docx',
-                    'UEsDBBQABgAIAAAAIQBKvAJxbQEAACgGAAATAAgCW0NvbnRlbnRfVHlwZXNdLnhtbCCiBAI...AAAAAA0ADQBAAwAAA2EAAAAA',
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Uploaded file version with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UploadVersionResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION: number
+      FILE_ID: string
+      SIZE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UploadVersionResult>({
+        method: 'disk.file.uploadversion',
+        params: {
+          id: 9043,
+          fileContent: [
+            'Тест №2.docx',
+            'UEsDBBQABgAIAAAAIQBKvAJxbQEAACgGAAATAAgCW0NvbnRlbnRfVHlwZXNdLnhtbCCiBAI...AAAAAA0ADQBAAwAAA2EAAAAA',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Uploaded file version ID:', result.ID, 'Name:', result.NAME, 'Version:', result.GLOBAL_CONTENT_VERSION)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function uploadFileVersion() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.file.uploadversion',
+            params: {
+              id: 9043,
+              fileContent: [
+                'Тест №2.docx',
+                'UEsDBBQABgAIAAAAIQBKvAJxbQEAACgGAAATAAgCW0NvbnRlbnRfVHlwZXNdLnhtbCCiBAI...AAAAAA0ADQBAAwAAA2EAAAAA',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Uploaded file version ID:', result.ID, 'Name:', result.NAME, 'Version:', result.GLOBAL_CONTENT_VERSION)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', uploadFileVersion)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-add-subfolder.md
+++ b/api-reference/disk/folder/disk-folder-add-subfolder.md
@@ -63,30 +63,98 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.addsubfolder
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.addsubfolder',
-            {
-                id: 8907,
-                data: {
-                    NAME: 'Папка в папке',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created subfolder with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddSubfolderResult = {
+      ID: number
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: number
+      PARENT_ID: string
+      DELETED_TYPE: number
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddSubfolderResult>({
+        method: 'disk.folder.addsubfolder',
+        params: {
+          id: 8907,
+          data: {
+            NAME: 'Subfolder name',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created subfolder:', result.ID, result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSubfolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.addsubfolder',
+            params: {
+              id: 8907,
+              data: {
+                NAME: 'Subfolder name',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created subfolder:', result.ID, result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSubfolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-copy-to.md
+++ b/api-reference/disk/folder/disk-folder-copy-to.md
@@ -57,28 +57,94 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.copyto
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.copyto',
-            {
-                id: 8930,
-                targetFolderId: 8895,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Copied folder with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FolderCopyToResult = {
+      ID: number
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: number
+      PARENT_ID: string
+      DELETED_TYPE: number
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FolderCopyToResult>({
+        method: 'disk.folder.copyto',
+        params: {
+          id: 8930,
+          targetFolderId: 8895,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Copied folder:', result.ID, result.NAME, result.DETAIL_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function copyFolderTo() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.copyto',
+            params: {
+              id: 8930,
+              targetFolderId: 8895,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Copied folder:', result.ID, result.NAME, result.DETAIL_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', copyFolderTo)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-delete-tree.md
+++ b/api-reference/disk/folder/disk-folder-delete-tree.md
@@ -63,27 +63,73 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.deletetree
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.deletetree',
-            {
-                id: 8942,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted folder tree with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'disk.folder.deletetree',
+        params: {
+          id: 8942,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFolderTree() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.deletetree',
+            params: {
+              id: 8942,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFolderTree)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-get-children.md
+++ b/api-reference/disk/folder/disk-folder-get-children.md
@@ -124,33 +124,118 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.getchildren
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.getchildren',
-            {
-                id: 8907,
-                filter: {
-                    '>=CREATE_TIME': '2026-01-12'
-                },
-                order: {
-                    NAME: 'DESC'
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each FolderChild returned in result[]
+    type FolderChild = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: 'folder' | 'file'
+      REAL_OBJECT_ID?: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      GLOBAL_CONTENT_VERSION?: string
+      FILE_ID?: string
+      SIZE?: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DOWNLOAD_URL?: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // disk.folder.getchildren returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<FolderChild[]>({
+        method: 'disk.folder.getchildren',
+        params: {
+          id: 8907,
+          filter: {
+            '>=CREATE_TIME': '2026-01-12',
+          },
+          order: {
+            NAME: 'DESC',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Children count:', result.length, 'first item:', result[0]?.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFolderChildren() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // disk.folder.getchildren returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.getchildren',
+            params: {
+              id: 8907,
+              filter: {
+                '>=CREATE_TIME': '2026-01-12',
+              },
+              order: {
+                NAME: 'DESC',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Children count:', result.length, 'first item:', result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFolderChildren)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-get-external-link.md
+++ b/api-reference/disk/folder/disk-folder-get-external-link.md
@@ -54,27 +54,73 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.getexternallink
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.getexternallink',
-            {
-                id: 8930
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'disk.folder.getexternallink',
+        params: {
+          id: 8930,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External link:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFolderExternalLink() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.getexternallink',
+            params: {
+              id: 8930,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External link:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFolderExternalLink)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-get-fields.md
+++ b/api-reference/disk/folder/disk-folder-get-fields.md
@@ -45,25 +45,78 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.getfields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.getfields',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FolderField = {
+      TYPE: string
+      USE_IN_FILTER: boolean
+      USE_IN_SHOW: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FolderFieldsResult = Record<string, FolderField>
+
+    try {
+      const response = await $b24.actions.v2.call.make<FolderFieldsResult>({
+        method: 'disk.folder.getfields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result), result['NAME'])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFolderFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.getfields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result), result['NAME'])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFolderFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-get.md
+++ b/api-reference/disk/folder/disk-folder-get.md
@@ -54,27 +54,92 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.get',
-            {
-                id: 8930,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved folder with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFolderGetResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFolderGetResult>({
+        method: 'disk.folder.get',
+        params: {
+          id: 8930,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder:', result.NAME, '| Storage ID:', result.STORAGE_ID, '| Parent ID:', result.PARENT_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.get',
+            params: {
+              id: 8930,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder:', result.NAME, '| Storage ID:', result.STORAGE_ID, '| Parent ID:', result.PARENT_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-mark-deleted.md
+++ b/api-reference/disk/folder/disk-folder-mark-deleted.md
@@ -66,27 +66,92 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.markdeleted
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.markdeleted',
-            {
-                id: 8996,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Folder marked as deleted with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MarkDeletedResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: string
+      PARENT_ID: string
+      DELETED_TYPE: number
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MarkDeletedResult>({
+        method: 'disk.folder.markdeleted',
+        params: {
+          id: 8996,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder moved to trash:', result.ID, result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markFolderDeleted() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.markdeleted',
+            params: {
+              id: 8996,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder moved to trash:', result.ID, result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markFolderDeleted)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-move-to.md
+++ b/api-reference/disk/folder/disk-folder-move-to.md
@@ -62,28 +62,94 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.moveto
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.moveto',
-            {
-                id: 8968,
-                targetFolderId: 8907,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Folder moved with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveFolderResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: string
+      PARENT_ID: number
+      DELETED_TYPE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MoveFolderResult>({
+        method: 'disk.folder.moveto',
+        params: {
+          id: 8968,
+          targetFolderId: 8907,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder moved:', result.ID, result.NAME, result.DETAIL_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.moveto',
+            params: {
+              id: 8968,
+              targetFolderId: 8907,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder moved:', result.ID, result.NAME, result.DETAIL_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-rename.md
+++ b/api-reference/disk/folder/disk-folder-rename.md
@@ -56,28 +56,94 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.rename
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.rename',
-            {
-                id: 8968,
-                newName: 'Новое имя папки',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Folder renamed with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FolderRenameResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FolderRenameResult>({
+        method: 'disk.folder.rename',
+        params: {
+          id: 8968,
+          newName: 'New folder name',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder renamed:', result.ID, result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renameFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.rename',
+            params: {
+              id: 8968,
+              newName: 'New folder name',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder renamed:', result.ID, result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renameFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-restore.md
+++ b/api-reference/disk/folder/disk-folder-restore.md
@@ -54,27 +54,92 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.restore
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.restore',
-            {
-                id: 8996,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Restored folder with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFolderRestoreResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: string
+      PARENT_ID: string
+      DELETED_TYPE: number
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFolderRestoreResult>({
+        method: 'disk.folder.restore',
+        params: {
+          id: 8996,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Restored folder:', result.ID, result.NAME, result.DETAIL_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function restoreFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.restore',
+            params: {
+              id: 8996,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Restored folder:', result.ID, result.NAME, result.DETAIL_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', restoreFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-share-to-user.md
+++ b/api-reference/disk/folder/disk-folder-share-to-user.md
@@ -71,29 +71,77 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.sharetouser
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.folder.sharetouser',
-            {
-                id: 8994,
-                userId: 1271,
-                taskName: 'disk_access_read',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Folder shared to user with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'disk.folder.sharetouser',
+        params: {
+          id: 8994,
+          userId: 1271,
+          taskName: 'disk_access_read',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder shared to user:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function shareFolderToUser() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.sharetouser',
+            params: {
+              id: 8994,
+              userId: 1271,
+              taskName: 'disk_access_read',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder shared to user:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', shareFolderToUser)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/folder/disk-folder-upload-file.md
+++ b/api-reference/disk/folder/disk-folder-upload-file.md
@@ -85,37 +85,123 @@
     https://**put_your_bitrix24_address**/rest/disk.folder.uploadfile
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'disk.folder.uploadfile',
-            {
-                id: 8930,
-                data: {
-                    NAME: 'test.png',
-                },
-                fileContent: [
-                    'test.png',
-                    'iVBORw0KGgoAAAANSUhEUgAAAD4AAABDCAYAAADEfbZbAAAACXBIWXMAABJ0AAASdAHeZh94...rk5CYII=',
-                ],
-                generateUniqueName: true,
-                rights: [
-                    {
-                        TASK_ID: 75,
-                        ACCESS_CODE: 'U1271'
-                    }
-                ]
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UploadFileResult = {
+      ID: number
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: number
+      GLOBAL_CONTENT_VERSION: number
+      FILE_ID: number
+      SIZE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<UploadFileResult>({
+        method: 'disk.folder.uploadfile',
+        params: {
+          id: 8930,
+          data: {
+            NAME: 'test.png',
+          },
+          fileContent: [
+            'test.png',
+            'iVBORw0KGgoAAAANSUhEUgAAAD4AAABDCAYAAADEfbZbAAAACXBIWXMAABJ0AAASdAHeZh94...rk5CYII=',
+          ],
+          generateUniqueName: true,
+          rights: [
+            {
+              TASK_ID: 75,
+              ACCESS_CODE: 'U1271',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Uploaded file:', result.ID, result.NAME, result.DOWNLOAD_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function uploadFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.folder.uploadfile',
+            params: {
+              id: 8930,
+              data: {
+                NAME: 'test.png',
+              },
+              fileContent: [
+                'test.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAD4AAABDCAYAAADEfbZbAAAACXBIWXMAABJ0AAASdAHeZh94...rk5CYII=',
+              ],
+              generateUniqueName: true,
+              rights: [
+                {
+                  TASK_ID: 75,
+                  ACCESS_CODE: 'U1271',
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Uploaded file:', result.ID, result.NAME, result.DOWNLOAD_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', uploadFile)
+    </script>
     ```
 
 - PHP
@@ -249,27 +335,79 @@
         https://**put_your_bitrix24_address**/rest/disk.folder.uploadfile
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        try
-        {
-            const response = await $b24.callMethod(
-                'disk.folder.uploadfile',
-                {
-                    id: 8930,
-                }
-            );
-            
-            const result = response.getData().result;
-            console.log(result);
-            
-            processResult(result);
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type GetUploadUrlResult = {
+          field: string
+          uploadUrl: string
         }
-        catch( error )
-        {
-            console.error('Error:', error);
+
+        try {
+          const response = await $b24.actions.v2.call.make<GetUploadUrlResult>({
+            method: 'disk.folder.uploadfile',
+            params: {
+              id: 8930,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Upload URL:', result.uploadUrl, 'field:', result.field)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getUploadUrl() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'disk.folder.uploadfile',
+                params: {
+                  id: 8930,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Upload URL:', result.uploadUrl, 'field:', result.field)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getUploadUrl)
+        </script>
         ```
 
     - PHP

--- a/api-reference/disk/rights/disk-rights-get-tasks.md
+++ b/api-reference/disk/rights/disk-rights-get-tasks.md
@@ -47,25 +47,90 @@
     https://**put_your_bitrix24_address**/rest/disk.rights.getTasks
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.rights.getTasks',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each AccessTask returned in result[]
+    type AccessTask = {
+      ID: string
+      NAME: string
+      TITLE: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // disk.rights.getTasks returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<AccessTask[]>({
+        method: 'disk.rights.getTasks',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Access levels:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDiskRightsTasks() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // disk.rights.getTasks returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.rights.getTasks',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Access levels:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDiskRightsTasks)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-add-folder.md
+++ b/api-reference/disk/storage/disk-storage-add-folder.md
@@ -69,35 +69,110 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.addfolder
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.addfolder',
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddFolderResult = {
+      ID: number
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: number
+      PARENT_ID: string
+      DELETED_TYPE: number
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DETAIL_URL: string
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddFolderResult>({
+        method: 'disk.storage.addfolder',
+        params: {
+          id: 1357,
+          data: {
+            NAME: 'New folder',
+          },
+          rights: [
             {
-                id: 1357,
-                data: {
-                    NAME: 'Новая папка',
+              TASK_ID: 71,
+              ACCESS_CODE: 'U1271',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created folder:', result.ID, result.NAME, result.DETAIL_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.addfolder',
+            params: {
+              id: 1357,
+              data: {
+                NAME: 'New folder',
+              },
+              rights: [
+                {
+                  TASK_ID: 71,
+                  ACCESS_CODE: 'U1271',
                 },
-                rights: [
-                    {
-                        TASK_ID: 71,
-                        ACCESS_CODE: 'U1271'
-                    }
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created folder with ID:', result);
-        processResult(result);
-    }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created folder:', result.ID, result.NAME, result.DETAIL_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-get-children.md
+++ b/api-reference/disk/storage/disk-storage-get-children.md
@@ -124,33 +124,116 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.getchildren
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.getchildren',
-            {
-                id: 1357,
-                filter: {
-                    NAME: '%Папка%',
-                },
-                order: {
-                    NAME: 'DESC',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved children:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each StorageChildItem returned in result[]
+    type StorageChildItem = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      REAL_OBJECT_ID: string
+      PARENT_ID: string
+      DELETED_TYPE: string
+      CREATE_TIME: ISODate | null
+      UPDATE_TIME: ISODate | null
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DETAIL_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // disk.storage.getchildren returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<StorageChildItem[]>({
+        method: 'disk.storage.getchildren',
+        params: {
+          id: 1357,
+          filter: {
+            NAME: '%Folder%',
+          },
+          order: {
+            NAME: 'DESC',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Items found:', result.length, result[0]?.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStorageChildren() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // disk.storage.getchildren returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.getchildren',
+            params: {
+              id: 1357,
+              filter: {
+                NAME: '%Folder%',
+              },
+              order: {
+                NAME: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Items found:', result.length, result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStorageChildren)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-get-fields.md
+++ b/api-reference/disk/storage/disk-storage-get-fields.md
@@ -45,25 +45,80 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.getfields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.getfields',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved fields:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldDescriptor = {
+      TYPE: string
+      USE_IN_FILTER: boolean
+      USE_IN_SHOW: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StorageFieldsResult = Record<string, FieldDescriptor>
+
+    try {
+      const response = await $b24.actions.v2.call.make<StorageFieldsResult>({
+        method: 'disk.storage.getfields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Storage fields:', Object.keys(result))
+        console.info('ID field descriptor:', result['ID'])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStorageFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.getfields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Storage fields:', Object.keys(result))
+          console.info('ID field descriptor:', result['ID'])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStorageFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-get-for-app.md
+++ b/api-reference/disk/storage/disk-storage-get-for-app.md
@@ -41,25 +41,80 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.getforapp
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.getforapp',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Storage data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StorageResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      MODULE_ID: string
+      ENTITY_TYPE: string
+      ENTITY_ID: string
+      ROOT_OBJECT_ID: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StorageResult>({
+        method: 'disk.storage.getforapp',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Storage ID:', result.ID, 'Name:', result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStorageForApp() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.getforapp',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Storage ID:', result.ID, 'Name:', result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStorageForApp)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-get-list.md
+++ b/api-reference/disk/storage/disk-storage-get-list.md
@@ -114,69 +114,106 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.getlist
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each StorageItem returned in result[]
+    type StorageItem = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      MODULE_ID: string
+      ENTITY_TYPE: string
+      ENTITY_ID: string
+      ROOT_OBJECT_ID: string
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'disk.storage.getlist',
-        {
-        filter: {
-            NAME: '%Битрикс24%',
+      // disk.storage.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<StorageItem[]>({
+        method: 'disk.storage.getlist',
+        params: {
+          filter: {
+            NAME: '%Bitrix24%',
+          },
+          order: {
+            NAME: 'DESC',
+          },
+          start: 0,
         },
-        order: {
-            NAME: 'DESC'
-        }
-        },
-        (progress) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Storages:', result.length, result)
+      }
     } catch (error) {
-    console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+- JS (UMD)
 
-    try {
-    const generator = $b24.fetchListMethod('disk.storage.getlist', {
-        filter: {
-        NAME: '%Битрикс24%',
-        },
-        order: {
-        NAME: 'DESC'
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStorageList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // disk.storage.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.getlist',
+            params: {
+              filter: {
+                NAME: '%Bitrix24%',
+              },
+              order: {
+                NAME: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Storages:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+      }
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-    const response = await $b24.callMethod('disk.storage.getlist', {
-        filter: {
-        NAME: '%Битрикс24%',
-        },
-        order: {
-        NAME: 'DESC'
-        }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+      document.addEventListener('DOMContentLoaded', getStorageList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-get-types.md
+++ b/api-reference/disk/storage/disk-storage-get-types.md
@@ -45,25 +45,69 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.gettypes
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.gettypes',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved types:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'disk.storage.gettypes',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Storage types:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStorageTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.gettypes',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Storage types:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStorageTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-get.md
+++ b/api-reference/disk/storage/disk-storage-get.md
@@ -54,27 +54,84 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.get',
-            {
-                id: 1357
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved storage:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StorageGetResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      MODULE_ID: string
+      ENTITY_TYPE: string
+      ENTITY_ID: string
+      ROOT_OBJECT_ID: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StorageGetResult>({
+        method: 'disk.storage.get',
+        params: {
+          id: 1357,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Storage:', result.ID, result.NAME, result.ENTITY_TYPE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStorage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.get',
+            params: {
+              id: 1357,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Storage:', result.ID, result.NAME, result.ENTITY_TYPE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStorage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-rename.md
+++ b/api-reference/disk/storage/disk-storage-rename.md
@@ -52,28 +52,86 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.rename
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.rename',
-            {
-                id: 1366,
-                newName: 'Bitrix REST API'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Renamed storage:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StorageRenameResult = {
+      ID: string
+      NAME: string
+      CODE: string | null
+      MODULE_ID: string
+      ENTITY_TYPE: string
+      ENTITY_ID: string
+      ROOT_OBJECT_ID: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StorageRenameResult>({
+        method: 'disk.storage.rename',
+        params: {
+          id: 1366,
+          newName: 'Bitrix REST API',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Renamed storage:', result.ID, result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function renameStorage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.rename',
+            params: {
+              id: 1366,
+              newName: 'Bitrix REST API',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Renamed storage:', result.ID, result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', renameStorage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/storage/disk-storage-upload-file.md
+++ b/api-reference/disk/storage/disk-storage-upload-file.md
@@ -79,41 +79,123 @@
     https://**put_your_bitrix24_address**/rest/disk.storage.uploadfile
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.storage.uploadfile',
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UploadFileResult = {
+      ID: number
+      NAME: string
+      CODE: string | null
+      STORAGE_ID: string
+      TYPE: string
+      PARENT_ID: string
+      DELETED_TYPE: number
+      GLOBAL_CONTENT_VERSION: number
+      FILE_ID: number
+      SIZE: string
+      CREATE_TIME: ISODate
+      UPDATE_TIME: ISODate
+      DELETE_TIME: ISODate | null
+      CREATED_BY: string
+      UPDATED_BY: string
+      DELETED_BY: string | null
+      DOWNLOAD_URL: string
+      DETAIL_URL: string
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<UploadFileResult>({
+        method: 'disk.storage.uploadfile',
+        params: {
+          id: 1357,
+          data: {
+            NAME: 'picture.png',
+          },
+          fileContent: [
+            'picture.png',
+            'iVBORw0KGgoAAAANSUhEUgAAAD4AAABDCAYAAADEfbZbAAAACXBIWXMAABJ0AAASdAHeZh94...RK5CYII=',
+          ],
+          generateUniqueName: true,
+          rights: [
             {
-                id: 1357,
-                data: {
-                    NAME: 'picture.png'
+              TASK_ID: 79,
+              ACCESS_CODE: 'U1271',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.DOWNLOAD_URL)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function uploadFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.storage.uploadfile',
+            params: {
+              id: 1357,
+              data: {
+                NAME: 'picture.png',
+              },
+              fileContent: [
+                'picture.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAD4AAABDCAYAAADEfbZbAAAACXBIWXMAABJ0AAASdAHeZh94...RK5CYII=',
+              ],
+              generateUniqueName: true,
+              rights: [
+                {
+                  TASK_ID: 79,
+                  ACCESS_CODE: 'U1271',
                 },
-                fileContent: [
-                    'picture.png',
-                    'iVBORw0KGgoAAAANSUhEUgAAAD4AAABDCAYAAADEfbZbAAAACXBIWXMAABJ0AAASdAHeZh94...RK5CYII='
-                ],
-                generateUniqueName: true,
-                rights: [
-                    {
-                        TASK_ID: 79,
-                        ACCESS_CODE: 'U1271'
-                    }
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Uploaded file:', result);
-        
-        processResult(result);
-    }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.DOWNLOAD_URL)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', uploadFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/disk/version/disk-version-get.md
+++ b/api-reference/disk/version/disk-version-get.md
@@ -54,27 +54,85 @@
     https://**put_your_bitrix24_address**/rest/disk.version.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'disk.version.get',
-            {
-                id: 7169,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Fetched data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskVersionGetResult = {
+      ID: string
+      OBJECT_ID: string
+      SIZE: string
+      NAME: string
+      GLOBAL_CONTENT_VERSION: string
+      CREATE_TIME: ISODate
+      CREATED_BY: string
+      DOWNLOAD_URL: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskVersionGetResult>({
+        method: 'disk.version.get',
+        params: {
+          id: 7169,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Version:', result.ID, 'File:', result.NAME, 'Size:', result.SIZE, 'Created:', result.CREATE_TIME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getVersion() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'disk.version.get',
+            params: {
+              id: 7169,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Version:', result.ID, 'File:', result.NAME, 'Size:', result.SIZE, 'Created:', result.CREATE_TIME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getVersion)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.