### PR TITLE
docs(sonet-group): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/sonet-group/members/sonet-group-user-add.md
+++ b/api-reference/sonet-group/members/sonet-group-user-add.md
@@ -60,28 +60,75 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.add',
-            {
-                GROUP_ID: 69,
-                USER_ID: [1271, 1272],
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Users added to group:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'sonet_group.user.add',
+        params: {
+          GROUP_ID: 69,
+          USER_ID: [1271, 1272],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added user IDs:', result, 'count:', result.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addUsersToGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.add',
+            params: {
+              GROUP_ID: 69,
+              USER_ID: [1271, 1272],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added user IDs:', result, 'count:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addUsersToGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/members/sonet-group-user-delete.md
+++ b/api-reference/sonet-group/members/sonet-group-user-delete.md
@@ -64,28 +64,75 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.delete',
-            {
-                GROUP_ID: 69,
-                USER_ID: [1271, 1272]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Users deleted from group:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'sonet_group.user.delete',
+        params: {
+          GROUP_ID: 69,
+          USER_ID: [1271, 1272],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted user IDs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteGroupUsers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.delete',
+            params: {
+              GROUP_ID: 69,
+              USER_ID: [1271, 1272],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted user IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteGroupUsers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/members/sonet-group-user-get.md
+++ b/api-reference/sonet-group/members/sonet-group-user-get.md
@@ -54,27 +54,79 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.get',
-            {
-                ID: 69
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Group users:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each GroupMember returned in result[]
+    type GroupMember = {
+      USER_ID: string
+      ROLE: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GroupMember[]>({
+        method: 'sonet_group.user.get',
+        params: {
+          ID: 69,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Group members count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getGroupMembers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.get',
+            params: {
+              ID: 69,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Group members count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getGroupMembers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/members/sonet-group-user-invite.md
+++ b/api-reference/sonet-group/members/sonet-group-user-invite.md
@@ -60,29 +60,77 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.invite
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.invite',
-            {
-                GROUP_ID: 69,
-                USER_ID: 1271,
-                MESSAGE: 'Присоединяйтесь к проекту',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('User invited to group:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'sonet_group.user.invite',
+        params: {
+          GROUP_ID: 69,
+          USER_ID: 1271,
+          MESSAGE: 'Join the project',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Invited user IDs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function inviteGroupUser() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.invite',
+            params: {
+              GROUP_ID: 69,
+              USER_ID: 1271,
+              MESSAGE: 'Join the project',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Invited user IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', inviteGroupUser)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/members/sonet-group-user-request.md
+++ b/api-reference/sonet-group/members/sonet-group-user-request.md
@@ -56,28 +56,75 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.request
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.request',
-            {
-                GROUP_ID: 69,
-                MESSAGE: 'Прошу добавить меня в проект',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Request result:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sonet_group.user.request',
+        params: {
+          GROUP_ID: 69,
+          MESSAGE: 'Please add me to the project',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Request sent:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function requestGroupJoin() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.request',
+            params: {
+              GROUP_ID: 69,
+              MESSAGE: 'Please add me to the project',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Request sent:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', requestGroupJoin)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/members/sonet-group-user-update.md
+++ b/api-reference/sonet-group/members/sonet-group-user-update.md
@@ -73,29 +73,77 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.update',
-            {
-                GROUP_ID: 69,
-                USER_ID: [1271, 1272],
-                ROLE: 'E'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Users updated in group:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'sonet_group.user.update',
+        params: {
+          GROUP_ID: 69,
+          USER_ID: [1271, 1272],
+          ROLE: 'E',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated user IDs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateGroupUsersRole() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.update',
+            params: {
+              GROUP_ID: 69,
+              USER_ID: [1271, 1272],
+              ROLE: 'E',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated user IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateGroupUsersRole)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-add.md
+++ b/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-add.md
@@ -80,29 +80,87 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.backlog.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.backlog.add',
-    		{
-    			"fields": {
-    				"groupId": 125,
-    				"createdBy": 6,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BacklogAddResult = {
+      id: number
+      groupId: number
+      createdBy: number
+      modifiedBy: number
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BacklogAddResult>({
+        method: 'tasks.api.scrum.backlog.add',
+        params: {
+          fields: {
+            groupId: 125,
+            createdBy: 6,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Backlog created:', result.id, 'for group:', result.groupId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBacklog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.backlog.add',
+            params: {
+              fields: {
+                groupId: 125,
+                createdBy: 6,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Backlog created:', result.id, 'for group:', result.groupId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBacklog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-delete.md
+++ b/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-delete.md
@@ -58,26 +58,73 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.backlog.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.backlog.delete',
-    		{
-    			"id": 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<unknown[]>({
+        method: 'tasks.api.scrum.backlog.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Backlog deleted successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteBacklog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.backlog.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Backlog deleted successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteBacklog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-get-fields.md
+++ b/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-get-fields.md
@@ -43,24 +43,78 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.backlog.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.backlog.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type FieldInfo = {
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BacklogGetFieldsResult = {
+      fields: Record<string, FieldInfo>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<BacklogGetFieldsResult>({
+        method: 'tasks.api.scrum.backlog.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.fields), result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBacklogFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.backlog.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.fields), result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBacklogFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-get.md
+++ b/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-get.md
@@ -56,26 +56,81 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.backlog.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.backlog.get',
-    		{
-    			"id": 125,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BacklogGetResult = {
+      id: number
+      groupId: number
+      createdBy: number
+      modifiedBy: number
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BacklogGetResult>({
+        method: 'tasks.api.scrum.backlog.get',
+        params: {
+          id: 125,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Backlog id:', result.id, 'groupId:', result.groupId, 'createdBy:', result.createdBy, 'modifiedBy:', result.modifiedBy)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBacklog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.backlog.get',
+            params: {
+              id: 125,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Backlog id:', result.id, 'groupId:', result.groupId, 'createdBy:', result.createdBy, 'modifiedBy:', result.modifiedBy)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBacklog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-update.md
+++ b/api-reference/sonet-group/scrum/backlog/tasks-api-scrum-backlog-update.md
@@ -80,30 +80,89 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.backlog.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.backlog.update',
-    		{
-    			"id": 1,
-    			"fields": {
-    				"groupId": 125,
-    				"createdBy": 6,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BacklogUpdateResult = {
+      id: number
+      groupId: number
+      createdBy: number
+      modifiedBy: number
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BacklogUpdateResult>({
+        method: 'tasks.api.scrum.backlog.update',
+        params: {
+          id: 1,
+          fields: {
+            groupId: 125,
+            createdBy: 6,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.groupId, result.createdBy, result.modifiedBy)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBacklog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.backlog.update',
+            params: {
+              id: 1,
+              fields: {
+                groupId: 125,
+                createdBy: 6,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.groupId, result.createdBy, result.modifiedBy)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBacklog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-add.md
+++ b/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-add.md
@@ -109,32 +109,96 @@ fields: {
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.epic.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.epic.add',
-    		{
-    			fields: {
-    				name: name,
-    				groupId: groupId,
-    				description: description,
-    				color: color,
-    				files: files
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EpicAddResult = {
+      id: number
+      groupId: number
+      name: string
+      description: string
+      createdBy: number
+      modifiedBy: number
+      color: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<EpicAddResult>({
+        method: 'tasks.api.scrum.epic.add',
+        params: {
+          fields: {
+            name: 'Epic 1',
+            groupId: 1,
+            description: 'Description text',
+            color: '#69dafc',
+            files: ['n428', 'n345'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added epic:', result.id, result.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addEpic() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.epic.add',
+            params: {
+              fields: {
+                name: 'Epic 1',
+                groupId: 1,
+                description: 'Description text',
+                color: '#69dafc',
+                files: ['n428', 'n345'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added epic:', result.id, result.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addEpic)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-delete.md
+++ b/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-delete.md
@@ -57,26 +57,73 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.epic.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.epic.delete',
-    		{
-    			id: epicId,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.epic.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Epic deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteEpic() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.epic.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Epic deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteEpic)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-get-fields.md
+++ b/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-get-fields.md
@@ -44,24 +44,78 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.epic.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.epic.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type EpicFieldItem = {
+      type: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EpicFieldsResult = {
+      fields: Record<string, EpicFieldItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<EpicFieldsResult>({
+        method: 'tasks.api.scrum.epic.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.fields), result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEpicFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.epic.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.fields), result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEpicFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-get.md
+++ b/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-get.md
@@ -64,27 +64,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.epic.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const epicId = 1;
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.epic.get',
-    		{
-    			id: epicId,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EpicGetResult = {
+      id: number
+      groupId: number
+      name: string
+      description: string
+      createdBy: number
+      modifiedBy: number
+      color: string
+      files: Record<string, unknown>
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<EpicGetResult>({
+        method: 'tasks.api.scrum.epic.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.color)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEpic() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.epic.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.color)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEpic)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-list.md
+++ b/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-list.md
@@ -134,98 +134,124 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.epic.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const groupId = 143;
+    declare const $b24: B24Frame
+
+    // Shape of each EpicItem returned in result[]
+    type EpicItem = {
+      id: number
+      groupId: number
+      name: string
+      description: string
+      createdBy: number
+      modifiedBy: number
+      color: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'tasks.api.scrum.epic.list',
-        {
+      // tasks.api.scrum.epic.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<EpicItem[]>({
+        method: 'tasks.api.scrum.epic.list',
+        params: {
           filter: {
-            GROUP_ID: groupId,
+            GROUP_ID: 143,
             '>=ID': 1,
             '<=ID': 50,
-            'NAME': '%эпик%',
+            NAME: '%epic%',
             '!=DESCRIPTION': 'old epic',
-            'CREATED_BY': 1,
-            'MODIFIED_BY': 3,
-            'COLOR': '#69dafc'
+            CREATED_BY: 1,
+            MODIFIED_BY: 3,
+            COLOR: '#69dafc',
           },
           order: {
-            'ID': 'asc',
-            'NAME': 'desc'
+            ID: 'asc',
+            NAME: 'desc',
           },
           select: ['ID', 'NAME', 'DESCRIPTION', 'CREATED_BY', 'MODIFIED_BY', 'COLOR'],
-          start: 0
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const groupId = 143;
-    try {
-      const generator = $b24.fetchListMethod('tasks.api.scrum.epic.list', {
-        filter: {
-          GROUP_ID: groupId,
-          '>=ID': 1,
-          '<=ID': 50,
-          'NAME': '%эпик%',
-          '!=DESCRIPTION': 'old epic',
-          'CREATED_BY': 1,
-          'MODIFIED_BY': 3,
-          'COLOR': '#69dafc'
-        },
-        order: {
-          'ID': 'asc',
-          'NAME': 'desc'
-        },
-        select: ['ID', 'NAME', 'DESCRIPTION', 'CREATED_BY', 'MODIFIED_BY', 'COLOR'],
-        start: 0
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Loaded epics:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const groupId = 143;
-    try {
-      const response = await $b24.callMethod('tasks.api.scrum.epic.list', {
-        filter: {
-          GROUP_ID: groupId,
-          '>=ID': 1,
-          '<=ID': 50,
-          'NAME': '%эпик%',
-          '!=DESCRIPTION': 'old epic',
-          'CREATED_BY': 1,
-          'MODIFIED_BY': 3,
-          'COLOR': '#69dafc'
-        },
-        order: {
-          'ID': 'asc',
-          'NAME': 'desc'
-        },
-        select: ['ID', 'NAME', 'DESCRIPTION', 'CREATED_BY', 'MODIFIED_BY', 'COLOR'],
-        start: 0
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function loadEpicList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // tasks.api.scrum.epic.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.epic.list',
+            params: {
+              filter: {
+                GROUP_ID: 143,
+                '>=ID': 1,
+                '<=ID': 50,
+                NAME: '%epic%',
+                '!=DESCRIPTION': 'old epic',
+                CREATED_BY: 1,
+                MODIFIED_BY: 3,
+                COLOR: '#69dafc',
+              },
+              order: {
+                ID: 'asc',
+                NAME: 'desc',
+              },
+              select: ['ID', 'NAME', 'DESCRIPTION', 'CREATED_BY', 'MODIFIED_BY', 'COLOR'],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Loaded epics:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', loadEpicList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-update.md
+++ b/api-reference/sonet-group/scrum/epic/tasks-api-scrum-epic-update.md
@@ -120,32 +120,96 @@ fields: {
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.epic.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.epic.update',
-    		{
-    			id: epicId,
-    			fields:{
-    				name: name,
-    				description: description,
-    				color: color,
-    				files: files
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EpicUpdateResult = {
+      id: number
+      groupId: number
+      name: string
+      description: string
+      createdBy: number
+      modifiedBy: number
+      color: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<EpicUpdateResult>({
+        method: 'tasks.api.scrum.epic.update',
+        params: {
+          id: 1,
+          fields: {
+            name: 'Updated epic name',
+            description: 'Updated description text',
+            color: '#bbecf1',
+            files: ['n429', 'n243'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated epic:', result.id, result.name, result.color)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateEpic() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.epic.update',
+            params: {
+              id: 1,
+              fields: {
+                name: 'Updated epic name',
+                description: 'Updated description text',
+                color: '#bbecf1',
+                files: ['n429', 'n243'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated epic:', result.id, result.name, result.color)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateEpic)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-add-stage.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-add-stage.md
@@ -75,32 +75,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.addStage
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.addStage',
-    		{
-    			"fields": {
-    				"sprintId": 1,
-    				"name": "Первая стадия",
-    				"type": "NEW",
-    				"color": "00C4FB",
-    				"sort": 100,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'tasks.api.scrum.kanban.addStage',
+        params: {
+          fields: {
+            sprintId: 1,
+            name: 'First stage',
+            type: 'NEW',
+            color: '00C4FB',
+            sort: 100,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New kanban stage ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addKanbanStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.addStage',
+            params: {
+              fields: {
+                sprintId: 1,
+                name: 'First stage',
+                type: 'NEW',
+                color: '00C4FB',
+                sort: 100,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New kanban stage ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addKanbanStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-add-task.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-add-task.md
@@ -56,28 +56,77 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.addTask
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.addTask',
-    		{
-    			"sprintId": 5,
-    			"taskId": 751,
-    			"stageId": 58,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.kanban.addTask',
+        params: {
+          sprintId: 5,
+          taskId: 751,
+          stageId: 58,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task added to kanban:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskToKanban() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.addTask',
+            params: {
+              sprintId: 5,
+              taskId: 751,
+              stageId: 58,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task added to kanban:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskToKanban)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-delete-stage.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-delete-stage.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.deleteStage
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.deleteStage',
-    		{
-    			"stageId": 65,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.kanban.deleteStage',
+        params: {
+          stageId: 65,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stage deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.deleteStage',
+            params: {
+              stageId: 65,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stage deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-delete-task.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-delete-task.md
@@ -54,27 +54,75 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.deleteTask
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.deleteTask',
-    		{
-    			"sprintId": 5,
-    			"taskId": 751,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.kanban.deleteTask',
+        params: {
+          sprintId: 5,
+          taskId: 751,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task deleted from Scrum kanban:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteKanbanTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.deleteTask',
+            params: {
+              sprintId: 5,
+              taskId: 751,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task deleted from Scrum kanban:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteKanbanTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-get-fields.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-get-fields.md
@@ -43,24 +43,77 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = {
+      fields: Record<string, FieldInfo>
     }
-    catch( error )
-    {
-    	console.error(error);
+    type FieldInfo = {
+      type: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'tasks.api.scrum.kanban.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Kanban stage fields:', Object.keys(result.fields), result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getKanbanFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Kanban stage fields:', Object.keys(result.fields), result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getKanbanFields)
+    </script>
     ```
 
 - BX24.js

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-get-stages.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-get-stages.md
@@ -52,26 +52,83 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.getStages
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.getStages',
-    		{
-    			"sprintId": 5,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each KanbanStage returned in result[]
+    type KanbanStage = {
+      id: string
+      name: string
+      sort: string
+      type: 'NEW' | 'WORK' | 'FINISH'
+      sprintId: string
+      color: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<KanbanStage[]>({
+        method: 'tasks.api.scrum.kanban.getStages',
+        params: {
+          sprintId: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Kanban stages:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getKanbanStages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.getStages',
+            params: {
+              sprintId: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Kanban stages:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getKanbanStages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-update-stage.md
+++ b/api-reference/sonet-group/scrum/kanban/tasks-api-scrum-kanban-update-stage.md
@@ -73,32 +73,85 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.kanban.updateStage
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.kanban.updateStage',
-    		{
-    			"stageId": 65,
-    			"fields": {
-    				"name": "Обновленная стадия",
-    				"type": "WORK",
-    				"color": "00C4FB",
-    				"sort": 100,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.kanban.updateStage',
+        params: {
+          stageId: 65,
+          fields: {
+            name: 'Updated stage',
+            type: 'WORK',
+            color: '00C4FB',
+            sort: 100,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stage updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateKanbanStage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.kanban.updateStage',
+            params: {
+              stageId: 65,
+              fields: {
+                name: 'Updated stage',
+                type: 'WORK',
+                color: '00C4FB',
+                sort: 100,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stage updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateKanbanStage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-add.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-add.md
@@ -94,34 +94,104 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.add',
-    		{
-    			fields: {
-    				name: name,
-    				groupId: groupId,
-    				createdBy: createdBy,
-    				sort: sort,
-    				status: status,
-    				dateStart: dateStart,
-    				dateEnd: dateEnd,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SprintAddResult = {
+      id: number
+      groupId: number
+      entityType: string
+      name: string
+      goal: string
+      sort: number
+      createdBy: number
+      modifiedBy: number
+      dateStart: ISODate | null
+      dateEnd: ISODate | null
+      status: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SprintAddResult>({
+        method: 'tasks.api.scrum.sprint.add',
+        params: {
+          fields: {
+            name: 'Sprint 1',
+            groupId: 1,
+            createdBy: 1,
+            sort: 1,
+            status: 'planned',
+            dateStart: '2021-11-22T00:00:00+02:00',
+            dateEnd: '2021-11-29T00:00:00+02:00',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sprint added:', result.id, result.name, result.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSprint() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.add',
+            params: {
+              fields: {
+                name: 'Sprint 1',
+                groupId: 1,
+                createdBy: 1,
+                sort: 1,
+                status: 'planned',
+                dateStart: '2021-11-22T00:00:00+02:00',
+                dateEnd: '2021-11-29T00:00:00+02:00',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sprint added:', result.id, result.name, result.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSprint)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-complete.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-complete.md
@@ -57,26 +57,88 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.complete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.complete',
-    		{
-    			id: groupId
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SprintResult = {
+      id: number
+      groupId: number
+      entityType: string
+      name: string
+      goal: string
+      sort: number
+      createdBy: number
+      modifiedBy: number
+      dateStart: ISODate | null
+      dateEnd: ISODate | null
+      status: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SprintResult>({
+        method: 'tasks.api.scrum.sprint.complete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Completed sprint:', result.id, 'Status:', result.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function completeSprint() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.complete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Completed sprint:', result.id, 'Status:', result.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', completeSprint)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-delete.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-delete.md
@@ -57,26 +57,73 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.delete
     ```
     
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.delete',
-    		{
-    			id: sprintId
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.sprint.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sprint deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSprint() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sprint deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSprint)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-get-fields.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-get-fields.md
@@ -44,24 +44,78 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      type: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SprintGetFieldsResult = {
+      fields: Record<string, FieldItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SprintGetFieldsResult>({
+        method: 'tasks.api.scrum.sprint.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.fields), result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSprintFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.fields), result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSprintFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-get.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-get.md
@@ -57,26 +57,88 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.get
     ```    
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.get',
-    		{
-    			id: sprintId,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SprintGetResult = {
+      id: number
+      groupId: number
+      entityType: string
+      name: string
+      goal: string
+      sort: number
+      createdBy: number
+      modifiedBy: number
+      dateStart: ISODate | null
+      dateEnd: ISODate | null
+      status: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SprintGetResult>({
+        method: 'tasks.api.scrum.sprint.get',
+        params: {
+          id: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSprintById() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.get',
+            params: {
+              id: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSprintById)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-list.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-list.md
@@ -104,62 +104,110 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const groupId = 1;
+    declare const $b24: B24Frame
+
+    // Shape of each sprint returned in result[]
+    type Sprint = {
+      id: number
+      groupId: number
+      entityType: string
+      name: string
+      goal: string
+      sort: number
+      createdBy: number
+      modifiedBy: number
+      dateStart: ISODate | null
+      dateEnd: ISODate | null
+      status: string
+    }
+
+    const groupId = 1
+
+    // tasks.api.scrum.sprint.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-      const response = await $b24.callListMethod(
-        'tasks.api.scrum.sprint.list',
-        {
+      const response = await $b24.actions.v2.call.make<Sprint[]>({
+        method: 'tasks.api.scrum.sprint.list',
+        params: {
           filter: {
             GROUP_ID: groupId,
-            '>=DATE_END': new Date()
-          }
+            '>=DATE_END': new Date().toISOString(),
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const groupId = 1;
-    try {
-      const generator = $b24.fetchListMethod('tasks.api.scrum.sprint.list', {
-        filter: {
-          GROUP_ID: groupId,
-          '>=DATE_END': new Date()
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sprints:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const groupId = 1;
-    try {
-      const response = await $b24.callMethod('tasks.api.scrum.sprint.list', {
-        filter: {
-          GROUP_ID: groupId,
-          '>=DATE_END': new Date()
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listScrumSprints() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const groupId = 1
+
+          // tasks.api.scrum.sprint.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.list',
+            params: {
+              filter: {
+                GROUP_ID: groupId,
+                '>=DATE_END': new Date().toISOString(),
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sprints:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listScrumSprints)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-start.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-start.md
@@ -61,26 +61,92 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.start
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.start',
-    		{
-    			id: sprintId
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SprintStartResult = {
+      id: number,
+      groupId: number,
+      entityType: string,
+      name: string,
+      goal: string,
+      sort: number,
+      createdBy: number,
+      modifiedBy: number,
+      dateStart: ISODate | null,
+      dateEnd: ISODate | null,
+      status: string,
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    const sprintId = 2
+
+    try {
+      const response = await $b24.actions.v2.call.make<SprintStartResult>({
+        method: 'tasks.api.scrum.sprint.start',
+        params: {
+          id: sprintId,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sprint started:', result.id, result.name, result.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startSprint() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const sprintId = 2
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.start',
+            params: {
+              id: sprintId,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sprint started:', result.id, result.name, result.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startSprint)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-update.md
+++ b/api-reference/sonet-group/scrum/sprint/tasks-api-scrum-sprint-update.md
@@ -90,32 +90,100 @@
     https://your-domain.bitrix24.com/rest/tasks.api.scrum.sprint.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.sprint.update',
-    		{
-    			id: sprintId,
-    			fields: {
-    				name: name,
-    				groupId: groupId,
-    				dateStart: dateStart,
-    				dateEnd: dateEnd,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SprintResult = {
+      id: number
+      groupId: number
+      entityType: string
+      name: string
+      goal: string
+      sort: number
+      createdBy: number
+      modifiedBy: number
+      dateStart: ISODate | null
+      dateEnd: ISODate | null
+      status: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SprintResult>({
+        method: 'tasks.api.scrum.sprint.update',
+        params: {
+          id: 2,
+          fields: {
+            name: 'Sprint 2',
+            groupId: 1,
+            dateStart: '2021-11-22T00:00:00+02:00',
+            dateEnd: '2021-11-29T00:00:00+02:00',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated sprint:', result.id, result.name, result.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSprint() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.sprint.update',
+            params: {
+              id: 2,
+              fields: {
+                name: 'Sprint 2',
+                groupId: 1,
+                dateStart: '2021-11-22T00:00:00+02:00',
+                dateEnd: '2021-11-29T00:00:00+02:00',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated sprint:', result.id, result.name, result.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSprint)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/task/tasks-api-scrum-task-get-fields.md
+++ b/api-reference/sonet-group/scrum/task/tasks-api-scrum-task-get-fields.md
@@ -41,24 +41,78 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.task.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.task.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      type: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = {
+      fields: Record<string, FieldItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'tasks.api.scrum.task.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.fields), result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.task.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.fields), result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/task/tasks-api-scrum-task-get.md
+++ b/api-reference/sonet-group/scrum/task/tasks-api-scrum-task-get.md
@@ -52,33 +52,83 @@
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.task.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.task.get',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ScrumTaskResult = {
+      entityId: number
+      storyPoints: string
+      epicId: number
+      sort: number
+      createdBy: number
+      modifiedBy: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ScrumTaskResult>({
+        method: 'tasks.api.scrum.task.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.entityId, result.storyPoints, result.epicId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getScrumTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.task.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.entityId, result.storyPoints, result.epicId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getScrumTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/scrum/task/tasks-api-scrum-task-update.md
+++ b/api-reference/sonet-group/scrum/task/tasks-api-scrum-task-update.md
@@ -89,32 +89,83 @@ fields: {
     https://**put_your_bitrix24_address**/rest/tasks.api.scrum.task.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'tasks.api.scrum.task.update',
-    		{
-    			id: 1,
-    			fields: 
-    			{
-    				epicId: 1,
-    				storyPoints: '8',
-    				entityId: 2
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'tasks.api.scrum.task.update',
+        params: {
+          id: 1,
+          fields: {
+            epicId: 1,
+            storyPoints: '8',
+            entityId: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Scrum task updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateScrumTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'tasks.api.scrum.task.update',
+            params: {
+              id: 1,
+              fields: {
+                epicId: 1,
+                storyPoints: '8',
+                entityId: 2,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Scrum task updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateScrumTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/socialnetwork-api-workgroup-get.md
+++ b/api-reference/sonet-group/socialnetwork-api-workgroup-get.md
@@ -112,28 +112,111 @@
     https://**put_your_bitrix24_address**/rest/socialnetwork.api.workgroup.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'socialnetwork.api.workgroup.get',
-    		{
-    			params: {
-    				groupId: 622,
-    				select: [ 'DEPARTMENTS', 'TAGS' ],
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type WorkgroupGetResult = {
+      ID: number
+      ACTIVE: string
+      NAME: string
+      DESCRIPTION: string
+      CLOSED: string
+      VISIBLE: string
+      OPENED: string
+      DATE_CREATE: string
+      DATE_UPDATE: string
+      DATE_ACTIVITY: string
+      AVATAR_TYPE: string
+      OWNER_ID: number
+      INITIATE_PERMS: string
+      NUMBER_OF_MEMBERS: number
+      NUMBER_OF_MODERATORS: number
+      PROJECT: string
+      PROJECT_DATE_START: string | null
+      PROJECT_DATE_FINISH: string | null
+      TYPE: string
+      MEMBERS: number[]
+      CHAT_ID: number
+      DIALOG_ID: string
+      ORDINARY_MEMBERS: number[]
+      INVITED_MEMBERS: number[]
+      MODERATOR_MEMBERS: number[]
+      SITE_IDS: string[]
+      TAGS: string[]
+      DEPARTMENTS: number[]
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<WorkgroupGetResult>({
+        method: 'socialnetwork.api.workgroup.get',
+        params: {
+          params: {
+            groupId: 622,
+            select: ['DEPARTMENTS', 'TAGS'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.TYPE, result.TAGS, result.DEPARTMENTS)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getWorkgroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'socialnetwork.api.workgroup.get',
+            params: {
+              params: {
+                groupId: 622,
+                select: ['DEPARTMENTS', 'TAGS'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.TYPE, result.TAGS, result.DEPARTMENTS)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getWorkgroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/socialnetwork-api-workgroup-list.md
+++ b/api-reference/sonet-group/socialnetwork-api-workgroup-list.md
@@ -241,62 +241,108 @@
     https://**put_your_bitrix24_address**/rest/socialnetwork.api.workgroup.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    try {
-        const response = await $b24.callListMethod(
-            'socialnetwork.api.workgroup.list',
-            {
-                filter: { ACTIVE: 'Y', CLOSED: 'N', '%NAME': 'группа' },
-                select: ['ID', 'NAME', 'TYPE', 'AVATAR'],
-                order: { ID: 'DESC' },
-                params: { mode: 'mobile', shouldSelectDialogId: 'Y' }
-            },
-            (progress) => { console.log('Progress:', progress) }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-        console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type WorkgroupListResult = {
+      workgroups: Workgroup[]
     }
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
+    type Workgroup = {
+      id: string
+      name: string
+      type: string
+      avatar: string
+      additionalData: {
+        role: string
+        initiatedByType: string
+      }
+      dialogId: string
+    }
+
     try {
-        const generator = $b24.fetchListMethod(
-            'socialnetwork.api.workgroup.list',
-            {
-                filter: { ACTIVE: 'Y', CLOSED: 'N', '%NAME': 'группа' },
-                select: ['ID', 'NAME', 'TYPE'],
-                order: { ID: 'DESC' }
+      // socialnetwork.api.workgroup.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<WorkgroupListResult>({
+        method: 'socialnetwork.api.workgroup.list',
+        params: {
+          filter: { ACTIVE: 'Y', CLOSED: 'N', '%NAME': 'group' },
+          select: ['ID', 'NAME', 'TYPE', 'AVATAR'],
+          order: { ID: 'DESC' },
+          params: { mode: 'mobile', shouldSelectDialogId: 'Y' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Workgroups:', result.workgroups.length, result.workgroups)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchWorkgroupList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // socialnetwork.api.workgroup.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'socialnetwork.api.workgroup.list',
+            params: {
+              filter: { ACTIVE: 'Y', CLOSED: 'N', '%NAME': 'group' },
+              select: ['ID', 'NAME', 'TYPE', 'AVATAR'],
+              order: { ID: 'DESC' },
+              params: { mode: 'mobile', shouldSelectDialogId: 'Y' },
+              start: 0,
             },
-            'ID'
-        );
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity) }
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Workgroups:', result.workgroups.length, result.workgroups)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    try {
-        const response = await $b24.callMethod(
-            'socialnetwork.api.workgroup.list',
-            {
-                filter: { ACTIVE: 'Y', CLOSED: 'N', '%NAME': 'группа' },
-                select: ['ID', 'NAME', 'TYPE'],
-                order: { ID: 'DESC' }
-            },
-            0
-        );
-        const result = response.getData().result.workgroups || [];
-        for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      document.addEventListener('DOMContentLoaded', fetchWorkgroupList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-create.md
+++ b/api-reference/sonet-group/sonet-group-create.md
@@ -127,34 +127,89 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.create
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.create',
-            {
-                NAME: 'Новый проект',
-                PROJECT: 'Y',
-                VISIBLE: 'Y',
-                OPENED: 'N',
-                INITIATE_PERMS: 'K',
-                IMAGE: [
-                    'avatar.png',
-                    'iVBORw0KGgoAAAANSUhEUgAA...'
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created group with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'sonet_group.create',
+        params: {
+          NAME: 'New project',
+          PROJECT: 'Y',
+          VISIBLE: 'Y',
+          OPENED: 'N',
+          INITIATE_PERMS: 'K',
+          IMAGE: [
+            'avatar.png',
+            'iVBORw0KGgoAAAANSUhEUgAA...',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created group or project ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.create',
+            params: {
+              NAME: 'New project',
+              PROJECT: 'Y',
+              VISIBLE: 'Y',
+              OPENED: 'N',
+              INITIATE_PERMS: 'K',
+              IMAGE: [
+                'avatar.png',
+                'iVBORw0KGgoAAAANSUhEUgAA...',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created group or project ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-delete.md
+++ b/api-reference/sonet-group/sonet-group-delete.md
@@ -54,27 +54,73 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.delete',
-            {
-                GROUP_ID: 77
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted group:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sonet_group.delete',
+        params: {
+          GROUP_ID: 77,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Group deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.delete',
+            params: {
+              GROUP_ID: 77,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Group deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-feature-access.md
+++ b/api-reference/sonet-group/sonet-group-feature-access.md
@@ -97,29 +97,77 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.feature.access
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.feature.access',
-            {
-                GROUP_ID: 77,
-                FEATURE: 'blog',
-                OPERATION: 'write_post'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Feature access result:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sonet_group.feature.access',
+        params: {
+          GROUP_ID: 77,
+          FEATURE: 'blog',
+          OPERATION: 'write_post',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Feature access allowed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkFeatureAccess() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.feature.access',
+            params: {
+              GROUP_ID: 77,
+              FEATURE: 'blog',
+              OPERATION: 'write_post',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Feature access allowed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkFeatureAccess)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-get.md
+++ b/api-reference/sonet-group/sonet-group-get.md
@@ -150,28 +150,109 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.get',
-            {
-                ORDER: { NAME: 'ASC' },
-                FILTER: { '%NAME': 'Про' }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved groups:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each SonetGroup returned in result[]
+    type SonetGroup = {
+      ID: string
+      SITE_ID: string
+      NAME: string
+      DESCRIPTION: string | null
+      DATE_CREATE: ISODate
+      DATE_UPDATE: ISODate
+      DATE_ACTIVITY: ISODate
+      ACTIVE: string
+      VISIBLE: string
+      OPENED: string
+      CLOSED: string
+      SUBJECT_ID: string
+      OWNER_ID: string
+      KEYWORDS: string | null
+      NUMBER_OF_MEMBERS: string
+      SUBJECT_NAME: string
+      PROJECT: string
+      IS_EXTRANET: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // sonet_group.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SonetGroup[]>({
+        method: 'sonet_group.get',
+        params: {
+          ORDER: { NAME: 'ASC' },
+          FILTER: { '%NAME': 'Про' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Retrieved groups:', result.length, result[0]?.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getGroups() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // sonet_group.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.get',
+            params: {
+              ORDER: { NAME: 'ASC' },
+              FILTER: { '%NAME': 'Про' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Retrieved groups:', result.length, result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getGroups)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-setowner.md
+++ b/api-reference/sonet-group/sonet-group-setowner.md
@@ -58,28 +58,75 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.setowner
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.setowner',
-            {
-                GROUP_ID: 77,
-                USER_ID: 1269
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Set owner for group:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sonet_group.setowner',
+        params: {
+          GROUP_ID: 77,
+          USER_ID: 1269,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Owner changed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setGroupOwner() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.setowner',
+            params: {
+              GROUP_ID: 77,
+              USER_ID: 1269,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Owner changed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setGroupOwner)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-update.md
+++ b/api-reference/sonet-group/sonet-group-update.md
@@ -107,28 +107,75 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.update',
-            {
-                GROUP_ID: 77,
-                NAME: 'Новый заголовок проекта'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated group with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'sonet_group.update',
+        params: {
+          GROUP_ID: 77,
+          NAME: 'New project title',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated group ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSonetGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.update',
+            params: {
+              GROUP_ID: 77,
+              NAME: 'New project title',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated group ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSonetGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sonet-group/sonet-group-user-groups.md
+++ b/api-reference/sonet-group/sonet-group-user-groups.md
@@ -45,25 +45,89 @@
     https://**put_your_bitrix24_address**/rest/sonet_group.user.groups
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'sonet_group.user.groups',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved user groups:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each UserGroupItem returned in result[]
+    type UserGroupItem = {
+      GROUP_ID: string
+      GROUP_NAME: string
+      ROLE: string
+      GROUP_IMAGE_ID: string | null
+      GROUP_IMAGE: string
+      IS_EXTRANET?: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // sonet_group.user.groups returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<UserGroupItem[]>({
+        method: 'sonet_group.user.groups',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User groups count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserGroups() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // sonet_group.user.groups returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'sonet_group.user.groups',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User groups count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserGroups)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.