### PR TITLE
docs(booking): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/booking/booking-v1-clienttype-list.md
+++ b/api-reference/booking/booking-v1-clienttype-list.md
@@ -46,44 +46,93 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.clienttype.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'booking.v1.clienttype.list',
-        {},
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ClientTypeListResult = {
+      clientType: {
+        code: string
+        module: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('booking.v1.clienttype.list', {}, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // booking.v1.clienttype.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ClientTypeListResult>({
+        method: 'booking.v1.clienttype.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Client types:', result.clientType)
+        console.info('Count:', result.clientType.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.clienttype.list', {}, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listClientTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.clienttype.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.clienttype.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Client types:', result.clientType)
+          console.info('Count:', result.clientType.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listClientTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/booking-v1-booking-add.md
+++ b/api-reference/booking/booking/booking-v1-booking-add.md
@@ -81,43 +81,106 @@ ID ресурсов можно получить методом [booking.v1.resou
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.add',
-    		{
-    			fields: {
-    				name: 'Название',
-    				description: 'Описание',
-    				resourceIds: [1, 2, 3],
-    				datePeriod: {
-    					from: {
-    						timestamp: 1723446900,
-    						timezone: 'Europe/Moscow'
-    					},
-    					to: {
-    						timestamp: 1723447800,
-    						timezone: 'Europe/Moscow'
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddBookingResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddBookingResult>({
+        method: 'booking.v1.booking.add',
+        params: {
+          fields: {
+            name: 'Name',
+            description: 'Description',
+            resourceIds: [1, 2, 3],
+            datePeriod: {
+              from: {
+                timestamp: 1723446900,
+                timezone: 'Europe/Moscow',
+              },
+              to: {
+                timestamp: 1723447800,
+                timezone: 'Europe/Moscow',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added booking ID:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBooking() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.add',
+            params: {
+              fields: {
+                name: 'Name',
+                description: 'Description',
+                resourceIds: [1, 2, 3],
+                datePeriod: {
+                  from: {
+                    timestamp: 1723446900,
+                    timezone: 'Europe/Moscow',
+                  },
+                  to: {
+                    timestamp: 1723447800,
+                    timezone: 'Europe/Moscow',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added booking ID:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBooking)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/booking-v1-booking-createfromwaitlist.md
+++ b/api-reference/booking/booking/booking-v1-booking-createfromwaitlist.md
@@ -84,42 +84,99 @@ ID ресурсов можно получить методом [booking.v1.resou
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.createfromwaitlist
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.booking.createfromwaitlist",
-    		{
-    			waitListId: 10,
-    			fields: {
-    				resourceIds: [1, 2, 3],
-    				datePeriod: {
-    					from: {
-    						timestamp: 1723446900,
-    						timezone: "Europe/Moscow"
-    					},
-    					to: {
-    						timestamp: 1723447800,
-    						timezone: "Europe/Moscow"
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'booking.v1.booking.createfromwaitlist',
+        params: {
+          waitListId: 10,
+          fields: {
+            resourceIds: [1, 2, 3],
+            datePeriod: {
+              from: {
+                timestamp: 1723446900,
+                timezone: 'Europe/Moscow',
+              },
+              to: {
+                timestamp: 1723447800,
+                timezone: 'Europe/Moscow',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New booking ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createBookingFromWaitlist() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.createfromwaitlist',
+            params: {
+              waitListId: 10,
+              fields: {
+                resourceIds: [1, 2, 3],
+                datePeriod: {
+                  from: {
+                    timestamp: 1723446900,
+                    timezone: 'Europe/Moscow',
+                  },
+                  to: {
+                    timestamp: 1723447800,
+                    timezone: 'Europe/Moscow',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New booking ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createBookingFromWaitlist)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/booking-v1-booking-delete.md
+++ b/api-reference/booking/booking/booking-v1-booking-delete.md
@@ -52,29 +52,73 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.delete',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.booking.delete',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Booking deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteBooking() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.delete',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Booking deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteBooking)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/booking-v1-booking-get.md
+++ b/api-reference/booking/booking/booking-v1-booking-get.md
@@ -52,33 +52,87 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.get',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BookingGetResult = {
+      booking: {
+        datePeriod: {
+          from: { timestamp: number; timezone: string }
+          to: { timestamp: number; timezone: string }
+        }
+        description: string | null
+        id: number
+        name: string
+        resourceIds: number[]
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BookingGetResult>({
+        method: 'booking.v1.booking.get',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.booking.id, result.booking.name, result.booking.resourceIds)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBooking() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.get',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.booking.id, result.booking.name, result.booking.resourceIds)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBooking)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/booking-v1-booking-list.md
+++ b/api-reference/booking/booking/booking-v1-booking-list.md
@@ -89,16 +89,39 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BookingListResult = {
+      booking: {
+        datePeriod: {
+          from: { timestamp: number; timezone: string }
+          to: { timestamp: number; timezone: string }
+        }
+        description: string | null
+        id: number
+        name: string
+        resourceIds: number[]
+      }[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'booking.v1.booking.list',
-        {
+      // booking.v1.booking.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<BookingListResult>({
+        method: 'booking.v1.booking.list',
+        params: {
           filter: {
             within: {
               dateFrom: 0,
@@ -107,104 +130,106 @@
             client: {
               entities: [
                 {
-                  "code": "CONTACT",
-                  "module": "crm",
-                  "id": "1"
+                  code: 'CONTACT',
+                  module: 'crm',
+                  id: '1',
                 },
                 {
-                  "code": "COMPANY",
-                  "module": "crm",
-                  "id": "1"
-                }
-              ]
-            }
+                  code: 'COMPANY',
+                  module: 'crm',
+                  id: '1',
+                },
+              ],
+            },
           },
           order: {
-            id: "ASC",
-            dateFrom: "DESC",
-            dateTo: "ASC",
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('booking.v1.booking.list', {
-        filter: {
-          within: {
-            dateFrom: 0,
-            dateTo: 1739262600,
+            id: 'ASC',
+            dateFrom: 'DESC',
+            dateTo: 'ASC',
           },
-          client: {
-            entities: [
-              {
-                "code": "CONTACT",
-                "module": "crm",
-                "id": "1"
-              },
-              {
-                "code": "COMPANY",
-                "module": "crm",
-                "id": "1"
-              }
-            ]
-          }
+          start: 0,
         },
-        order: {
-          id: "ASC",
-          dateFrom: "DESC",
-          dateTo: "ASC",
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.booking.length, result.booking)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.booking.list', {
-        filter: {
-          within: {
-            dateFrom: 0,
-            dateTo: 1739262600,
-          },
-          client: {
-            entities: [
-              {
-                "code": "CONTACT",
-                "module": "crm",
-                "id": "1"
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchBookingList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.booking.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.list',
+            params: {
+              filter: {
+                within: {
+                  dateFrom: 0,
+                  dateTo: 1739262600,
+                },
+                client: {
+                  entities: [
+                    {
+                      code: 'CONTACT',
+                      module: 'crm',
+                      id: '1',
+                    },
+                    {
+                      code: 'COMPANY',
+                      module: 'crm',
+                      id: '1',
+                    },
+                  ],
+                },
               },
-              {
-                "code": "COMPANY",
-                "module": "crm",
-                "id": "1"
-              }
-            ]
+              order: {
+                id: 'ASC',
+                dateFrom: 'DESC',
+                dateTo: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-        },
-        order: {
-          id: "ASC",
-          dateFrom: "DESC",
-          dateTo: "ASC",
+
+          const result = response.getData().result
+          console.info(result.booking.length, result.booking)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchBookingList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/booking-v1-booking-update.md
+++ b/api-reference/booking/booking/booking-v1-booking-update.md
@@ -81,48 +81,103 @@ ID ресурсов можно получить методом [booking.v1.resou
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.update',
-    		{
-    			id: 10,
-    			fields: {
-    				name: 'Название',
-    				description: 'Описание',
-    				resourceIds: [1, 2, 3],
-    				datePeriod: {
-    					from: {
-    						timestamp: 1723446900,
-    						timezone: 'Europe/Moscow'
-    					},
-    					to: {
-    						timestamp: 1723447800,
-    						timezone: 'Europe/Moscow'
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.booking.update',
+        params: {
+          id: 10,
+          fields: {
+            name: 'Name',
+            description: 'Description',
+            resourceIds: [1, 2, 3],
+            datePeriod: {
+              from: {
+                timestamp: 1723446900,
+                timezone: 'Europe/Moscow',
+              },
+              to: {
+                timestamp: 1723447800,
+                timezone: 'Europe/Moscow',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Booking updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBooking() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.update',
+            params: {
+              id: 10,
+              fields: {
+                name: 'Name',
+                description: 'Description',
+                resourceIds: [1, 2, 3],
+                datePeriod: {
+                  from: {
+                    timestamp: 1723446900,
+                    timezone: 'Europe/Moscow',
+                  },
+                  to: {
+                    timestamp: 1723447800,
+                    timezone: 'Europe/Moscow',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Booking updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBooking)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/client/booking-v1-booking-client-list.md
+++ b/api-reference/booking/booking/client/booking-v1-booking-client-list.md
@@ -53,44 +53,96 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.client.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'booking.v1.booking.client.list',
-        { bookingId: 123 },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BookingClientListResult = {
+      bookingClient: {
+        id: number
+        type: {
+          code: string
+          module: string
+        }
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
+    // booking.v1.booking.client.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-      const generator = $b24.fetchListMethod('booking.v1.booking.client.list', { bookingId: 123 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      const response = await $b24.actions.v2.call.make<BookingClientListResult>({
+        method: 'booking.v1.booking.client.list',
+        params: {
+          bookingId: 123,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Booking clients:', result.bookingClient, 'Count:', result.bookingClient.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.booking.client.list', { bookingId: 123 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listBookingClients() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.booking.client.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.client.list',
+            params: {
+              bookingId: 123,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Booking clients:', result.bookingClient, 'Count:', result.bookingClient.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listBookingClients)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/client/booking-v1-booking-client-set.md
+++ b/api-reference/booking/booking/client/booking-v1-booking-client-set.md
@@ -71,42 +71,105 @@ Cтруктуру объекта возвращает метод [booking.v1.cli
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.booking.client.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.client.set',
-    		{
-    			bookingId: 14,
-    			clients: [
-    				{
-    					id: 1,
-    					type: {
-    						module: 'crm',
-    						code: 'CONTACT'
-    					}
-    				},
-    				{
-    					id: 2,
-    					type: {
-    						module: 'crm',
-    						code: 'CONTACT'
-    					}
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.booking.client.set',
+        params: {
+          bookingId: 14,
+          clients: [
+            {
+              id: 1,
+              type: {
+                module: 'crm',
+                code: 'CONTACT',
+              },
+            },
+            {
+              id: 2,
+              type: {
+                module: 'crm',
+                code: 'CONTACT',
+              },
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Clients set successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setBookingClients() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.client.set',
+            params: {
+              bookingId: 14,
+              clients: [
+                {
+                  id: 1,
+                  type: {
+                    module: 'crm',
+                    code: 'CONTACT',
+                  },
+                },
+                {
+                  id: 2,
+                  type: {
+                    module: 'crm',
+                    code: 'CONTACT',
+                  },
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Clients set successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setBookingClients)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/client/booking-v1-booking-client-unset.md
+++ b/api-reference/booking/booking/client/booking-v1-booking-client-unset.md
@@ -53,29 +53,73 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.booking.client.unset
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.client.unset',
-    		{
-    			bookingId: 14,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.booking.client.unset',
+        params: {
+          bookingId: 14,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Clients unset successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unsetBookingClients() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.client.unset',
+            params: {
+              bookingId: 14,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Clients unset successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unsetBookingClients)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/external-data/booking-v1-booking-externaldata-list.md
+++ b/api-reference/booking/booking/external-data/booking-v1-booking-externaldata-list.md
@@ -53,44 +53,94 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.booking.externalData.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'booking.v1.booking.externalData.list',
-        { bookingId: 123 },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExternalDataListResult = {
+      externalData: {
+        entityTypeId: string
+        moduleId: string
+        value: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('booking.v1.booking.externalData.list', { bookingId: 123 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // booking.v1.booking.externalData.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ExternalDataListResult>({
+        method: 'booking.v1.booking.externalData.list',
+        params: {
+          bookingId: 123,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External data:', result.externalData, 'count:', result.externalData.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.booking.externalData.list', { bookingId: 123 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchExternalDataList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.booking.externalData.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.externalData.list',
+            params: {
+              bookingId: 123,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External data:', result.externalData, 'count:', result.externalData.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchExternalDataList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/external-data/booking-v1-booking-externaldata-set.md
+++ b/api-reference/booking/booking/external-data/booking-v1-booking-externaldata-set.md
@@ -68,36 +68,87 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.booking.externalData.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.booking.externalData.set",
-    		{
-    			bookingId: 14,
-    			externalData: [
-    				{
-    					moduleId: "crm",
-    					entityTypeId: "DEAL",
-    					value: "1"
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.booking.externalData.set',
+        params: {
+          bookingId: 14,
+          externalData: [
+            {
+              moduleId: 'crm',
+              entityTypeId: 'DEAL',
+              value: '1',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External data set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setExternalData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.externalData.set',
+            params: {
+              bookingId: 14,
+              externalData: [
+                {
+                  moduleId: 'crm',
+                  entityTypeId: 'DEAL',
+                  value: '1',
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External data set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setExternalData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/booking/external-data/booking-v1-booking-externaldata-unset.md
+++ b/api-reference/booking/booking/external-data/booking-v1-booking-externaldata-unset.md
@@ -53,29 +53,73 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.booking.externalData.unset
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.booking.externalData.unset',
-    		{
-    			bookingId: 14,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.booking.externalData.unset',
+        params: {
+          bookingId: 14,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External data unset successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unsetBookingExternalData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.booking.externalData.unset',
+            params: {
+              bookingId: 14,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External data unset successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unsetBookingExternalData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/booking-v1-resource-add.md
+++ b/api-reference/booking/resource/booking-v1-resource-add.md
@@ -163,56 +163,124 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resource.add',
-    		{
-    			fields: {
-    				name: 'Название',
-    				description: 'Описание',
-    				typeId: 1,
-    				isMain: 'N',
-    				isInfoNotificationOn: 'Y',
-    				templateTypeInfo: 'inanimate',
-    				isConfirmationNotificationOn: 'Y',
-    				templateTypeConfirmation: 'animate',
-    				isReminderNotificationOn: 'N',
-    				templateTypeReminder: 'base',
-    				isFeedbackNotificationOn: 'Y',
-    				templateTypeFeedback: 'inanimate',
-    				isDelayedNotificationOn: 'Y',
-    				templateTypeDelayed: 'inanimate',
-    				infoDelay: 60,
-    				reminderDelay: -1,
-    				delayedDelay: 300,
-    				delayedCounterDelay: 7200,
-    				confirmationDelay: 86400,
-    				confirmationRepetitions: 1,
-    				confirmationRepetitionsInterval: 3600,
-    				confirmationCounterDelay: 7200
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceAddResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ResourceAddResult>({
+        method: 'booking.v1.resource.add',
+        params: {
+          fields: {
+            name: 'Name',
+            description: 'Description',
+            typeId: 1,
+            isMain: 'N',
+            isInfoNotificationOn: 'Y',
+            templateTypeInfo: 'inanimate',
+            isConfirmationNotificationOn: 'Y',
+            templateTypeConfirmation: 'animate',
+            isReminderNotificationOn: 'N',
+            templateTypeReminder: 'base',
+            isFeedbackNotificationOn: 'Y',
+            templateTypeFeedback: 'inanimate',
+            isDelayedNotificationOn: 'Y',
+            templateTypeDelayed: 'inanimate',
+            infoDelay: 60,
+            reminderDelay: -1,
+            delayedDelay: 300,
+            delayedCounterDelay: 7200,
+            confirmationDelay: 86400,
+            confirmationRepetitions: 1,
+            confirmationRepetitionsInterval: 3600,
+            confirmationCounterDelay: 7200,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New resource ID:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.add',
+            params: {
+              fields: {
+                name: 'Name',
+                description: 'Description',
+                typeId: 1,
+                isMain: 'N',
+                isInfoNotificationOn: 'Y',
+                templateTypeInfo: 'inanimate',
+                isConfirmationNotificationOn: 'Y',
+                templateTypeConfirmation: 'animate',
+                isReminderNotificationOn: 'N',
+                templateTypeReminder: 'base',
+                isFeedbackNotificationOn: 'Y',
+                templateTypeFeedback: 'inanimate',
+                isDelayedNotificationOn: 'Y',
+                templateTypeDelayed: 'inanimate',
+                infoDelay: 60,
+                reminderDelay: -1,
+                delayedDelay: 300,
+                delayedCounterDelay: 7200,
+                confirmationDelay: 86400,
+                confirmationRepetitions: 1,
+                confirmationRepetitionsInterval: 3600,
+                confirmationCounterDelay: 7200,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New resource ID:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addResource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/booking-v1-resource-delete.md
+++ b/api-reference/booking/resource/booking-v1-resource-delete.md
@@ -53,33 +53,73 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resource.delete',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.resource.delete',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resource deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.delete',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resource deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteResource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/booking-v1-resource-get.md
+++ b/api-reference/booking/resource/booking-v1-resource-get.md
@@ -53,33 +53,102 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resource.get',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceResult = {
+      resource: {
+        confirmationCounterDelay: number,
+        confirmationNotificationDelay: number,
+        confirmationNotificationRepetitions: number | null,
+        confirmationNotificationRepetitionsInterval: number,
+        delayedCounterDelay: number,
+        delayedNotificationDelay: number,
+        description: string | null,
+        id: number,
+        infoNotificationDelay: number | null,
+        isConfirmationNotificationOn: string,
+        isDelayedNotificationOn: string,
+        isFeedbackNotificationOn: string,
+        isInfoNotificationOn: string,
+        isMain: string,
+        isReminderNotificationOn: string,
+        name: string,
+        reminderNotificationDelay: number,
+        templateTypeConfirmation: string,
+        templateTypeDelayed: string,
+        templateTypeFeedback: string,
+        templateTypeInfo: string,
+        templateTypeReminder: string,
+        typeId: number,
+      },
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ResourceResult>({
+        method: 'booking.v1.resource.get',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.resource.id, result.resource.name, result.resource.typeId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.get',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.resource.id, result.resource.name, result.resource.typeId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getResource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/booking-v1-resource-list.md
+++ b/api-reference/booking/resource/booking-v1-resource-list.md
@@ -94,74 +94,128 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each resource returned in result.resource[]
+    type ResourceItem = {
+      confirmationCounterDelay: number
+      confirmationNotificationDelay: number
+      confirmationNotificationRepetitions: number | null
+      confirmationNotificationRepetitionsInterval: number
+      delayedCounterDelay: number
+      delayedNotificationDelay: number
+      description: string | null
+      id: number
+      infoNotificationDelay: number | null
+      isConfirmationNotificationOn: string
+      isDelayedNotificationOn: string
+      isFeedbackNotificationOn: string
+      isInfoNotificationOn: string
+      isMain: string
+      isReminderNotificationOn: string
+      name: string
+      reminderNotificationDelay: number
+      templateTypeConfirmation: string
+      templateTypeDelayed: string
+      templateTypeFeedback: string
+      templateTypeInfo: string
+      templateTypeReminder: string
+      typeId: number
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'booking.v1.resource.list',
-        {
+      // booking.v1.resource.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<{ resource: ResourceItem[] }>({
+        method: 'booking.v1.resource.list',
+        params: {
           filter: {
-            "searchQuery": "авто",
-            "isMain": "Y",
-            "typeId": 1
+            searchQuery: 'auto',
+            isMain: 'Y',
+            typeId: 1,
           },
           order: {
-            id: "ASC",
-            name: "DESC"
-          }
+            id: 'ASC',
+            name: 'DESC',
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('booking.v1.resource.list', {
-        filter: {
-          "searchQuery": "авто",
-          "isMain": "Y",
-          "typeId": 1
-        },
-        order: {
-          id: "ASC",
-          name: "DESC"
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resources:', result.resource, 'Count:', result.resource.length)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.resource.list', {
-        filter: {
-          "searchQuery": "авто",
-          "isMain": "Y",
-          "typeId": 1
-        },
-        order: {
-          id: "ASC",
-          name: "DESC"
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchResourceList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.resource.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.list',
+            params: {
+              filter: {
+                searchQuery: 'auto',
+                isMain: 'Y',
+                typeId: 1,
+              },
+              order: {
+                id: 'ASC',
+                name: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resources:', result.resource, 'Count:', result.resource.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchResourceList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/booking-v1-resource-update.md
+++ b/api-reference/booking/resource/booking-v1-resource-update.md
@@ -129,50 +129,121 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.resource.update",
-    		{
-    			id: 10,
-    			fields: {
-    				name: "Новое название",
-    				description: "Новое описание",
-    				typeId: 1,
-    				isMain: "N",
-    				isInfoNotificationOn: "Y",
-    				templateTypeInfo: "inanimate",
-    				isConfirmationNotificationOn: "Y",
-    				templateTypeConfirmation: "animate",
-    				isReminderNotificationOn: "Y",
-    				templateTypeReminder: "base",
-    				isFeedbackNotificationOn: "N",
-    				templateTypeFeedback: "animate",
-    				isDelayedNotificationOn: "N",
-    				templateTypeDelayed: "animate",
-    				infoDelay: 300,
-    				reminderDelay: -1,
-    				delayedDelay: 300,
-    				delayedCounterDelay: 7200,
-    				confirmationDelay: 86400,
-    				confirmationRepetitions: 0,
-    				confirmationRepetitionsInterval: 0,
-    				confirmationCounterDelay: 7200
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.resource.update',
+        params: {
+          id: 10,
+          fields: {
+            name: 'New name',
+            description: 'New description',
+            typeId: 1,
+            isMain: 'N',
+            isInfoNotificationOn: 'Y',
+            templateTypeInfo: 'inanimate',
+            isConfirmationNotificationOn: 'Y',
+            templateTypeConfirmation: 'animate',
+            isReminderNotificationOn: 'Y',
+            templateTypeReminder: 'base',
+            isFeedbackNotificationOn: 'N',
+            templateTypeFeedback: 'animate',
+            isDelayedNotificationOn: 'N',
+            templateTypeDelayed: 'animate',
+            infoDelay: 300,
+            reminderDelay: -1,
+            delayedDelay: 300,
+            delayedCounterDelay: 7200,
+            confirmationDelay: 86400,
+            confirmationRepetitions: 0,
+            confirmationRepetitionsInterval: 0,
+            confirmationCounterDelay: 7200,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resource updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateResource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.update',
+            params: {
+              id: 10,
+              fields: {
+                name: 'New name',
+                description: 'New description',
+                typeId: 1,
+                isMain: 'N',
+                isInfoNotificationOn: 'Y',
+                templateTypeInfo: 'inanimate',
+                isConfirmationNotificationOn: 'Y',
+                templateTypeConfirmation: 'animate',
+                isReminderNotificationOn: 'Y',
+                templateTypeReminder: 'base',
+                isFeedbackNotificationOn: 'N',
+                templateTypeFeedback: 'animate',
+                isDelayedNotificationOn: 'N',
+                templateTypeDelayed: 'animate',
+                infoDelay: 300,
+                reminderDelay: -1,
+                delayedDelay: 300,
+                delayedCounterDelay: 7200,
+                confirmationDelay: 86400,
+                confirmationRepetitions: 0,
+                confirmationRepetitionsInterval: 0,
+                confirmationCounterDelay: 7200,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resource updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateResource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/resource-type/booking-v1-resourcetype-add.md
+++ b/api-reference/booking/resource/resource-type/booking-v1-resourcetype-add.md
@@ -151,47 +151,120 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resourceType.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.resourceType.add",
-    		{
-    			fields: {
-    				name: "Название",
-    				code: "code",
-    				isInfoNotificationOn: "Y",
-    				templateTypeInfo: "inanimate",
-    				isConfirmationNotificationOn: "Y",
-    				templateTypeConfirmation: "animate",
-    				isReminderNotificationOn: "N",
-    				templateTypeReminder: "base",
-    				isFeedbackNotificationOn: "Y",
-    				templateTypeFeedback: "inanimate",
-    				isDelayedNotificationOn: "Y",
-    				templateTypeDelayed: "inanimate",
-    				infoDelay: 300,
-    				reminderDelay: -1,
-    				delayedDelay: 300,
-    				delayedCounterDelay: 7200,
-    				confirmationDelay: 86400,
-    				confirmationRepetitions: 0,
-    				confirmationRepetitionsInterval: 0,
-    				confirmationCounterDelay: 7200
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceTypeAddResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ResourceTypeAddResult>({
+        method: 'booking.v1.resourceType.add',
+        params: {
+          fields: {
+            name: 'Equipment Room',
+            code: 'code',
+            isInfoNotificationOn: 'Y',
+            templateTypeInfo: 'inanimate',
+            isConfirmationNotificationOn: 'Y',
+            templateTypeConfirmation: 'animate',
+            isReminderNotificationOn: 'N',
+            templateTypeReminder: 'base',
+            isFeedbackNotificationOn: 'Y',
+            templateTypeFeedback: 'inanimate',
+            isDelayedNotificationOn: 'Y',
+            templateTypeDelayed: 'inanimate',
+            infoDelay: 300,
+            reminderDelay: -1,
+            delayedDelay: 300,
+            delayedCounterDelay: 7200,
+            confirmationDelay: 86400,
+            confirmationRepetitions: 0,
+            confirmationRepetitionsInterval: 0,
+            confirmationCounterDelay: 7200,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created resource type id:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addResourceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resourceType.add',
+            params: {
+              fields: {
+                name: 'Equipment Room',
+                code: 'code',
+                isInfoNotificationOn: 'Y',
+                templateTypeInfo: 'inanimate',
+                isConfirmationNotificationOn: 'Y',
+                templateTypeConfirmation: 'animate',
+                isReminderNotificationOn: 'N',
+                templateTypeReminder: 'base',
+                isFeedbackNotificationOn: 'Y',
+                templateTypeFeedback: 'inanimate',
+                isDelayedNotificationOn: 'Y',
+                templateTypeDelayed: 'inanimate',
+                infoDelay: 300,
+                reminderDelay: -1,
+                delayedDelay: 300,
+                delayedCounterDelay: 7200,
+                confirmationDelay: 86400,
+                confirmationRepetitions: 0,
+                confirmationRepetitionsInterval: 0,
+                confirmationCounterDelay: 7200,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created resource type id:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addResourceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/resource-type/booking-v1-resourcetype-delete.md
+++ b/api-reference/booking/resource/resource-type/booking-v1-resourcetype-delete.md
@@ -53,33 +53,73 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resourceType.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resourceType.delete',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.resourceType.delete',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resource type deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteResourceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resourceType.delete',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resource type deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteResourceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/resource-type/booking-v1-resourcetype-get.md
+++ b/api-reference/booking/resource/resource-type/booking-v1-resourcetype-get.md
@@ -53,26 +53,98 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resourceType.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resourceType.get',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceTypeGetResult = {
+      resourceType: {
+        id: number
+        code: string
+        name: string
+        confirmationCounterDelay: number
+        confirmationNotificationDelay: number
+        confirmationNotificationRepetitions: number | null
+        confirmationNotificationRepetitionsInterval: number
+        delayedCounterDelay: number
+        delayedNotificationDelay: number
+        infoNotificationDelay: number | null
+        isConfirmationNotificationOn: string
+        isDelayedNotificationOn: string
+        isFeedbackNotificationOn: string
+        isReminderNotificationOn: string
+        reminderNotificationDelay: number
+        templateTypeConfirmation: string
+        templateTypeDelayed: string
+        templateTypeFeedback: string
+        templateTypeReminder: string
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ResourceTypeGetResult>({
+        method: 'booking.v1.resourceType.get',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.resourceType.id, result.resourceType.code, result.resourceType.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getResourceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resourceType.get',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.resourceType.id, result.resourceType.code, result.resourceType.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getResourceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/resource-type/booking-v1-resourcetype-list.md
+++ b/api-reference/booking/resource/resource-type/booking-v1-resourcetype-list.md
@@ -90,74 +90,128 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resourceType.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ResourceTypeResult = {
+      resource: ResourceType[]
+    }
+
+    type ResourceType = {
+      code: string
+      confirmationCounterDelay: number
+      confirmationNotificationDelay: number
+      confirmationNotificationRepetitions: number | null
+      confirmationNotificationRepetitionsInterval: number
+      delayedCounterDelay: number
+      delayedNotificationDelay: number
+      id: number
+      infoNotificationDelay: number | null
+      isConfirmationNotificationOn: string
+      isDelayedNotificationOn: string
+      isFeedbackNotificationOn: string
+      isReminderNotificationOn: string
+      name: string
+      reminderNotificationDelay: number
+      templateTypeConfirmation: string
+      templateTypeDelayed: string
+      templateTypeFeedback: string
+      templateTypeReminder: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'booking.v1.resourceType.list',
-        {
+      // booking.v1.resourceType.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ResourceTypeResult>({
+        method: 'booking.v1.resourceType.list',
+        params: {
           filter: {
-            "searchQuery": "рес",
-            "moduleId": "booking"
+            searchQuery: 'res',
+            moduleId: 'booking',
           },
           order: {
-            id: "ASC",
-            name: "DESC",
-            code: "DESC"
-          }
+            id: 'ASC',
+            name: 'DESC',
+            code: 'DESC',
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('booking.v1.resourceType.list', {
-        filter: {
-          "searchQuery": "рес",
-          "moduleId": "booking"
-        },
-        order: {
-          id: "ASC",
-          name: "DESC",
-          code: "DESC"
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resource types:', result.resource.length, result.resource)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.resourceType.list', {
-        filter: {
-          "searchQuery": "рес",
-          "moduleId": "booking"
-        },
-        order: {
-          id: "ASC",
-          name: "DESC",
-          code: "DESC"
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listResourceTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.resourceType.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resourceType.list',
+            params: {
+              filter: {
+                searchQuery: 'res',
+                moduleId: 'booking',
+              },
+              order: {
+                id: 'ASC',
+                name: 'DESC',
+                code: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resource types:', result.resource.length, result.resource)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listResourceTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/resource-type/booking-v1-resourcetype-update.md
+++ b/api-reference/booking/resource/resource-type/booking-v1-resourcetype-update.md
@@ -120,51 +120,117 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resourceType.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.resourceType.update",
-    		{
-    			id: 10,
-    			fields: {
-    				name: "Новое название",
-    				code: "Обновлённый код",
-    				isInfoNotificationOn: "Y",
-    				templateTypeInfo: "inanimate",
-    				isConfirmationNotificationOn: "Y",
-    				templateTypeConfirmation: "animate",
-    				isReminderNotificationOn: "Y",
-    				templateTypeReminder: "base",
-    				isFeedbackNotificationOn: "N",
-    				templateTypeFeedback: "animate",
-    				isDelayedNotificationOn: "N",
-    				templateTypeDelayed: "animate",
-    				infoDelay: 300,
-    				reminderDelay: -1,
-    				delayedDelay: 300,
-    				delayedCounterDelay: 7200,
-    				confirmationDelay: 86400,
-    				confirmationRepetitions: 0,
-    				confirmationRepetitionsInterval: 0,
-    				confirmationCounterDelay: 7200
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.resourceType.update',
+        params: {
+          id: 10,
+          fields: {
+            name: 'New name',
+            code: 'updated-code',
+            isInfoNotificationOn: 'Y',
+            templateTypeInfo: 'inanimate',
+            isConfirmationNotificationOn: 'Y',
+            templateTypeConfirmation: 'animate',
+            isReminderNotificationOn: 'Y',
+            templateTypeReminder: 'base',
+            isFeedbackNotificationOn: 'N',
+            templateTypeFeedback: 'animate',
+            isDelayedNotificationOn: 'N',
+            templateTypeDelayed: 'animate',
+            infoDelay: 300,
+            reminderDelay: -1,
+            delayedDelay: 300,
+            delayedCounterDelay: 7200,
+            confirmationDelay: 86400,
+            confirmationRepetitions: 0,
+            confirmationRepetitionsInterval: 0,
+            confirmationCounterDelay: 7200,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resource type updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateResourceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resourceType.update',
+            params: {
+              id: 10,
+              fields: {
+                name: 'New name',
+                code: 'updated-code',
+                isInfoNotificationOn: 'Y',
+                templateTypeInfo: 'inanimate',
+                isConfirmationNotificationOn: 'Y',
+                templateTypeConfirmation: 'animate',
+                isReminderNotificationOn: 'Y',
+                templateTypeReminder: 'base',
+                isFeedbackNotificationOn: 'N',
+                templateTypeFeedback: 'animate',
+                isDelayedNotificationOn: 'N',
+                templateTypeDelayed: 'animate',
+                infoDelay: 300,
+                reminderDelay: -1,
+                delayedDelay: 300,
+                delayedCounterDelay: 7200,
+                confirmationDelay: 86400,
+                confirmationRepetitions: 0,
+                confirmationRepetitionsInterval: 0,
+                confirmationCounterDelay: 7200,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resource type updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateResourceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/slots/booking-v1-resource-slots-list.md
+++ b/api-reference/booking/resource/slots/booking-v1-resource-slots-list.md
@@ -53,44 +53,97 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.slots.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'booking.v1.resource.slots.list',
-        { resourceId: 257 },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SlotsListResult = {
+      slots: {
+        id: number
+        from: number
+        to: number
+        timezone: string
+        weekDays: string[]
+        slotSize: number
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('booking.v1.resource.slots.list', { resourceId: 257 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // booking.v1.resource.slots.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SlotsListResult>({
+        method: 'booking.v1.resource.slots.list',
+        params: {
+          resourceId: 257,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Slots:', result.slots, 'Count:', result.slots.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.resource.slots.list', { resourceId: 257 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listResourceSlots() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.resource.slots.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.slots.list',
+            params: {
+              resourceId: 257,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Slots:', result.slots, 'Count:', result.slots.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listResourceSlots)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/slots/booking-v1-resource-slots-set.md
+++ b/api-reference/booking/resource/slots/booking-v1-resource-slots-set.md
@@ -83,42 +83,91 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.resource.slots.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resource.slots.set',
-    		{
-    			resourceId: 10,
-    			slots: [
-    				{
-    					from: 540,
-    					to: 1080,
-    					timezone: 'Europe/Kaliningrad',
-    					weekDays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
-    					slotSize: 30
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.resource.slots.set',
+        params: {
+          resourceId: 10,
+          slots: [
+            {
+              from: 540,
+              to: 1080,
+              timezone: 'Europe/Kaliningrad',
+              weekDays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+              slotSize: 30,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Slots set successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setResourceSlots() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.slots.set',
+            params: {
+              resourceId: 10,
+              slots: [
+                {
+                  from: 540,
+                  to: 1080,
+                  timezone: 'Europe/Kaliningrad',
+                  weekDays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+                  slotSize: 30,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Slots set successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setResourceSlots)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/resource/slots/booking-v1-resource-slots-unset.md
+++ b/api-reference/booking/resource/slots/booking-v1-resource-slots-unset.md
@@ -53,33 +53,73 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.resource.slots.unset
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.resource.slots.unset',
-    		{
-    			resourceId: 14,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.resource.slots.unset',
+        params: {
+          resourceId: 14,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Slots unset:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unsetResourceSlots() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.resource.slots.unset',
+            params: {
+              resourceId: 14,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Slots unset:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unsetResourceSlots)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/booking-v1-waitlist-add.md
+++ b/api-reference/booking/waitlist/booking-v1-waitlist-add.md
@@ -62,35 +62,82 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.waitlist.add',
-    		{
-    			fields: {
-    				note: 'Заметка',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type WaitlistAddResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<WaitlistAddResult>({
+        method: 'booking.v1.waitlist.add',
+        params: {
+          fields: {
+            note: 'Note',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added to waitlist, id:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addToWaitlist() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.add',
+            params: {
+              fields: {
+                note: 'Note',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added to waitlist, id:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addToWaitlist)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/booking-v1-waitlist-createfrombooking.md
+++ b/api-reference/booking/waitlist/booking-v1-waitlist-createfrombooking.md
@@ -53,29 +53,73 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.createfrombooking
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.waitlist.createfrombooking",
-    		{
-    			bookingId: 5
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'booking.v1.waitlist.createfrombooking',
+        params: {
+          bookingId: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created waitlist entry with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createWaitlistFromBooking() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.createfrombooking',
+            params: {
+              bookingId: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created waitlist entry with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createWaitlistFromBooking)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/booking-v1-waitlist-delete.md
+++ b/api-reference/booking/waitlist/booking-v1-waitlist-delete.md
@@ -52,33 +52,73 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.waitlist.delete',
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.waitlist.delete',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Waitlist entry deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteWaitlistEntry() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.delete',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Waitlist entry deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteWaitlistEntry)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/booking-v1-waitlist-get.md
+++ b/api-reference/booking/waitlist/booking-v1-waitlist-get.md
@@ -52,29 +52,81 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.waitlist.get",
-    		{
-    			id: 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type WaitListGetResult = {
+      waitList: {
+        id: number
+        note: string | null
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<WaitListGetResult>({
+        method: 'booking.v1.waitlist.get',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.waitList.id, result.waitList.note)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getWaitListItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.get',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.waitList.id, result.waitList.note)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getWaitListItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/booking-v1-waitlist-list.md
+++ b/api-reference/booking/waitlist/booking-v1-waitlist-list.md
@@ -62,65 +62,103 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type WaitListResult = {
+      waitList: {
+        id: number
+        note: string | null
+      }[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'booking.v1.waitlist.list',
-        {
+      // booking.v1.waitlist.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<WaitListResult>({
+        method: 'booking.v1.waitlist.list',
+        params: {
           filter: {
             createdWithin: {
-              from: "01.04.2025",
-              to: "16.04.2025",
-            }
-          }
+              from: '01.04.2025',
+              to: '16.04.2025',
+            },
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('booking.v1.waitlist.list', {
-        filter: {
-          createdWithin: {
-            from: "01.04.2025",
-            to: "16.04.2025",
-          }
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Waitlist entries:', result.waitList, 'Count:', result.waitList.length)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.waitlist.list', {
-        filter: {
-          createdWithin: {
-            from: "01.04.2025",
-            to: "16.04.2025",
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchWaitList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.waitlist.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.list',
+            params: {
+              filter: {
+                createdWithin: {
+                  from: '01.04.2025',
+                  to: '16.04.2025',
+                },
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
+
+          const result = response.getData().result
+          console.info('Waitlist entries:', result.waitList, 'Count:', result.waitList.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchWaitList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/booking-v1-waitlist-update.md
+++ b/api-reference/booking/waitlist/booking-v1-waitlist-update.md
@@ -64,36 +64,79 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.waitlist.update',
-    		{
-    			id: 5,
-    			fields: {
-    				note: 'Новая заметка',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.waitlist.update',
+        params: {
+          id: 5,
+          fields: {
+            note: 'New note',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Waitlist entry updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateWaitlist() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.update',
+            params: {
+              id: 5,
+              fields: {
+                note: 'New note',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Waitlist entry updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateWaitlist)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/client/booking-v1-waitlist-client-list.md
+++ b/api-reference/booking/waitlist/client/booking-v1-waitlist-client-list.md
@@ -53,44 +53,96 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitlist.client.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'booking.v1.waitlist.client.list',
-        { waitListId: 257 },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type WaitListClientListResult = {
+      waitListClient: Array<{
+        id: number
+        type: {
+          code: string
+          module: string
+        }
+      }>
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('booking.v1.waitlist.client.list', { waitListId: 257 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // booking.v1.waitlist.client.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<WaitListClientListResult>({
+        method: 'booking.v1.waitlist.client.list',
+        params: {
+          waitListId: 257,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Clients:', result.waitListClient, 'Count:', result.waitListClient.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.waitlist.client.list', { waitListId: 257 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listWaitListClients() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.waitlist.client.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.client.list',
+            params: {
+              waitListId: 257,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Clients:', result.waitListClient, 'Count:', result.waitListClient.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listWaitListClients)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/client/booking-v1-waitlist-client-set.md
+++ b/api-reference/booking/waitlist/client/booking-v1-waitlist-client-set.md
@@ -71,42 +71,105 @@ Cтруктуру объекта возвращает метод [booking.v1.cli
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.waitlist.client.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.waitlist.client.set",
-    		{
-    			waitListId: 4,
-    			clients: [
-    				{
-    					id: 1,
-    					type: {
-    						module: "crm",
-    						code: "CONTACT"
-    					}
-    				},
-    				{
-    					id: 2,
-    					type: {
-    						module: "crm",
-    						code: "CONTACT"
-    					}
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.waitlist.client.set',
+        params: {
+          waitListId: 4,
+          clients: [
+            {
+              id: 1,
+              type: {
+                module: 'crm',
+                code: 'CONTACT',
+              },
+            },
+            {
+              id: 2,
+              type: {
+                module: 'crm',
+                code: 'CONTACT',
+              },
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Clients set successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setWaitlistClients() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.client.set',
+            params: {
+              waitListId: 4,
+              clients: [
+                {
+                  id: 1,
+                  type: {
+                    module: 'crm',
+                    code: 'CONTACT',
+                  },
+                },
+                {
+                  id: 2,
+                  type: {
+                    module: 'crm',
+                    code: 'CONTACT',
+                  },
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Clients set successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setWaitlistClients)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/client/booking-v1-waitlist-client-unset.md
+++ b/api-reference/booking/waitlist/client/booking-v1-waitlist-client-unset.md
@@ -53,29 +53,73 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.waitlist.client.unset
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.waitlist.client.unset',
-    		{
-    			waitListId: 14,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.waitlist.client.unset',
+        params: {
+          waitListId: 14,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Clients unset from waitlist:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unsetWaitlistClients() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.client.unset',
+            params: {
+              waitListId: 14,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Clients unset from waitlist:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unsetWaitlistClients)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/external-data/booking-v1-waitlist-externaldata-list.md
+++ b/api-reference/booking/waitlist/external-data/booking-v1-waitlist-externaldata-list.md
@@ -53,44 +53,94 @@
     https://**put_your_bitrix24_address**/rest/booking.v1.waitList.externalData.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'booking.v1.waitList.externalData.list',
-        { waitListId: 257 },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExternalDataListResult = {
+      externalData: {
+        entityTypeId: string
+        moduleId: string
+        value: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('booking.v1.waitList.externalData.list', { waitListId: 257 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // booking.v1.waitList.externalData.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ExternalDataListResult>({
+        method: 'booking.v1.waitList.externalData.list',
+        params: {
+          waitListId: 257,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External data entries:', result.externalData.length, result.externalData)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('booking.v1.waitList.externalData.list', { waitListId: 257 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getWaitListExternalData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // booking.v1.waitList.externalData.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitList.externalData.list',
+            params: {
+              waitListId: 257,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External data entries:', result.externalData.length, result.externalData)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getWaitListExternalData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/external-data/booking-v1-waitlist-externaldata-set.md
+++ b/api-reference/booking/waitlist/external-data/booking-v1-waitlist-externaldata-set.md
@@ -70,36 +70,87 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.waitlist.externalData.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"booking.v1.waitlist.externalData.set",
-    		{
-    			waitListId: 14,
-    			externalData: [
-    				{
-    					moduleId: "crm",
-    					entityTypeId: "DEAL",
-    					value: "1"
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.waitlist.externalData.set',
+        params: {
+          waitListId: 14,
+          externalData: [
+            {
+              moduleId: 'crm',
+              entityTypeId: 'DEAL',
+              value: '1',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External data set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setExternalData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.externalData.set',
+            params: {
+              waitListId: 14,
+              externalData: [
+                {
+                  moduleId: 'crm',
+                  entityTypeId: 'DEAL',
+                  value: '1',
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External data set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setExternalData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/booking/waitlist/external-data/booking-v1-waitlist-externaldata-unset.md
+++ b/api-reference/booking/waitlist/external-data/booking-v1-waitlist-externaldata-unset.md
@@ -53,29 +53,73 @@
     https://**put_your_bitrix24_address**/rest/**put_your_user_id_here**/**put_your_webhook_here**/booking.v1.waitlist.externalData.unset
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'booking.v1.waitlist.externalData.unset',
-    		{
-    			waitListId: 14,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    		console.error(result.error());
-    	else
-    		console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'booking.v1.waitlist.externalData.unset',
+        params: {
+          waitListId: 14,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('External data unset successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unsetWaitlistExternalData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'booking.v1.waitlist.externalData.unset',
+            params: {
+              waitListId: 14,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('External data unset successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unsetWaitlistExternalData)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.