### PR TITLE
docs(document-generator): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/document-generator/document-generator-document-add.md
+++ b/api-reference/document-generator/document-generator-document-add.md
@@ -145,46 +145,138 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.add',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentAddResult = {
+      document: {
+        id: number
+        title: string
+        number: string
+        templateId: string
+        provider: string
+        value: string
+        values: Record<string, unknown>
+        stampsEnabled: boolean
+        downloadUrl: string
+        downloadUrlMachine: string
+        publicUrl: string | null
+        isTransformationError: boolean
+        pullTag: string
+        emailDiskFile: number
+        createTime: ISODate
+        updateTime: ISODate
+        createdBy: number
+        updatedBy: number | null
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentAddResult>({
+        method: 'documentgenerator.document.add',
+        params: {
+          templateId: 53,
+          value: 'SUPPLY_CONTRACT_2026_015',
+          values: {
+            DocumentNumber: 'DG-2026-001',
+            CurrentDate: '2026-03-18T00:00:00+03:00',
+            ClientName: 'Romashka LLC',
+            ClientPhone: '+7 999 123-45-67',
+            Total: '125000',
+            Comment: 'Payment within 5 business days after signing',
+            UserName: 'Ivan Petrov',
+          },
+          fields: {
+            CurrentDate: {
+              TYPE: 'DATE',
+              FORMAT: {
+                format: 'd.m.Y',
+              },
+              TITLE: 'Contract date',
+            },
+          },
+          stampsEnabled: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created document id:', result.document.id, 'title:', result.document.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.document.add',
+            params: {
               templateId: 53,
               value: 'SUPPLY_CONTRACT_2026_015',
               values: {
-                  DocumentNumber: 'ДГ-2026-001',
-                  CurrentDate: '2026-03-18T00:00:00+03:00',
-                  ClientName: 'ООО Ромашка',
-                  ClientPhone: '+7 999 123-45-67',
-                  Total: '125000',
-                  Comment: 'Оплата в течение 5 рабочих дней после подписания',
-                  UserName: 'Иван Петров'
+                DocumentNumber: 'DG-2026-001',
+                CurrentDate: '2026-03-18T00:00:00+03:00',
+                ClientName: 'Romashka LLC',
+                ClientPhone: '+7 999 123-45-67',
+                Total: '125000',
+                Comment: 'Payment within 5 business days after signing',
+                UserName: 'Ivan Petrov',
               },
               fields: {
-                  CurrentDate: {
-                      TYPE: 'DATE',
-                      FORMAT: {
-                          format: 'd.m.Y'
-                      },
-                      TITLE: 'Дата договора'
-                  }
+                CurrentDate: {
+                  TYPE: 'DATE',
+                  FORMAT: {
+                    format: 'd.m.Y',
+                  },
+                  TITLE: 'Contract date',
+                },
               },
-              stampsEnabled: 1
-          }
-      );
+              stampsEnabled: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created document id:', result.document.id, 'title:', result.document.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDocument)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/document-generator-document-delete.md
+++ b/api-reference/document-generator/document-generator-document-delete.md
@@ -54,26 +54,74 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.delete
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.delete',
-          {
-              id: 51
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'documentgenerator.document.delete',
+        params: {
+          id: 51,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.document.delete',
+            params: {
+              id: 51,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info('Document deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDocument)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/document-generator-document-enable-public-url.md
+++ b/api-reference/document-generator/document-generator-document-enable-public-url.md
@@ -60,27 +60,81 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.enablepublicurl
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.enablepublicurl',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EnablePublicUrlResult = {
+      publicUrl: string | null
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<EnablePublicUrlResult>({
+        method: 'documentgenerator.document.enablepublicurl',
+        params: {
+          id: 51,
+          status: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Public URL:', result.publicUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function enablePublicUrl() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.document.enablepublicurl',
+            params: {
               id: 51,
-              status: 1
-          }
-      );
+              status: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Public URL:', result.publicUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', enablePublicUrl)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/document-generator-document-get-fields.md
+++ b/api-reference/document-generator/document-generator-document-get-fields.md
@@ -62,35 +62,107 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.getfields
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.getfields',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = {
+      documentFields: Record<string, FieldInfo>
+    }
+
+    type FieldInfo = {
+      title?: string
+      value?: string
+      default?: string
+      group?: string[]
+      chain?: string | unknown[]
+      required?: 'Y' | 'N'
+      type?: string
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'documentgenerator.document.getfields',
+        params: {
+          id: 51,
+          values: {
+            DocumentNumber: 'DG-2026-001',
+            CurrentDate: '2026-03-18T00:00:00+03:00',
+            ClientName: 'LLC Romashka',
+            ClientPhone: '+7 999 123-45-67',
+            Total: '51000',
+            Comment: 'Payment within 5 business days after signing',
+            UserName: 'Ivan Petrov',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document fields:', Object.keys(result.documentFields))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.document.getfields',
+            params: {
               id: 51,
               values: {
-                  DocumentNumber: 'ДГ-2026-001',
-                  CurrentDate: '2026-03-18T00:00:00+03:00',
-                  ClientName: 'ООО Ромашка',
-                  ClientPhone: '+7 999 123-45-67',
-                  Total: '51000',
-                  Comment: 'Оплата в течение 5 рабочих дней после подписания',
-                  UserName: 'Иван Петров'
-              }
-          }
-      );
+                DocumentNumber: 'DG-2026-001',
+                CurrentDate: '2026-03-18T00:00:00+03:00',
+                ClientName: 'LLC Romashka',
+                ClientPhone: '+7 999 123-45-67',
+                Total: '51000',
+                Comment: 'Payment within 5 business days after signing',
+                UserName: 'Ivan Petrov',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document fields:', Object.keys(result.documentFields))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentFields)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/document-generator-document-get.md
+++ b/api-reference/document-generator/document-generator-document-get.md
@@ -54,26 +54,105 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.get
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.get',
-          {
-              id: 51
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentGetResult = {
+      document: {
+        id: string,
+        title: string,
+        number: string,
+        templateId: string,
+        provider: string,
+        value: string,
+        values: Record<string, string | boolean>,
+        stampsEnabled: boolean,
+        isTransformationError: boolean,
+        downloadUrl: string,
+        downloadUrlMachine: string,
+        pdfUrl: string | null,
+        pdfUrlMachine: string | null,
+        printUrl: string | null,
+        printUrlMachine: string | null,
+        imageUrl: string | null,
+        imageUrlMachine: string | null,
+        publicUrl: string | null,
+        pullTag: string,
+        emailDiskFile: number,
+        createTime: ISODate,
+        updateTime: ISODate,
+        createdBy: string,
+        updatedBy: number | null,
+        publicUrlView: { time: ISODate } | null,
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentGetResult>({
+        method: 'documentgenerator.document.get',
+        params: {
+          id: 51,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document.id, result.document.title, result.document.downloadUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.document.get',
+            params: {
+              id: 51,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info(result.document.id, result.document.title, result.document.downloadUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocument)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/document-generator-document-list.md
+++ b/api-reference/document-generator/document-generator-document-list.md
@@ -180,47 +180,156 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.list
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.list',
-          {
-              select: [
-                  'id',
-                  'title',
-                  'number',
-                  'templateId',
-                  'provider',
-                  'value',
-                  'fileId',
-                  'imageId',
-                  'pdfId',
-                  'createTime',
-                  'updateTime',
-                  'createdBy'
-              ],
-              order: {
-                  updateTime: 'desc',
-                  id: 'desc'
-              },
-              filter: {
-                  '>=createTime': '2026-03-18T00:00:00+03:00',
-                  '%title': 'ДГ-2026'
-              },
-              start: 0
-          }
-      );
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const result = response.getData().result;
-      console.log(result);
+  declare const $b24: B24Frame
+
+  // Shape of the payload returned in result (match the "response handling" section of the page)
+  type DocumentListResult = {
+    documents: {
+      id: string
+      title: string
+      number: string
+      templateId: string
+      provider: string
+      value: string
+      fileId: number
+      imageId: number
+      pdfId: number
+      createTime: ISODate | null
+      updateTime: ISODate | null
+      createdBy: string
+      updatedBy: number
+      downloadUrl: string
+      pdfUrl: string
+      imageUrl: string
+      stampsEnabled: boolean
+      downloadUrlMachine: string
+      pdfUrlMachine: string
+      imageUrlMachine: string
+      values: object | null
+    }[]
   }
-  catch (error)
-  {
-      console.error(error);
+
+  try {
+    // documentgenerator.document.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+    const response = await $b24.actions.v2.call.make<DocumentListResult>({
+      method: 'documentgenerator.document.list',
+      params: {
+        select: [
+          'id',
+          'title',
+          'number',
+          'templateId',
+          'provider',
+          'value',
+          'fileId',
+          'imageId',
+          'pdfId',
+          'createTime',
+          'updateTime',
+          'createdBy',
+        ],
+        order: {
+          updateTime: 'desc',
+          id: 'desc',
+        },
+        filter: {
+          '>=createTime': '2026-03-18T00:00:00+03:00',
+          '%title': 'ДГ-2026',
+        },
+        start: 0,
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info('Documents on page:', result.documents.length)
+      console.info('Documents:', result.documents)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function fetchDocumentList() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        // documentgenerator.document.list returns a single page (max 50 records). For the whole result set
+        // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+        // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+        // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+        // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.document.list',
+          params: {
+            select: [
+              'id',
+              'title',
+              'number',
+              'templateId',
+              'provider',
+              'value',
+              'fileId',
+              'imageId',
+              'pdfId',
+              'createTime',
+              'updateTime',
+              'createdBy',
+            ],
+            order: {
+              updateTime: 'desc',
+              id: 'desc',
+            },
+            filter: {
+              '>=createTime': '2026-03-18T00:00:00+03:00',
+              '%title': 'ДГ-2026',
+            },
+            start: 0,
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info('Documents on page:', result.documents.length)
+        console.info('Documents:', result.documents)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', fetchDocumentList)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/document-generator-document-update.md
+++ b/api-reference/document-generator/document-generator-document-update.md
@@ -118,36 +118,125 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.document.update
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.document.update',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentUpdateResult = {
+      document: {
+        id: string
+        title: string
+        number: string
+        templateId: string
+        provider: string
+        value: string
+        values: Record<string, unknown>
+        stampsEnabled: boolean
+        downloadUrl: string
+        pdfUrl: string
+        imageUrl: string
+        printUrl: string
+        downloadUrlMachine: string
+        pdfUrlMachine: string
+        imageUrlMachine: string
+        printUrlMachine: string
+        publicUrl: string
+        publicUrlView: { time: ISODate | null }
+        isTransformationError: boolean
+        pullTag: string
+        emailDiskFile: number
+        createTime: ISODate | null
+        updateTime: ISODate | null
+        createdBy: string
+        updatedBy: number | null
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentUpdateResult>({
+        method: 'documentgenerator.document.update',
+        params: {
+          id: 51,
+          values: {
+            DocumentNumber: 'DG-2026-001',
+            CurrentDate: '2026-03-20T00:00:00+03:00',
+            ClientName: 'Romashka LLC',
+            ClientPhone: '+7 999 123-45-67',
+            Total: '130000',
+            Comment: 'Payment within 3 business days after signing',
+            UserName: 'Ivan Petrov',
+          },
+          stampsEnabled: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document.id, result.document.title, result.document.downloadUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.document.update',
+            params: {
               id: 51,
               values: {
-                  DocumentNumber: 'ДГ-2026-001',
-                  CurrentDate: '2026-03-20T00:00:00+03:00',
-                  ClientName: 'ООО Ромашка',
-                  ClientPhone: '+7 999 123-45-67',
-                  Total: '130000',
-                  Comment: 'Оплата в течение 3 рабочих дней после подписания',
-                  UserName: 'Иван Петров'
+                DocumentNumber: 'DG-2026-001',
+                CurrentDate: '2026-03-20T00:00:00+03:00',
+                ClientName: 'Romashka LLC',
+                ClientPhone: '+7 999 123-45-67',
+                Total: '130000',
+                Comment: 'Payment within 3 business days after signing',
+                UserName: 'Ivan Petrov',
               },
-              stampsEnabled: 1
-          }
-      );
+              stampsEnabled: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.document.id, result.document.title, result.document.downloadUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDocument)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/numerators/document-generator-numerator-add.md
+++ b/api-reference/document-generator/numerators/document-generator-numerator-add.md
@@ -167,40 +167,123 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.numerator.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.numerator.add',
-          {
-              fields: {
-                  name: 'REST Invoice Numerator',
-                  template: 'INV-{NUMBER}',
-                  settings: {
-                      Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
-                          start: 1000,
-                          step: 5,
-                          length: 8,
-                          padString: '0',
-                          periodicBy: 'year',
-                          timezone: 'Europe/Moscow',
-                          isDirectNumeration: 0
-                      }
-                  }
-              }
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorAddResult = {
+      numerator: {
+        id: number
+        name: string
+        template: string
+        code: string | null
+        settings: {
+          Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+            start: number
+            step: number
+            length: number
+            padString: string
+            periodicBy: string
+            timezone: string
+            isDirectNumeration: boolean
           }
-      );
+        }
+      }
+    }
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+    try {
+      const response = await $b24.actions.v2.call.make<NumeratorAddResult>({
+        method: 'documentgenerator.numerator.add',
+        params: {
+          fields: {
+            name: 'REST Invoice Numerator',
+            template: 'INV-{NUMBER}',
+            settings: {
+              Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                start: 1000,
+                step: 5,
+                length: 8,
+                padString: '0',
+                periodicBy: 'year',
+                timezone: 'Europe/Moscow',
+                isDirectNumeration: 0,
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.numerator.id, result.numerator.name, result.numerator.template)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.numerator.add',
+            params: {
+              fields: {
+                name: 'REST Invoice Numerator',
+                template: 'INV-{NUMBER}',
+                settings: {
+                  Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                    start: 1000,
+                    step: 5,
+                    length: 8,
+                    padString: '0',
+                    periodicBy: 'year',
+                    timezone: 'Europe/Moscow',
+                    isDirectNumeration: 0,
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.numerator.id, result.numerator.name, result.numerator.template)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addNumerator)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/numerators/document-generator-numerator-delete.md
+++ b/api-reference/document-generator/numerators/document-generator-numerator-delete.md
@@ -60,26 +60,72 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.numerator.delete
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.numerator.delete',
-          {
-              id: 57
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'documentgenerator.numerator.delete',
+        params: {
+          id: 57,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        console.info('Numerator deleted successfully')
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.numerator.delete',
+            params: {
+              id: 57,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          console.info('Numerator deleted successfully')
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteNumerator)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/numerators/document-generator-numerator-get.md
+++ b/api-reference/document-generator/numerators/document-generator-numerator-get.md
@@ -54,25 +54,92 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.numerator.get
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.numerator.get',
-          {
-              id: 55
-          }
-      );
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
 
-      const result = response.getData().result;
-      console.log(result);
+  declare const $b24: B24Frame
+
+  // Shape of the payload returned in result (match the "response handling" section of the page)
+  type NumeratorGetResult = {
+    numerator: {
+      id: string
+      name: string
+      template: string
+      code: string | null
+      settings: Record<string, {
+        start: number
+        step: number
+        length: number
+        padString: string
+        periodicBy: string
+        timezone: string
+        isDirectNumeration: boolean
+      }>
+    }
   }
-  catch (error)
-  {
-      console.error(error);
+
+  try {
+    const response = await $b24.actions.v2.call.make<NumeratorGetResult>({
+      method: 'documentgenerator.numerator.get',
+      params: {
+        id: 55,
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info(result.numerator.id, result.numerator.name, result.numerator.template)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function getNumerator() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.numerator.get',
+          params: {
+            id: 55,
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info(result.numerator.id, result.numerator.name, result.numerator.template)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', getNumerator)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/numerators/document-generator-numerator-list.md
+++ b/api-reference/document-generator/numerators/document-generator-numerator-list.md
@@ -58,26 +58,107 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.numerator.list
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.numerator.list',
-          {
-              start: 0
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type NumeratorItem = {
+      id: string
+      name: string
+      template: string
+      code: string | null
+      settings: {
+        Bitrix_Main_Numerator_Generator_SequentNumberGenerator?: {
+          start: number
+          step: number
+          length: number
+          padString: string
+          periodicBy: string | null
+          timezone: string | null
+          isDirectNumeration: boolean
+        }
+      }
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorListResult = {
+      numerators: NumeratorItem[]
+    }
+
+    try {
+      // documentgenerator.numerator.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<NumeratorListResult>({
+        method: 'documentgenerator.numerator.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Numerators:', result.numerators, 'Count:', result.numerators.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchNumeratorList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // documentgenerator.numerator.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.numerator.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info('Numerators:', result.numerators, 'Count:', result.numerators.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchNumeratorList)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/numerators/document-generator-numerator-update.md
+++ b/api-reference/document-generator/numerators/document-generator-numerator-update.md
@@ -171,41 +171,123 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.numerator.update
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.numerator.update',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorUpdateResult = {
+      id: string
+      name: string
+      template: string
+      code: string | null
+      settings: {
+        Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+          start: number
+          step: number
+          length: number
+          padString: string
+          periodicBy: string
+          timezone: string
+          isDirectNumeration: boolean
+        }
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<NumeratorUpdateResult>({
+        method: 'documentgenerator.numerator.update',
+        params: {
+          id: 55,
+          fields: {
+            name: 'REST Invoice Numerator Updated',
+            template: 'INV-UPD-{NUMBER}',
+            settings: {
+              Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                start: 2000,
+                step: 10,
+                length: 8,
+                padString: '0',
+                periodicBy: 'year',
+                timezone: 'Europe/Moscow',
+                isDirectNumeration: 0,
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.template)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.numerator.update',
+            params: {
               id: 55,
               fields: {
-                  name: 'REST Invoice Numerator Updated',
-                  template: 'INV-UPD-{NUMBER}',
-                  settings: {
-                      Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
-                          start: 2000,
-                          step: 10,
-                          length: 8,
-                          padString: '0',
-                          periodicBy: 'year',
-                          timezone: 'Europe/Moscow',
-                          isDirectNumeration: 0
-                      }
-                  }
-              }
-          }
-      );
+                name: 'REST Invoice Numerator Updated',
+                template: 'INV-UPD-{NUMBER}',
+                settings: {
+                  Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                    start: 2000,
+                    step: 10,
+                    length: 8,
+                    padString: '0',
+                    periodicBy: 'year',
+                    timezone: 'Europe/Moscow',
+                    isDirectNumeration: 0,
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.template)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateNumerator)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/region/document-generator-region-add.md
+++ b/api-reference/document-generator/region/document-generator-region-add.md
@@ -124,36 +124,107 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.region.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.region.add',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddRegionResult = {
+      region: {
+        id: string
+        title: string
+        languageId: string
+        formatDate: string
+        formatDatetime: string
+        formatName: string
+        phrases: Record<string, string>
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddRegionResult>({
+        method: 'documentgenerator.region.add',
+        params: {
+          fields: {
+            title: 'Russia (Custom)',
+            languageId: 'ru',
+            formatDate: 'DD.MM.YYYY',
+            formatDatetime: 'DD.MM.YYYY HH:MI:SS',
+            formatName: '#LAST_NAME# #NAME# #SECOND_NAME#',
+            phrases: {
+              TAX_INCLUDED: 'VAT included in price',
+              TAX_NOT_INCLUDED: 'VAT not included in price',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.region.id, result.region.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRegion() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.region.add',
+            params: {
               fields: {
-                  title: 'Россия (Пользовательский)',
-                  languageId: 'ru',
-                  formatDate: 'DD.MM.YYYY',
-                  formatDatetime: 'DD.MM.YYYY HH:MI:SS',
-                  formatName: '#LAST_NAME# #NAME# #SECOND_NAME#',
-                  phrases: {
-                      TAX_INCLUDED: 'НДС включен в цену',
-                      TAX_NOT_INCLUDED: 'НДС не включен в цену'
-                  }
-              }
+                title: 'Russia (Custom)',
+                languageId: 'ru',
+                formatDate: 'DD.MM.YYYY',
+                formatDatetime: 'DD.MM.YYYY HH:MI:SS',
+                formatName: '#LAST_NAME# #NAME# #SECOND_NAME#',
+                phrases: {
+                  TAX_INCLUDED: 'VAT included in price',
+                  TAX_NOT_INCLUDED: 'VAT not included in price',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
-  
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+
+          const result = response.getData().result
+          console.info(result.region.id, result.region.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRegion)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/region/document-generator-region-delete.md
+++ b/api-reference/document-generator/region/document-generator-region-delete.md
@@ -54,25 +54,73 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.region.delete
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.region.delete',
-          {
-              id: 1
-          }
-      );
-  
-      const result = response.getData().result;
-      console.log(result);
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
+
+  declare const $b24: B24Frame
+
+  try {
+    const response = await $b24.actions.v2.call.make<null>({
+      method: 'documentgenerator.region.delete',
+      params: {
+        id: 1,
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info('Region deleted, result:', result)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
-  catch (error)
-  {
-      console.error(error);
-  }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function deleteRegion() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.region.delete',
+          params: {
+            id: 1,
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info('Region deleted, result:', result)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', deleteRegion)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/region/document-generator-region-get.md
+++ b/api-reference/document-generator/region/document-generator-region-get.md
@@ -54,25 +54,86 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.region.get
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.region.get',
-          {
-              id: '1'
-          }
-      );
-  
-      const result = response.getData().result;
-      console.log(result);
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
+
+  declare const $b24: B24Frame
+
+  // Shape of the payload returned in result (match the "response handling" section of the page)
+  type RegionGetResult = {
+    region: {
+      id: string
+      title: string
+      languageId: string
+      formatDate: string
+      formatDatetime: string
+      formatName: string
+      phrases: Record<string, string>
+    }
   }
-  catch (error)
-  {
-      console.error(error);
+
+  try {
+    const response = await $b24.actions.v2.call.make<RegionGetResult>({
+      method: 'documentgenerator.region.get',
+      params: {
+        id: '1',
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info(result.region.id, result.region.title, result.region.languageId)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function getRegion() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.region.get',
+          params: {
+            id: '1',
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info(result.region.id, result.region.title, result.region.languageId)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', getRegion)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/region/document-generator-region-list.md
+++ b/api-reference/document-generator/region/document-generator-region-list.md
@@ -43,20 +43,85 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.region.list
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod('documentgenerator.region.list');
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type RegionItem = {
+      id?: string
+      code: string
+      title: string
+      languageId: string
+      formatDate?: string
+      formatDatetime?: string
+      formatName?: string
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RegionsResult = {
+      regions: Record<string, RegionItem>
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<RegionsResult>({
+        method: 'documentgenerator.region.list',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.regions).length, result.regions)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchRegionList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.region.list',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.regions).length, result.regions)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchRegionList)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/region/document-generator-region-update.md
+++ b/api-reference/document-generator/region/document-generator-region-update.md
@@ -122,32 +122,100 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.region.update
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.region.update',
-          {
-              id: 1,
-              fields: {
-                  title: 'Россия (Пользовательский)',
-                  formatDate: 'YYYY-MM-DD',
-                  phrases: {
-                      TAX_INCLUDED: 'Налог включен в цену'
-                  }
-              }
-          }
-      );
-  
-      const result = response.getData().result;
-      console.log(result);
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
+
+  declare const $b24: B24Frame
+
+  // Shape of the payload returned in result (match the "response handling" section of the page)
+  type RegionUpdateResult = {
+    region: {
+      id: string
+      title: string
+      languageId: string
+      formatDate: string
+      formatDatetime: string
+      formatName: string
+      phrases: Record<string, string>
+    }
   }
-  catch (error)
-  {
-      console.error(error);
+
+  try {
+    const response = await $b24.actions.v2.call.make<RegionUpdateResult>({
+      method: 'documentgenerator.region.update',
+      params: {
+        id: 1,
+        fields: {
+          title: 'Russia (Custom)',
+          formatDate: 'YYYY-MM-DD',
+          phrases: {
+            TAX_INCLUDED: 'Tax is included in the price',
+          },
+        },
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info(result.region.id, result.region.title, result.region.languageId)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function updateRegion() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.region.update',
+          params: {
+            id: 1,
+            fields: {
+              title: 'Russia (Custom)',
+              formatDate: 'YYYY-MM-DD',
+              phrases: {
+                TAX_INCLUDED: 'Tax is included in the price',
+              },
+            },
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info(result.region.id, result.region.title, result.region.languageId)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', updateRegion)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/role/document-generator-role-add.md
+++ b/api-reference/document-generator/role/document-generator-role-add.md
@@ -167,41 +167,125 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.role.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.role.add',
-          {
-              fields: {
-                  name: 'Редакторы шаблонов',
-                  code: 'DOCGEN_TEMPLATE_EDITORS',
-                  permissions: {
-                      SETTINGS: {
-                          MODIFY: ''
-                      },
-                      TEMPLATES: {
-                          MODIFY: 'D'
-                      },
-                      DOCUMENTS: {
-                          MODIFY: 'X',
-                          VIEW: 'X'
-                      }
-                  }
-              }
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoleAddResult = {
+      role: {
+        id: number
+        name: string
+        code: string
+        permissions: {
+          settings: {
+            modify: string
           }
-      );
+          templates: {
+            modify: string
+          }
+          documents: {
+            modify: string
+            view: string
+          }
+        }
+      }
+    }
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+    try {
+      const response = await $b24.actions.v2.call.make<RoleAddResult>({
+        method: 'documentgenerator.role.add',
+        params: {
+          fields: {
+            name: 'Template Editors',
+            code: 'DOCGEN_TEMPLATE_EDITORS',
+            permissions: {
+              SETTINGS: {
+                MODIFY: '',
+              },
+              TEMPLATES: {
+                MODIFY: 'D',
+              },
+              DOCUMENTS: {
+                MODIFY: 'X',
+                VIEW: 'X',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added role:', result.role.id, result.role.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRole() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.role.add',
+            params: {
+              fields: {
+                name: 'Template Editors',
+                code: 'DOCGEN_TEMPLATE_EDITORS',
+                permissions: {
+                  SETTINGS: {
+                    MODIFY: '',
+                  },
+                  TEMPLATES: {
+                    MODIFY: 'D',
+                  },
+                  DOCUMENTS: {
+                    MODIFY: 'X',
+                    VIEW: 'X',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added role:', result.role.id, result.role.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRole)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/role/document-generator-role-delete.md
+++ b/api-reference/document-generator/role/document-generator-role-delete.md
@@ -54,26 +54,74 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.role.delete
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.role.delete',
-          {
-              id: 9
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'documentgenerator.role.delete',
+        params: {
+          id: 9,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Role deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteRole() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.role.delete',
+            params: {
+              id: 9,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info('Role deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteRole)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/role/document-generator-role-fill-accesses.md
+++ b/api-reference/document-generator/role/document-generator-role-fill-accesses.md
@@ -116,39 +116,100 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.role.fillaccesses
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.role.fillaccesses',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'documentgenerator.role.fillaccesses',
+        params: {
+          accesses: [
+            {
+              roleId: 9,
+              accessCode: 'U1',
+            },
+            {
+              roleId: 9,
+              accessCode: 'D1',
+            },
+            {
+              roleId: 9,
+              accessCode: 'UA',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Role accesses applied successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fillRoleAccesses() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.role.fillaccesses',
+            params: {
               accesses: [
-                  {
-                      roleId: 9,
-                      accessCode: 'U1'
-                  },
-                  {
-                      roleId: 9,
-                      accessCode: 'D1'
-                  },
-                  {
-                      roleId: 9,
-                      accessCode: 'UA'
-                  }
-              ]
-          }
-      );
+                {
+                  roleId: 9,
+                  accessCode: 'U1',
+                },
+                {
+                  roleId: 9,
+                  accessCode: 'D1',
+                },
+                {
+                  roleId: 9,
+                  accessCode: 'UA',
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Role accesses applied successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fillRoleAccesses)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/role/document-generator-role-get.md
+++ b/api-reference/document-generator/role/document-generator-role-get.md
@@ -54,26 +54,95 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.role.get
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.role.get',
-          {
-              id: 9
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoleGetResult = {
+      role: {
+        id: number
+        name: string
+        code: string
+        permissions: {
+          settings: {
+            modify: string
           }
-      );
+          templates: {
+            modify: string
+          }
+          documents: {
+            modify: string
+            view: string
+          }
+        }
+      }
+    }
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+    try {
+      const response = await $b24.actions.v2.call.make<RoleGetResult>({
+        method: 'documentgenerator.role.get',
+        params: {
+          id: 9,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.role.id, result.role.name, result.role.code, result.role.permissions)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRoleById() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.role.get',
+            params: {
+              id: 9,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.role.id, result.role.name, result.role.code, result.role.permissions)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRoleById)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/role/document-generator-role-list.md
+++ b/api-reference/document-generator/role/document-generator-role-list.md
@@ -58,25 +58,94 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.role.list
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.role.list',
-          {
-              start: 0
-          }
-      );
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
 
-      const result = response.getData().result;
-      console.log(result);
+  declare const $b24: B24Frame
+
+  type RoleItem = {
+    id: number
+    name: string
+    code: string
   }
-  catch (error)
-  {
-      console.error(error);
+
+  // Shape of the payload returned in result (match the "response handling" section of the page)
+  type RoleListResult = {
+    roles: RoleItem[]
   }
+
+  try {
+    // documentgenerator.role.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+    const response = await $b24.actions.v2.call.make<RoleListResult>({
+      method: 'documentgenerator.role.list',
+      params: {
+        start: 0,
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info(result.roles.length, result.roles)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
+  }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function listRoles() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        // documentgenerator.role.list returns a single page (max 50 records). For the whole result set
+        // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+        // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+        // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+        // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.role.list',
+          params: {
+            start: 0,
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info(result.roles.length, result.roles)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', listRoles)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/role/document-generator-role-update.md
+++ b/api-reference/document-generator/role/document-generator-role-update.md
@@ -171,41 +171,118 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.role.update
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.role.update',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoleUpdateResult = {
+      role: {
+        id: number
+        name: string
+        code: string
+        permissions: {
+          settings: { modify: string }
+          templates: { modify: string }
+          documents: { modify: string; view: string }
+        }
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<RoleUpdateResult>({
+        method: 'documentgenerator.role.update',
+        params: {
+          id: 9,
+          fields: {
+            name: 'Editors of own templates',
+            permissions: {
+              SETTINGS: {
+                MODIFY: '',
+              },
+              TEMPLATES: {
+                MODIFY: 'A',
+              },
+              DOCUMENTS: {
+                MODIFY: 'X',
+                VIEW: 'X',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.role.id, result.role.name, result.role.code)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateRole() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.role.update',
+            params: {
               id: 9,
               fields: {
-                  name: 'Редакторы своих шаблонов',
-                  permissions: {
-                      SETTINGS: {
-                          MODIFY: ''
-                      },
-                      TEMPLATES: {
-                          MODIFY: 'A'
-                      },
-                      DOCUMENTS: {
-                          MODIFY: 'X',
-                          VIEW: 'X'
-                      }
-                  }
-              }
-          }
-      );
+                name: 'Editors of own templates',
+                permissions: {
+                  SETTINGS: {
+                    MODIFY: '',
+                  },
+                  TEMPLATES: {
+                    MODIFY: 'A',
+                  },
+                  DOCUMENTS: {
+                    MODIFY: 'X',
+                    VIEW: 'X',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.role.id, result.role.name, result.role.code)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateRole)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/templates/document-generator-template-add.md
+++ b/api-reference/document-generator/templates/document-generator-template-add.md
@@ -130,35 +130,115 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.template.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.template.add',
-          {
-              fields: {
-                  name: 'SUPPLY_CONTRACT Template',
-                  fileId: 5641,
-                  numeratorId: 1,
-                  region: 'ru',
-                  code: 'REST_TEMPLATE',
-                  users: ['UA'],
-                  active: 'Y',
-                  withStamps: 'N',
-                  sort: 500
-              }
-          }
-      );
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const result = response.getData().result;
-      console.log(result);
+  declare const $b24: B24Frame
+
+  // Shape of the payload returned in result (match the "response handling" section of the page)
+  type TemplateAddResult = {
+    template: {
+      id: string
+      name: string
+      region: string
+      code: string
+      download: string
+      downloadMachine: string
+      active: 'Y' | 'N'
+      moduleId: string
+      numeratorId: string
+      withStamps: 'Y' | 'N'
+      providers: Record<string, string>
+      users: Record<string, string>
+      isDeleted: 'Y' | 'N'
+      sort: string
+      createTime: ISODate
+      updateTime: ISODate
+    }
   }
-  catch (error)
-  {
-      console.error(error);
+
+  try {
+    const response = await $b24.actions.v2.call.make<TemplateAddResult>({
+      method: 'documentgenerator.template.add',
+      params: {
+        fields: {
+          name: 'SUPPLY_CONTRACT Template',
+          fileId: 5641,
+          numeratorId: 1,
+          region: 'ru',
+          code: 'REST_TEMPLATE',
+          users: ['UA'],
+          active: 'Y',
+          withStamps: 'N',
+          sort: 500,
+        },
+      },
+      requestId: Text.getUuidRfc4122()
+    })
+
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info('Added template:', result.template.id, result.template.name)
+    }
+  } catch (error) {
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function addTemplate() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'documentgenerator.template.add',
+          params: {
+            fields: {
+              name: 'SUPPLY_CONTRACT Template',
+              fileId: 5641,
+              numeratorId: 1,
+              region: 'ru',
+              code: 'REST_TEMPLATE',
+              users: ['UA'],
+              active: 'Y',
+              withStamps: 'N',
+              sort: 500,
+            },
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info('Added template:', result.template.id, result.template.name)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', addTemplate)
+  </script>
   ```
 
 - PHP

--- a/api-reference/document-generator/templates/document-generator-template-delete.md
+++ b/api-reference/document-generator/templates/document-generator-template-delete.md
@@ -57,26 +57,74 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.template.delete
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.template.delete',
-          {
-              id: 59
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'documentgenerator.template.delete',
+        params: {
+          id: 59,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Template deleted, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.template.delete',
+            params: {
+              id: 59,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info('Template deleted, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTemplate)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/templates/document-generator-template-get-fields.md
+++ b/api-reference/document-generator/templates/document-generator-template-get-fields.md
@@ -54,26 +54,89 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.template.getfields
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.template.getfields',
-          {
-              id: 57
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type TemplateField = {
+      title?: string
+      value: unknown
+      default: unknown
+      required?: string
+      type?: string
+      group?: string[]
+      chain?: string | unknown[]
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateGetFieldsResult = {
+      templateFields: Record<string, TemplateField>
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateGetFieldsResult>({
+        method: 'documentgenerator.template.getfields',
+        params: {
+          id: 57,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.templateFields))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTemplateFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.template.getfields',
+            params: {
+              id: 57,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info(Object.keys(result.templateFields))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTemplateFields)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/templates/document-generator-template-get.md
+++ b/api-reference/document-generator/templates/document-generator-template-get.md
@@ -54,26 +54,95 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.template.get
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.template.get',
-          {
-              id: 57
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateGetResult = {
+      template: {
+        id: string
+        name: string
+        region: string
+        code: string
+        download: string
+        active: string
+        moduleId: string
+        numeratorId: string
+        withStamps: string
+        providers: Record<string, string>
+        users: Record<string, string>
+        isDeleted: string
+        sort: string
+        createTime: ISODate | null
+        updateTime: ISODate | null
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateGetResult>({
+        method: 'documentgenerator.template.get',
+        params: {
+          id: 57,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.template.id, result.template.name, result.template.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.template.get',
+            params: {
+              id: 57,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          const result = response.getData().result
+          console.info(result.template.id, result.template.name, result.template.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTemplate)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/templates/document-generator-template-list.md
+++ b/api-reference/document-generator/templates/document-generator-template-list.md
@@ -166,35 +166,132 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.template.list
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.template.list',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type TemplateItem = {
+      id: string
+      active: string
+      name: string
+      code: string
+      region: string
+      sort: string
+      createTime: ISODate | null
+      updateTime: ISODate | null
+      createdBy: string
+      updatedBy: string
+      moduleId: string
+      fileId: string
+      bodyType: string
+      numeratorId: string
+      withStamps: string
+      productsTableVariant: string
+      isDeleted: string
+      isDefault: string
+      download: string
+      downloadMachine: string
+      users?: string[]
+      providers?: string[]
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateListResult = {
+      templates: Record<string, TemplateItem>
+    }
+
+    try {
+      // documentgenerator.template.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TemplateListResult>({
+        method: 'documentgenerator.template.list',
+        params: {
+          select: ['*', 'users', 'providers'],
+          order: {
+            id: 'desc',
+          },
+          filter: {
+            region: 'ru',
+            active: 'Y',
+            '>=createTime': '2026-03-18T00:00:00+03:00',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Templates count:', Object.keys(result.templates).length, result.templates)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listTemplates() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // documentgenerator.template.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.template.list',
+            params: {
               select: ['*', 'users', 'providers'],
               order: {
-                  id: 'desc'
+                id: 'desc',
               },
               filter: {
-                  region: 'ru',
-                  active: 'Y',
-                  '>=createTime': '2026-03-18T00:00:00+03:00'
+                region: 'ru',
+                active: 'Y',
+                '>=createTime': '2026-03-18T00:00:00+03:00',
               },
-              start: 0
-          }
-      );
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Templates count:', Object.keys(result.templates).length, result.templates)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listTemplates)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/document-generator/templates/document-generator-template-update.md
+++ b/api-reference/document-generator/templates/document-generator-template-update.md
@@ -113,33 +113,110 @@
     https://**put_your_bitrix24_address**/rest/documentgenerator.template.update
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try
-  {
-      const response = await $b24.callMethod(
-          'documentgenerator.template.update',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateUpdateResult = {
+      template: {
+        id: string
+        name: string
+        region: string
+        code: string
+        download: string
+        downloadMachine: string
+        active: string
+        moduleId: string
+        numeratorId: string
+        withStamps: string
+        providers: Record<string, string>
+        users: Record<string, string>
+        isDeleted: string
+        sort: string
+        createTime: ISODate | null
+        updateTime: ISODate | null
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateUpdateResult>({
+        method: 'documentgenerator.template.update',
+        params: {
+          id: 57,
+          fields: {
+            name: 'SUPPLY_CONTRACT_NEW Template',
+            numeratorId: 3,
+            code: 'REST_TEMPLATE',
+            users: ['U503'],
+            sort: 700,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.template.id, result.template.name, result.template.updateTime)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'documentgenerator.template.update',
+            params: {
               id: 57,
               fields: {
-                  name: 'SUPPLY_CONTRACT_NEW Template',
-                  numeratorId: 3,
-                  code: 'REST_TEMPLATE',
-                  users: ['U503'],
-                  sort: 700
-              }
-          }
-      );
+                name: 'SUPPLY_CONTRACT_NEW Template',
+                numeratorId: 3,
+                code: 'REST_TEMPLATE',
+                users: ['U503'],
+                sort: 700,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log(result);
-  }
-  catch (error)
-  {
-      console.error(error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.template.id, result.template.name, result.template.updateTime)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTemplate)
+    </script>
+    ```
 
 - PHP
 


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.