### PR TITLE
	docs(imopenlines): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/imopenlines/imconnector/imconnector-activate.md
+++ b/api-reference/imopenlines/imconnector/imconnector-activate.md
@@ -56,15 +56,77 @@
       https://**put_your_bitrix24_address**/rest/imconnector.activate
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const response = await $b24.callMethod('imconnector.activate', {
-      CONNECTOR: 'myconnector',
-      LINE: 107,
-      ACTIVE: '1',
-    });
-    console.log(response.getData());
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imconnector.activate',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          ACTIVE: '1',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connector activated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function activateConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.activate',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              ACTIVE: '1',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connector activated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', activateConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-chat-name-set.md
+++ b/api-reference/imopenlines/imconnector/imconnector-chat-name-set.md
@@ -58,32 +58,87 @@
     https://**put_your_bitrix24_address**/rest/imconnector.chat.name.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imconnector.chat.name.set',
-            {
-                CONNECTOR: 'connector',
-                LINE: 105,
-                CHAT_ID: '47e007b1-ee15-43db-bcba-1c26e5884d3f',
-                NAME: 'Новое имя диалога'
-            }
-        );
-        
-        const result = response.getData().result;
-        if(result.error())
-            alert("Error: " + result.error());
-        else
-            alert("Успешно: " + result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ChatNameSetResult = {
+      SUCCESS: boolean
+      DATA: {
+        RESULT: Record<string, unknown>
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ChatNameSetResult>({
+        method: 'imconnector.chat.name.set',
+        params: {
+          CONNECTOR: 'connector',
+          LINE: 105,
+          CHAT_ID: '47e007b1-ee15-43db-bcba-1c26e5884d3f',
+          NAME: 'New dialog name',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('SUCCESS:', result.SUCCESS, 'DATA:', result.DATA)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setChatName() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.chat.name.set',
+            params: {
+              CONNECTOR: 'connector',
+              LINE: 105,
+              CHAT_ID: '47e007b1-ee15-43db-bcba-1c26e5884d3f',
+              NAME: 'New dialog name',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('SUCCESS:', result.SUCCESS, 'DATA:', result.DATA)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setChatName)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-connector-data-set.md
+++ b/api-reference/imopenlines/imconnector/imconnector-connector-data-set.md
@@ -82,19 +82,85 @@
       https://**put_your_bitrix24_address**/rest/imconnector.connector.data.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const response = await $b24.callMethod('imconnector.connector.data.set', {
-      CONNECTOR: 'myconnector',
-      LINE: 107,
-      DATA: {
-        ID: 'channel-123',
-        URL: 'https://example.ru/chats/123',
-        NAME: 'Канал поддержки',
-      },
-    });
-    console.log(response.getData());
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imconnector.connector.data.set',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          DATA: {
+            ID: 'channel-123',
+            URL: 'https://example.com/chats/123',
+            NAME: 'Support Channel',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connector data saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setConnectorData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.connector.data.set',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              DATA: {
+                ID: 'channel-123',
+                URL: 'https://example.com/chats/123',
+                NAME: 'Support Channel',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connector data saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setConnectorData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-delete-messages.md
+++ b/api-reference/imopenlines/imconnector/imconnector-delete-messages.md
@@ -121,23 +121,103 @@
       https://**put_your_bitrix24_address**/rest/imconnector.delete.messages
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const payload = {
-      CONNECTOR: 'myconnector',
-      LINE: 107,
-      MESSAGES: [
-        {
-          user: { id: 'ext-user-42' },
-          message: { id: 'ext-msg-1001' },
-          chat: { id: 'channel-123' },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteMessagesResult = {
+      SUCCESS: boolean
+      DATA: {
+        RESULT: Array<{
+          user: string
+          message: { id: string; date?: number; text?: string; files?: unknown[] }
+          chat: { id: string; description?: string }
+          SUCCESS: boolean
+          ERRORS?: string[]
+        }>
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeleteMessagesResult>({
+        method: 'imconnector.delete.messages',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          MESSAGES: [
+            {
+              user: { id: 'ext-user-42' },
+              message: { id: 'ext-msg-1001' },
+              chat: { id: 'channel-123' },
+            },
+          ],
         },
-      ],
-    };
+        requestId: Text.getUuidRfc4122()
+      })
 
-    const response = await $b24.callMethod('imconnector.delete.messages', payload);
-    console.log(response.getData());
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.SUCCESS, result.DATA.RESULT)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteMessages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.delete.messages',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              MESSAGES: [
+                {
+                  user: { id: 'ext-user-42' },
+                  message: { id: 'ext-msg-1001' },
+                  chat: { id: 'channel-123' },
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.SUCCESS, result.DATA.RESULT)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteMessages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-list.md
+++ b/api-reference/imopenlines/imconnector/imconnector-list.md
@@ -41,11 +41,72 @@
       https://**put_your_bitrix24_address**/rest/imconnector.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const response = await $b24.callMethod('imconnector.list', {});
-    console.log(response.getData());
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConnectorListResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConnectorListResult>({
+        method: 'imconnector.list',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connectors:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listConnectors() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.list',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connectors:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listConnectors)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-register.md
+++ b/api-reference/imopenlines/imconnector/imconnector-register.md
@@ -128,34 +128,111 @@
       https://**put_your_bitrix24_address**/rest/imconnector.register
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const payload = {
-      ID: 'myconnector',
-      NAME: 'Мой коннектор',
-      ICON: {
-        DATA_IMAGE: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22/%3E',
-        COLOR: '#69acc0',
-        SIZE: '90%',
-        POSITION: 'center',
-      },
-      PLACEMENT_HANDLER: 'https://example.com/connector/settings',
-      ICON_DISABLED: {
-        DATA_IMAGE: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22/%3E',
-        COLOR: '#99adb3',
-      },
-      DEL_EXTERNAL_MESSAGES: true,
-      EDIT_INTERNAL_MESSAGES: true,
-      DEL_INTERNAL_MESSAGES: true,
-      NEWSLETTER: true,
-      NEED_SYSTEM_MESSAGES: true,
-      NEED_SIGNATURE: true,
-      CHAT_GROUP: false,
-    };
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    const response = await $b24.callMethod('imconnector.register', payload);
-    console.log(response.getData());
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imconnector.register',
+        params: {
+          ID: 'myconnector',
+          NAME: 'My Connector',
+          ICON: {
+            DATA_IMAGE: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22/%3E',
+            COLOR: '#69acc0',
+            SIZE: '90%',
+            POSITION: 'center',
+          },
+          PLACEMENT_HANDLER: 'https://example.com/connector/settings',
+          ICON_DISABLED: {
+            DATA_IMAGE: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22/%3E',
+            COLOR: '#99adb3',
+          },
+          DEL_EXTERNAL_MESSAGES: true,
+          EDIT_INTERNAL_MESSAGES: true,
+          DEL_INTERNAL_MESSAGES: true,
+          NEWSLETTER: true,
+          NEED_SYSTEM_MESSAGES: true,
+          NEED_SIGNATURE: true,
+          CHAT_GROUP: false,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connector registered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.register',
+            params: {
+              ID: 'myconnector',
+              NAME: 'My Connector',
+              ICON: {
+                DATA_IMAGE: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22/%3E',
+                COLOR: '#69acc0',
+                SIZE: '90%',
+                POSITION: 'center',
+              },
+              PLACEMENT_HANDLER: 'https://example.com/connector/settings',
+              ICON_DISABLED: {
+                DATA_IMAGE: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22/%3E',
+                COLOR: '#99adb3',
+              },
+              DEL_EXTERNAL_MESSAGES: true,
+              EDIT_INTERNAL_MESSAGES: true,
+              DEL_INTERNAL_MESSAGES: true,
+              NEWSLETTER: true,
+              NEED_SYSTEM_MESSAGES: true,
+              NEED_SIGNATURE: true,
+              CHAT_GROUP: false,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connector registered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-send-messages.md
+++ b/api-reference/imopenlines/imconnector/imconnector-send-messages.md
@@ -187,43 +187,160 @@
       https://**put_your_bitrix24_address**/rest/imconnector.send.messages
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const payload = {
-      CONNECTOR: 'myconnector',
-      LINE: 107,
-      MESSAGES: [
-        {
-          user: {
-            id: 'ext-user-42',
-            last_name: 'Иванов',
-            name: 'Иван',
-            picture: { url: 'https://example.ru/u42.png' },
-            url: 'https://example.ru/users/42',
-            gender: 'male',
-            email: 'ivan@example.ru',
-            phone: '+79990000000',
-            skip_phone_validate: 'Y',
-          },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SendMessagesResult = {
+      SUCCESS: boolean
+      DATA: {
+        RESULT: Array<{
+          user: string
           message: {
-            id: 'ext-msg-1001',
-            date: 1773265993,
-            text: 'Добрый день',
-            files: [{ url: 'https://example.ru/files/spec.pdf', name: 'spec.pdf' }],
-            disable_crm: 'Y',
-          },
+            id: string
+            date: object
+            text: string
+            files: unknown[]
+          }
           chat: {
-            id: 'channel-123',
-            name: 'Канал поддержки',
-            url: 'https://example.ru/chats/123',
-          },
-        },
-      ],
-    };
+            id: string
+            name: string
+            description: string
+          }
+          extra: {
+            skip_phone_validate?: string
+            disable_tracker?: string
+          }
+          SUCCESS: boolean
+          ERRORS?: string[]
+          session?: {
+            ID: string
+            CHAT_ID: string
+          }
+        }>
+      }
+    }
 
-    const response = await $b24.callMethod('imconnector.send.messages', payload);
-    console.log(response.getData());
+    try {
+      const response = await $b24.actions.v2.call.make<SendMessagesResult>({
+        method: 'imconnector.send.messages',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          MESSAGES: [
+            {
+              user: {
+                id: 'ext-user-42',
+                last_name: 'Smith',
+                name: 'John',
+                picture: { url: 'https://example.com/u42.png' },
+                url: 'https://example.com/users/42',
+                gender: 'male',
+                email: 'john@example.com',
+                phone: '+79990000000',
+                skip_phone_validate: 'Y',
+              },
+              message: {
+                id: 'ext-msg-1001',
+                date: 1773265993,
+                text: 'Hello',
+                files: [{ url: 'https://example.com/files/spec.pdf', name: 'spec.pdf' }],
+                disable_crm: 'Y',
+              },
+              chat: {
+                id: 'channel-123',
+                name: 'Support channel',
+                url: 'https://example.com/chats/123',
+              },
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Success:', result.SUCCESS, 'Sessions:', result.DATA.RESULT.map(r => r.session?.CHAT_ID))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendMessages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.send.messages',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              MESSAGES: [
+                {
+                  user: {
+                    id: 'ext-user-42',
+                    last_name: 'Smith',
+                    name: 'John',
+                    picture: { url: 'https://example.com/u42.png' },
+                    url: 'https://example.com/users/42',
+                    gender: 'male',
+                    email: 'john@example.com',
+                    phone: '+79990000000',
+                    skip_phone_validate: 'Y',
+                  },
+                  message: {
+                    id: 'ext-msg-1001',
+                    date: 1773265993,
+                    text: 'Hello',
+                    files: [{ url: 'https://example.com/files/spec.pdf', name: 'spec.pdf' }],
+                    disable_crm: 'Y',
+                  },
+                  chat: {
+                    id: 'channel-123',
+                    name: 'Support channel',
+                    url: 'https://example.com/chats/123',
+                  },
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Success:', result.SUCCESS, 'Sessions:', result.DATA.RESULT.map(r => r.session?.CHAT_ID))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendMessages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-send-status-delivery.md
+++ b/api-reference/imopenlines/imconnector/imconnector-send-status-delivery.md
@@ -129,23 +129,95 @@
       https://**put_your_bitrix24_address**/rest/imconnector.send.status.delivery
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const payload = {
-      CONNECTOR: 'myconnector',
-      LINE: 107,
-      MESSAGES: [
-        {
-          im: { chat_id: 323, message_id: 85911 },
-          message: { id: ['ext-msg-1007'], date: 1738065600 },
-          chat: { id: 'channel-123' },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SendStatusDeliveryResult = {
+      SUCCESS: boolean
+      DATA: unknown[]
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SendStatusDeliveryResult>({
+        method: 'imconnector.send.status.delivery',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          MESSAGES: [
+            {
+              im: { chat_id: 323, message_id: 85911 },
+              message: { id: ['ext-msg-1007'], date: 1738065600 },
+              chat: { id: 'channel-123' },
+            },
+          ],
         },
-      ],
-    };
+        requestId: Text.getUuidRfc4122()
+      })
 
-    const response = await $b24.callMethod('imconnector.send.status.delivery', payload);
-    console.log(response.getData());
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Delivery status accepted:', result.SUCCESS, 'data:', result.DATA)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendStatusDelivery() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.send.status.delivery',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              MESSAGES: [
+                {
+                  im: { chat_id: 323, message_id: 85911 },
+                  message: { id: ['ext-msg-1007'], date: 1738065600 },
+                  chat: { id: 'channel-123' },
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Delivery status accepted:', result.SUCCESS, 'data:', result.DATA)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendStatusDelivery)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-send-status-reading.md
+++ b/api-reference/imopenlines/imconnector/imconnector-send-status-reading.md
@@ -134,23 +134,95 @@
       https://**put_your_bitrix24_address**/rest/imconnector.send.status.reading
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const payload = {
-      CONNECTOR: 'myconnector',
-      LINE: 107,
-      MESSAGES: [
-        {
-          im: { chat_id: 323, message_id: 85911 },
-          message: { id: ['ext-msg-1007'] },
-          chat: { id: 'channel-123' },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SendStatusReadingResult = {
+      SUCCESS: boolean
+      DATA: unknown[]
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SendStatusReadingResult>({
+        method: 'imconnector.send.status.reading',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          MESSAGES: [
+            {
+              im: { chat_id: 323, message_id: 85911 },
+              message: { id: ['ext-msg-1007'] },
+              chat: { id: 'channel-123' },
+            },
+          ],
         },
-      ],
-    };
+        requestId: Text.getUuidRfc4122()
+      })
 
-    const response = await $b24.callMethod('imconnector.send.status.reading', payload);
-    console.log(response.getData());
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Read status accepted:', result.SUCCESS, 'data:', result.DATA)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendStatusReading() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.send.status.reading',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              MESSAGES: [
+                {
+                  im: { chat_id: 323, message_id: 85911 },
+                  message: { id: ['ext-msg-1007'] },
+                  chat: { id: 'channel-123' },
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Read status accepted:', result.SUCCESS, 'data:', result.DATA)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendStatusReading)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-status.md
+++ b/api-reference/imopenlines/imconnector/imconnector-status.md
@@ -56,14 +56,84 @@
       https://**put_your_bitrix24_address**/rest/imconnector.status
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const response = await $b24.callMethod('imconnector.status', {
-      CONNECTOR: 'myconnector',
-      LINE: '12',
-    });
-    console.log(response.getData());
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConnectorStatusResult = {
+      LINE: number
+      CONNECTOR: string
+      ERROR: boolean
+      CONFIGURED: boolean
+      STATUS: boolean
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConnectorStatusResult>({
+        method: 'imconnector.status',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: '12',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connector status:', result.STATUS, '| Configured:', result.CONFIGURED, '| Error:', result.ERROR)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getConnectorStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.status',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: '12',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connector status:', result.STATUS, '| Configured:', result.CONFIGURED, '| Error:', result.ERROR)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getConnectorStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-unregister.md
+++ b/api-reference/imopenlines/imconnector/imconnector-unregister.md
@@ -48,13 +48,78 @@
       https://**put_your_bitrix24_address**/rest/imconnector.unregister
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const response = await $b24.callMethod('imconnector.unregister', {
-      ID: 'myconnector',
-    });
-    console.log(response.getData());
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UnregisterResult = {
+      result: boolean
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<UnregisterResult>({
+        method: 'imconnector.unregister',
+        params: {
+          ID: 'myconnector',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unregisterConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.unregister',
+            params: {
+              ID: 'myconnector',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unregisterConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/imconnector/imconnector-update-messages.md
+++ b/api-reference/imopenlines/imconnector/imconnector-update-messages.md
@@ -166,40 +166,150 @@
       https://**put_your_bitrix24_address**/rest/imconnector.update.messages
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const payload = {
-        CONNECTOR: 'myconnector',
-        LINE: 107,
-        MESSAGES: [
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateMessagesResult = {
+      SUCCESS: boolean
+      DATA: {
+        RESULT: Array<{
+          user: string
+          message: {
+            id: string
+            date: object
+            text: string
+            files?: unknown[]
+          }
+          chat: {
+            id: string
+            name: string
+            description: string
+          }
+          extra?: {
+            skip_phone_validate?: string
+            disable_tracker?: string
+          }
+          SUCCESS: boolean
+          ERRORS?: string[]
+        }>
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateMessagesResult>({
+        method: 'imconnector.update.messages',
+        params: {
+          CONNECTOR: 'myconnector',
+          LINE: 107,
+          MESSAGES: [
             {
-                user: {
+              user: {
+                id: 'ext-user-42',
+                last_name: 'Ivanov',
+                name: 'Ivan',
+                picture: { url: 'https://example.ru/u42.png' },
+                url: 'https://example.ru/users/42',
+                gender: 'male',
+                email: 'ivan@example.ru',
+                phone: '+79990000000',
+              },
+              message: {
+                id: 'ext-msg-1001',
+                date: 1773266050,
+                text: 'Good afternoon, details clarified',
+              },
+              chat: {
+                id: 'channel-123',
+                name: 'Support channel',
+                url: 'https://example.ru/chats/123',
+              },
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Update status:', result.SUCCESS, 'Results:', result.DATA.RESULT)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateMessages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imconnector.update.messages',
+            params: {
+              CONNECTOR: 'myconnector',
+              LINE: 107,
+              MESSAGES: [
+                {
+                  user: {
                     id: 'ext-user-42',
-                    last_name: 'Иванов',
-                    name: 'Иван',
+                    last_name: 'Ivanov',
+                    name: 'Ivan',
                     picture: { url: 'https://example.ru/u42.png' },
                     url: 'https://example.ru/users/42',
                     gender: 'male',
                     email: 'ivan@example.ru',
                     phone: '+79990000000',
-                },
-                message: {
+                  },
+                  message: {
                     id: 'ext-msg-1001',
                     date: 1773266050,
-                    text: 'Добрый день, уточнили детали',
-                },
-                chat: {
+                    text: 'Good afternoon, details clarified',
+                  },
+                  chat: {
                     id: 'channel-123',
-                    name: 'Канал поддержки',
+                    name: 'Support channel',
                     url: 'https://example.ru/chats/123',
+                  },
                 },
+              ],
             },
-        ],
-    };
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-    const response = await $b24.callMethod('imconnector.update.messages', payload);
-    console.log(response.getData());
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Update status:', result.SUCCESS, 'Results:', result.DATA.RESULT)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateMessages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-finish.md
+++ b/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-finish.md
@@ -60,20 +60,74 @@
     https://**put_your_bitrix24_address**/rest/imopenlines.bot.session.finish
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try {
-    const response = await $b24.callMethod('imopenlines.bot.session.finish', {
-      CHAT_ID: 112,
-    });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    const { result } = response.getData();
-    console.log('Session finished:', result);
-  } catch (error) {
-    console.error('Error finishing session:', error);
-  }
-  ```
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.bot.session.finish',
+        params: {
+          CHAT_ID: 112,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Session finished:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function finishBotSession() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.bot.session.finish',
+            params: {
+              CHAT_ID: 112,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Session finished:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', finishBotSession)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-message-send.md
+++ b/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-message-send.md
@@ -64,22 +64,78 @@
     https://**put_your_bitrix24_address**/rest/imopenlines.bot.session.message.send
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try {
-    const response = await $b24.callMethod('imopenlines.bot.session.message.send', {
-      CHAT_ID: 112,
-      NAME: 'DEFAULT',
-      MESSAGE: 'Здравствуйте! Чем могу помочь?',
-    });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    const { result } = response.getData();
-    console.log('Auto message sent:', result);
-  } catch (error) {
-    console.error('Error sending auto message:', error);
-  }
-  ```
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.bot.session.message.send',
+        params: {
+          CHAT_ID: 112,
+          NAME: 'DEFAULT',
+          MESSAGE: 'Hello! How can I help you?',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Auto message sent:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendSessionMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.bot.session.message.send',
+            params: {
+              CHAT_ID: 112,
+              NAME: 'DEFAULT',
+              MESSAGE: 'Hello! How can I help you?',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Auto message sent:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendSessionMessage)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-operator.md
+++ b/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-operator.md
@@ -54,20 +54,74 @@
     https://**put_your_bitrix24_address**/rest/imopenlines.bot.session.operator
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try {
-    const response = await $b24.callMethod('imopenlines.bot.session.operator', {
-      CHAT_ID: 112,
-    });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    const { result } = response.getData();
-    console.log('Session redirected to free operator:', result);
-  } catch (error) {
-    console.error('Error redirecting session:', error);
-  }
-  ```
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.bot.session.operator',
+        params: {
+          CHAT_ID: 112,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Session redirected to free operator:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function redirectSessionToOperator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.bot.session.operator',
+            params: {
+              CHAT_ID: 112,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Session redirected to free operator:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', redirectSessionToOperator)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-transfer.md
+++ b/api-reference/imopenlines/openlines/chat-bots/imopenlines-bot-session-transfer.md
@@ -86,21 +86,77 @@
     https://**put_your_bitrix24_address**/rest/imopenlines.bot.session.transfer
   ```
 
-- JS
+- JS (TS)
 
-  ```js
+  ```ts
+  // This snippet is an ES module: top-level await requires type="module" or a bundler.
+  // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+  import { Text } from '@bitrix24/b24jssdk'
+  import type { B24Frame } from '@bitrix24/b24jssdk'
+
+  declare const $b24: B24Frame
+
   try {
-    const response = await $b24.callMethod('imopenlines.bot.session.transfer', {
-      CHAT_ID: 112,
-      USER_ID: 12,
-      LEAVE: 'N',
-    });
+    const response = await $b24.actions.v2.call.make<boolean>({
+      method: 'imopenlines.bot.session.transfer',
+      params: {
+        CHAT_ID: 112,
+        USER_ID: 12,
+        LEAVE: 'N',
+      },
+      requestId: Text.getUuidRfc4122()
+    })
 
-    const { result } = response.getData();
-    console.log('Session transferred:', result);
+    // The payload is available only on a successful response
+    if (!response.isSuccess) {
+      console.error(response.getErrorMessages().join('; '))
+    } else {
+      const result = response.getData()!.result
+      console.info('Session transferred:', result)
+    }
   } catch (error) {
-    console.error('Error transferring session:', error);
+    // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+    console.error(error)
   }
+  ```
+
+- JS (UMD)
+
+  ```html
+  <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+  <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+  <script>
+    async function transferSession() {
+      try {
+        // Initialize the SDK inside a Bitrix24 frame
+        const $b24 = await B24Js.initializeB24Frame()
+
+        const response = await $b24.actions.v2.call.make({
+          method: 'imopenlines.bot.session.transfer',
+          params: {
+            CHAT_ID: 112,
+            USER_ID: 12,
+            LEAVE: 'N',
+          },
+          requestId: B24Js.Text.getUuidRfc4122()
+        })
+
+        // The payload is available only on a successful response
+        if (!response.isSuccess) {
+          console.error(response.getErrorMessages().join('; '))
+          return
+        }
+
+        const result = response.getData().result
+        console.info('Session transferred:', result)
+      } catch (error) {
+        // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+        console.error(error)
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', transferSession)
+  </script>
   ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-get-last-id.md
+++ b/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-get-last-id.md
@@ -60,26 +60,75 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.crm.chat.getLastId
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.crm.chat.getLastId',
-            {
-                CRM_ENTITY_TYPE: 'lead',
-                CRM_ENTITY: 1205
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'imopenlines.crm.chat.getLastId',
+        params: {
+          CRM_ENTITY_TYPE: 'lead',
+          CRM_ENTITY: 1205,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Last chat ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLastChatId() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.crm.chat.getLastId',
+            params: {
+              CRM_ENTITY_TYPE: 'lead',
+              CRM_ENTITY: 1205,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Last chat ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLastChatId)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-get.md
+++ b/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-get.md
@@ -68,27 +68,84 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.crm.chat.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.crm.chat.get',
-            {
-                CRM_ENTITY_TYPE: 'lead',
-                CRM_ENTITY: 1205,
-                ACTIVE_ONLY: 'N'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each Chat returned in result[]
+    type Chat = {
+      CHAT_ID: string
+      CONNECTOR_ID: string
+      CONNECTOR_TITLE: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<Chat[]>({
+        method: 'imopenlines.crm.chat.get',
+        params: {
+          CRM_ENTITY_TYPE: 'lead',
+          CRM_ENTITY: 1205,
+          ACTIVE_ONLY: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chats count:', result.length, 'First chat ID:', result[0]?.CHAT_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCrmChats() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.crm.chat.get',
+            params: {
+              CRM_ENTITY_TYPE: 'lead',
+              CRM_ENTITY: 1205,
+              ACTIVE_ONLY: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chats count:', result.length, 'First chat ID:', result[0]?.CHAT_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCrmChats)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-user-add.md
+++ b/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-user-add.md
@@ -70,28 +70,79 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.crm.chat.user.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.crm.chat.user.add',
-            {
-                CRM_ENTITY_TYPE: 'lead',
-                CRM_ENTITY: 1205,
-                USER_ID: 503,
-                CHAT_ID: 1763
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'imopenlines.crm.chat.user.add',
+        params: {
+          CRM_ENTITY_TYPE: 'lead',
+          CRM_ENTITY: 1205,
+          USER_ID: 503,
+          CHAT_ID: 1763,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat ID the user was added to:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addUserToChat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.crm.chat.user.add',
+            params: {
+              CRM_ENTITY_TYPE: 'lead',
+              CRM_ENTITY: 1205,
+              USER_ID: 503,
+              CHAT_ID: 1763,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat ID the user was added to:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addUserToChat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-user-delete.md
+++ b/api-reference/imopenlines/openlines/chats/imopenlines-crm-chat-user-delete.md
@@ -70,28 +70,79 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.crm.chat.user.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.crm.chat.user.delete',
-            {
-                CRM_ENTITY_TYPE: 'lead',
-                CRM_ENTITY: 1205,
-                USER_ID: 503,
-                CHAT_ID: 1763
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'imopenlines.crm.chat.user.delete',
+        params: {
+          CRM_ENTITY_TYPE: 'lead',
+          CRM_ENTITY: 1205,
+          USER_ID: 503,
+          CHAT_ID: 1763,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat ID from which the user was removed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteUserFromChat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.crm.chat.user.delete',
+            params: {
+              CRM_ENTITY_TYPE: 'lead',
+              CRM_ENTITY: 1205,
+              USER_ID: 503,
+              CHAT_ID: 1763,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat ID from which the user was removed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteUserFromChat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-config-add.md
+++ b/api-reference/imopenlines/openlines/imopenlines-config-add.md
@@ -402,59 +402,123 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.config.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.config.add',
-            {
-                PARAMS: {
-                    LINE_NAME: 'Линия поддержки интернет-магазина',
-                    QUEUE: [
-                        {
-                            ENTITY_TYPE: 'user',
-                            ENTITY_ID: '1'
-                        },
-                        {
-                            ENTITY_TYPE: 'user',
-                            ENTITY_ID: '15'
-                        },
-                        {
-                            ENTITY_TYPE: 'user',
-                            ENTITY_ID: '23'
-                        }
-                    ],
-                    QUEUE_TYPE: 'strictly',
-                    QUEUE_TIME: 45,
-                    NO_ANSWER_TIME: 120,
-                    WELCOME_MESSAGE: 'Y',
-                    WELCOME_MESSAGE_TEXT: 'Здравствуйте! Ответим в течение пары минут',
-                    CRM: 'Y',
-                    CRM_CREATE: 'deal',
-                    CRM_SOURCE: 'openline_web',
-                    CRM_FORWARD: 'Y',
-                    MAX_CHAT: 4,
-                    TYPE_MAX_CHAT: 'answered_new',
-                    WORKTIME_ENABLE: 'Y',
-                    WORKTIME_FROM: '09:00',
-                    WORKTIME_TO: '21:00',
-                    WORKTIME_TIMEZONE: 'Europe/Kaliningrad',
-                    WORKTIME_DAYOFF: ['SA', 'SU'],
-                    WORKTIME_DAYOFF_RULE: 'text',
-                    WORKTIME_DAYOFF_TEXT: 'Сейчас линия не работает. Напишите, и мы ответим в рабочее время'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'imopenlines.config.add',
+        params: {
+          PARAMS: {
+            LINE_NAME: 'Online store support line',
+            QUEUE: [
+              { ENTITY_TYPE: 'user', ENTITY_ID: '1' },
+              { ENTITY_TYPE: 'user', ENTITY_ID: '15' },
+              { ENTITY_TYPE: 'user', ENTITY_ID: '23' },
+            ],
+            QUEUE_TYPE: 'strictly',
+            QUEUE_TIME: 45,
+            NO_ANSWER_TIME: 120,
+            WELCOME_MESSAGE: 'Y',
+            WELCOME_MESSAGE_TEXT: 'Hello! We will respond within a couple of minutes',
+            CRM: 'Y',
+            CRM_CREATE: 'deal',
+            CRM_SOURCE: 'openline_web',
+            CRM_FORWARD: 'Y',
+            MAX_CHAT: 4,
+            TYPE_MAX_CHAT: 'answered_new',
+            WORKTIME_ENABLE: 'Y',
+            WORKTIME_FROM: '09:00',
+            WORKTIME_TO: '21:00',
+            WORKTIME_TIMEZONE: 'Europe/Kaliningrad',
+            WORKTIME_DAYOFF: ['SA', 'SU'],
+            WORKTIME_DAYOFF_RULE: 'text',
+            WORKTIME_DAYOFF_TEXT: 'The line is currently unavailable. Write to us and we will respond during business hours',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created open line ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addOpenlinesConfig() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.config.add',
+            params: {
+              PARAMS: {
+                LINE_NAME: 'Online store support line',
+                QUEUE: [
+                  { ENTITY_TYPE: 'user', ENTITY_ID: '1' },
+                  { ENTITY_TYPE: 'user', ENTITY_ID: '15' },
+                  { ENTITY_TYPE: 'user', ENTITY_ID: '23' },
+                ],
+                QUEUE_TYPE: 'strictly',
+                QUEUE_TIME: 45,
+                NO_ANSWER_TIME: 120,
+                WELCOME_MESSAGE: 'Y',
+                WELCOME_MESSAGE_TEXT: 'Hello! We will respond within a couple of minutes',
+                CRM: 'Y',
+                CRM_CREATE: 'deal',
+                CRM_SOURCE: 'openline_web',
+                CRM_FORWARD: 'Y',
+                MAX_CHAT: 4,
+                TYPE_MAX_CHAT: 'answered_new',
+                WORKTIME_ENABLE: 'Y',
+                WORKTIME_FROM: '09:00',
+                WORKTIME_TO: '21:00',
+                WORKTIME_TIMEZONE: 'Europe/Kaliningrad',
+                WORKTIME_DAYOFF: ['SA', 'SU'],
+                WORKTIME_DAYOFF_RULE: 'text',
+                WORKTIME_DAYOFF_TEXT: 'The line is currently unavailable. Write to us and we will respond during business hours',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created open line ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addOpenlinesConfig)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-config-delete.md
+++ b/api-reference/imopenlines/openlines/imopenlines-config-delete.md
@@ -59,25 +59,73 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.config.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.config.delete',
-            {
-                CONFIG_ID: 15
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.config.delete',
+        params: {
+          CONFIG_ID: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteOpenline() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.config.delete',
+            params: {
+              CONFIG_ID: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteOpenline)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-config-get.md
+++ b/api-reference/imopenlines/openlines/imopenlines-config-get.md
@@ -71,27 +71,93 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.config.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.config.get',
-            {
-                CONFIG_ID: 15,
-                WITH_QUEUE: 'Y',
-                SHOW_OFFLINE: 'Y'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConfigGetResult = {
+      ID: string,
+      LINE_NAME: string,
+      ACTIVE: string,
+      CRM: string,
+      QUEUE_TYPE: string,
+      QUEUE_TIME: string,
+      NO_ANSWER_TIME: string,
+      WORKTIME_ENABLE: string,
+      WORKTIME_TIMEZONE: string,
+      WELCOME_BOT_ENABLE: string,
+      QUEUE: string[],
+      QUEUE_ONLINE: string,
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConfigGetResult>({
+        method: 'imopenlines.config.get',
+        params: {
+          CONFIG_ID: 15,
+          WITH_QUEUE: 'Y',
+          SHOW_OFFLINE: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.LINE_NAME, result.ACTIVE, result.QUEUE_ONLINE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOpenlinesConfig() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.config.get',
+            params: {
+              CONFIG_ID: 15,
+              WITH_QUEUE: 'Y',
+              SHOW_OFFLINE: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.LINE_NAME, result.ACTIVE, result.QUEUE_ONLINE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOpenlinesConfig)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-config-list-get.md
+++ b/api-reference/imopenlines/openlines/imopenlines-config-list-get.md
@@ -125,35 +125,121 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.config.list.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.config.list.get',
-            {
-                PARAMS: {
-                    select: ['ID', 'LINE_NAME', 'ACTIVE'],
-                    order: { ID: 'ASC' },
-                    filter: { ACTIVE: 'Y' },
-                    limit: 50,
-                    offset: 0
-                },
-                OPTIONS: {
-                    QUEUE: 'Y',
-                    CONFIG_QUEUE: 'Y'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each OpenLineItem returned in result[]
+    type OpenLineItem = {
+      ID: string
+      LINE_NAME: string
+      ACTIVE: string
+      QUEUE?: number[]
+      QUEUE_USERS_FIELDS?: Record<string, {
+        USER_NAME: string | null
+        USER_WORK_POSITION: string | null
+        USER_AVATAR: string | null
+        USER_AVATAR_ID: number | null
+      }>
+      CONFIG_QUEUE?: Array<{
+        ENTITY_ID: string
+        ENTITY_TYPE: string
+      }>
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      // imopenlines.config.list.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<OpenLineItem[]>({
+        method: 'imopenlines.config.list.get',
+        params: {
+          PARAMS: {
+            select: ['ID', 'LINE_NAME', 'ACTIVE'],
+            order: { ID: 'ASC' },
+            filter: { ACTIVE: 'Y' },
+            limit: 50,
+            offset: 0,
+          },
+          OPTIONS: {
+            QUEUE: 'Y',
+            CONFIG_QUEUE: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Open lines count:', result.length, 'First line:', result[0]?.LINE_NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOpenLineList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // imopenlines.config.list.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.config.list.get',
+            params: {
+              PARAMS: {
+                select: ['ID', 'LINE_NAME', 'ACTIVE'],
+                order: { ID: 'ASC' },
+                filter: { ACTIVE: 'Y' },
+                limit: 50,
+                offset: 0,
+              },
+              OPTIONS: {
+                QUEUE: 'Y',
+                CONFIG_QUEUE: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Open lines count:', result.length, 'First line:', result[0]?.LINE_NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOpenLineList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-config-path-get.md
+++ b/api-reference/imopenlines/openlines/imopenlines-config-path-get.md
@@ -46,19 +46,75 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.config.path.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod('imopenlines.config.path.get', {});
-        const result = response.getData().result;
-        console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConfigPathGetResult = {
+      SERVER_ADDRESS: string
+      PUBLIC_PATH: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConfigPathGetResult>({
+        method: 'imopenlines.config.path.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.SERVER_ADDRESS, result.PUBLIC_PATH)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getConfigPath() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.config.path.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.SERVER_ADDRESS, result.PUBLIC_PATH)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getConfigPath)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-config-update.md
+++ b/api-reference/imopenlines/openlines/imopenlines-config-update.md
@@ -113,51 +113,125 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.config.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.config.update',
-            {
-                CONFIG_ID: 15,
-                PARAMS: {
-                    LINE_NAME: 'Линия поддержки интернет-магазина (VIP)',
-                    QUEUE: [
-                        {
-                            ENTITY_TYPE: 'user',
-                            ENTITY_ID: '1'
-                        },
-                        {
-                            ENTITY_TYPE: 'user',
-                            ENTITY_ID: '15'
-                        },
-                        {
-                            ENTITY_TYPE: 'user',
-                            ENTITY_ID: '23'
-                        }
-                    ],
-                    QUEUE_TYPE: 'strictly',
-                    QUEUE_TIME: 45,
-                    NO_ANSWER_TIME: 120,
-                    WELCOME_MESSAGE: 'Y',
-                    WELCOME_MESSAGE_TEXT: 'Здравствуйте! Ответим в течение пары минут',
-                    WORKTIME_ENABLE: 'Y',
-                    WORKTIME_FROM: '09:00',
-                    WORKTIME_TO: '21:00',
-                    WORKTIME_TIMEZONE: 'Europe/Kaliningrad'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.config.update',
+        params: {
+          CONFIG_ID: 15,
+          PARAMS: {
+            LINE_NAME: 'Online Store Support Line (VIP)',
+            QUEUE: [
+              {
+                ENTITY_TYPE: 'user',
+                ENTITY_ID: '1',
+              },
+              {
+                ENTITY_TYPE: 'user',
+                ENTITY_ID: '15',
+              },
+              {
+                ENTITY_TYPE: 'user',
+                ENTITY_ID: '23',
+              },
+            ],
+            QUEUE_TYPE: 'strictly',
+            QUEUE_TIME: 45,
+            NO_ANSWER_TIME: 120,
+            WELCOME_MESSAGE: 'Y',
+            WELCOME_MESSAGE_TEXT: 'Hello! We will reply in a couple of minutes',
+            WORKTIME_ENABLE: 'Y',
+            WORKTIME_FROM: '09:00',
+            WORKTIME_TO: '21:00',
+            WORKTIME_TIMEZONE: 'Europe/Kaliningrad',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Open line updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateOpenLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.config.update',
+            params: {
+              CONFIG_ID: 15,
+              PARAMS: {
+                LINE_NAME: 'Online Store Support Line (VIP)',
+                QUEUE: [
+                  {
+                    ENTITY_TYPE: 'user',
+                    ENTITY_ID: '1',
+                  },
+                  {
+                    ENTITY_TYPE: 'user',
+                    ENTITY_ID: '15',
+                  },
+                  {
+                    ENTITY_TYPE: 'user',
+                    ENTITY_ID: '23',
+                  },
+                ],
+                QUEUE_TYPE: 'strictly',
+                QUEUE_TIME: 45,
+                NO_ANSWER_TIME: 120,
+                WELCOME_MESSAGE: 'Y',
+                WELCOME_MESSAGE_TEXT: 'Hello! We will reply in a couple of minutes',
+                WORKTIME_ENABLE: 'Y',
+                WORKTIME_FROM: '09:00',
+                WORKTIME_TO: '21:00',
+                WORKTIME_TIMEZONE: 'Europe/Kaliningrad',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Open line updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateOpenLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-network-join.md
+++ b/api-reference/imopenlines/openlines/imopenlines-network-join.md
@@ -67,25 +67,73 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.network.join
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.network.join',
-            {
-                CODE: 'ab515f5d85a8b844d484f6ea75a2e494'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'imopenlines.network.join',
+        params: {
+          CODE: 'ab515f5d85a8b844d484f6ea75a2e494',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connected network bot ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function joinOpenLine() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.network.join',
+            params: {
+              CODE: 'ab515f5d85a8b844d484f6ea75a2e494',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connected network bot ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', joinOpenLine)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-network-message-add.md
+++ b/api-reference/imopenlines/openlines/imopenlines-network-message-add.md
@@ -164,67 +164,157 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.network.message.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'imopenlines.network.message.add',
-            {
-                CODE: 'ab515f5d85a8b844d484f6ea75a2e494',
-                USER_ID: 2,
-                MESSAGE: 'Подготовили материалы по подключению открытых линий',
-                ATTACH: {
-                    ID: 1,
-                    COLOR_TOKEN: 'primary',
-                    BLOCKS: [
-                        {
-                            MESSAGE: 'Во вложении отправили чек-лист и схему подключения'
-                        },
-                        {
-                            FILE: [
-                                {
-                                    NAME: 'checklist-openlines.pdf',
-                                    LINK: 'https://cdn.example.com/docs/checklist-openlines.pdf',
-                                    SIZE: 428736
-                                }
-                            ]
-                        },
-                        {
-                            IMAGE: [
-                                {
-                                    NAME: 'Схема подключения',
-                                    LINK: 'https://cdn.example.com/images/openlines-setup.png',
-                                    PREVIEW: 'https://cdn.example.com/images/openlines-setup-preview.png',
-                                    WIDTH: 1280,
-                                    HEIGHT: 720
-                                }
-                            ]
-                        }
-                    ]
-                },
-                KEYBOARD: {
-                    BUTTONS: [
-                        {
-                            TEXT: 'Открыть инструкцию',
-                            LINK: 'https://help.example.com/openlines/setup',
-                            DISPLAY: 'LINE',
-                            BG_COLOR_TOKEN: 'primary'
-                        }
-                    ]
-                },
-                URL_PREVIEW: 'N'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.network.message.add',
+        params: {
+          CODE: 'ab515f5d85a8b844d484f6ea75a2e494',
+          USER_ID: 2,
+          MESSAGE: 'We have prepared materials on connecting open lines',
+          ATTACH: {
+            ID: 1,
+            COLOR_TOKEN: 'primary',
+            BLOCKS: [
+              {
+                MESSAGE: 'Attached are the checklist and connection diagram',
+              },
+              {
+                FILE: [
+                  {
+                    NAME: 'checklist-openlines.pdf',
+                    LINK: 'https://cdn.example.com/docs/checklist-openlines.pdf',
+                    SIZE: 428736,
+                  },
+                ],
+              },
+              {
+                IMAGE: [
+                  {
+                    NAME: 'Connection diagram',
+                    LINK: 'https://cdn.example.com/images/openlines-setup.png',
+                    PREVIEW: 'https://cdn.example.com/images/openlines-setup-preview.png',
+                    WIDTH: 1280,
+                    HEIGHT: 720,
+                  },
+                ],
+              },
+            ],
+          },
+          KEYBOARD: {
+            BUTTONS: [
+              {
+                TEXT: 'Open instructions',
+                LINK: 'https://help.example.com/openlines/setup',
+                DISPLAY: 'LINE',
+                BG_COLOR_TOKEN: 'primary',
+              },
+            ],
+          },
+          URL_PREVIEW: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Message sent successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendNetworkMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.network.message.add',
+            params: {
+              CODE: 'ab515f5d85a8b844d484f6ea75a2e494',
+              USER_ID: 2,
+              MESSAGE: 'We have prepared materials on connecting open lines',
+              ATTACH: {
+                ID: 1,
+                COLOR_TOKEN: 'primary',
+                BLOCKS: [
+                  {
+                    MESSAGE: 'Attached are the checklist and connection diagram',
+                  },
+                  {
+                    FILE: [
+                      {
+                        NAME: 'checklist-openlines.pdf',
+                        LINK: 'https://cdn.example.com/docs/checklist-openlines.pdf',
+                        SIZE: 428736,
+                      },
+                    ],
+                  },
+                  {
+                    IMAGE: [
+                      {
+                        NAME: 'Connection diagram',
+                        LINK: 'https://cdn.example.com/images/openlines-setup.png',
+                        PREVIEW: 'https://cdn.example.com/images/openlines-setup-preview.png',
+                        WIDTH: 1280,
+                        HEIGHT: 720,
+                      },
+                    ],
+                  },
+                ],
+              },
+              KEYBOARD: {
+                BUTTONS: [
+                  {
+                    TEXT: 'Open instructions',
+                    LINK: 'https://help.example.com/openlines/setup',
+                    DISPLAY: 'LINE',
+                    BG_COLOR_TOKEN: 'primary',
+                  },
+                ],
+              },
+              URL_PREVIEW: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Message sent successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendNetworkMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/imopenlines-revision-get.md
+++ b/api-reference/imopenlines/openlines/imopenlines-revision-get.md
@@ -46,19 +46,76 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.revision.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod('imopenlines.revision.get', {});
-        const result = response.getData().result;
-        console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RevisionGetResult = {
+      rest: number
+      web: number
+      mobile: number
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RevisionGetResult>({
+        method: 'imopenlines.revision.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('REST revision:', result.rest, '| Web revision:', result.web, '| Mobile revision:', result.mobile)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOpenLinesRevision() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.revision.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('REST revision:', result.rest, '| Web revision:', result.web, '| Mobile revision:', result.mobile)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOpenLinesRevision)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/messages/imopenlines-crm-message-add.md
+++ b/api-reference/imopenlines/openlines/messages/imopenlines-crm-message-add.md
@@ -73,26 +73,81 @@
     https://**put_your_bitrix24_address**/rest/imopenlines.crm.message.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod(
-        'imopenlines.crm.message.add',
-        {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'imopenlines.crm.message.add',
+        params: {
           CRM_ENTITY_TYPE: 'lead',
           CRM_ENTITY: 1195,
           USER_ID: 27,
           CHAT_ID: 1341,
-          MESSAGE: 'Текст сообщения',
-        }
-      );
+          MESSAGE: 'Message text',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Created message:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created message ID:', result)
+      }
     } catch (error) {
-      console.error('Error sending message:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendCrmMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.crm.message.add',
+            params: {
+              CRM_ENTITY_TYPE: 'lead',
+              CRM_ENTITY: 1195,
+              USER_ID: 27,
+              CHAT_ID: 1341,
+              MESSAGE: 'Message text',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created message ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendCrmMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/messages/imopenlines-message-quick-save.md
+++ b/api-reference/imopenlines/openlines/messages/imopenlines-message-quick-save.md
@@ -58,23 +58,75 @@
     https://**put_your_bitrix24_address**/rest/imopenlines.message.quick.save
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod(
-        'imopenlines.message.quick.save',
-        {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.message.quick.save',
+        params: {
           CHAT_ID: 1331,
           MESSAGE_ID: 83507,
-        }
-      );
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Saved to quick answers:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Saved to quick answers:', result)
+      }
     } catch (error) {
-      console.error('Error saving quick answer:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function saveQuickAnswer() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.message.quick.save',
+            params: {
+              CHAT_ID: 1331,
+              MESSAGE_ID: 83507,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Saved to quick answers:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', saveQuickAnswer)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/operators/imopenlines-operator-another-finish.md
+++ b/api-reference/imopenlines/openlines/operators/imopenlines-operator-another-finish.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.operator.another.finish.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.operator.another.finish',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.operator.another.finish',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog finished successfully:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function finishAnotherDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.operator.another.finish',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog finished successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', finishAnotherDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/operators/imopenlines-operator-answer.md
+++ b/api-reference/imopenlines/openlines/operators/imopenlines-operator-answer.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.operator.answer.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.operator.answer',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.operator.answer',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Operator answered dialog:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function answerDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.operator.answer',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Operator answered dialog:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', answerDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/operators/imopenlines-operator-finish.md
+++ b/api-reference/imopenlines/openlines/operators/imopenlines-operator-finish.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.operator.finish.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.operator.finish',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.operator.finish',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog finished:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function finishDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.operator.finish',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog finished:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', finishDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/operators/imopenlines-operator-skip.md
+++ b/api-reference/imopenlines/openlines/operators/imopenlines-operator-skip.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.operator.skip.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.operator.skip',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.operator.skip',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog skipped:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function skipDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.operator.skip',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog skipped:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', skipDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/operators/imopenlines-operator-spam.md
+++ b/api-reference/imopenlines/openlines/operators/imopenlines-operator-spam.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.operator.spam.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.operator.spam',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.operator.spam',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog marked as spam:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markDialogAsSpam() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.operator.spam',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog marked as spam:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markDialogAsSpam)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/operators/imopenlines-operator-transfer.md
+++ b/api-reference/imopenlines/openlines/operators/imopenlines-operator-transfer.md
@@ -70,23 +70,75 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.operator.transfer.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.operator.transfer',
-            {
-                CHAT_ID: 2043,
-                USER_ID: 15,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.operator.transfer',
+        params: {
+          CHAT_ID: 2043,
+          USER_ID: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Transfer result:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function transferOperatorDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.operator.transfer',
+            params: {
+              CHAT_ID: 2043,
+              USER_ID: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Transfer result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', transferOperatorDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-crm-lead-create.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-crm-lead-create.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.crm.lead.create.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.crm.lead.create',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.crm.lead.create',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Lead created:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createCrmLead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.crm.lead.create',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Lead created:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createCrmLead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-dialog-get.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-dialog-get.md
@@ -70,22 +70,119 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.dialog.get.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'imopenlines.dialog.get',
-            {
-                USER_CODE: 'livechat|1|1373|211',
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const { result } = response.getData();
-        console.log(result);
-    } catch (error) {
-        console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DialogGetResult = {
+      id: number
+      parent_chat_id: number
+      parent_message_id: number
+      name: string
+      description: string | null
+      owner: number
+      extranet: boolean
+      avatar: string
+      color: string
+      type: string
+      counter: number
+      user_counter: number
+      message_count: number
+      unread_id: number
+      restrictions: Record<string, boolean>
+      last_message_id: number
+      last_id: number
+      marked_id: number
+      disk_folder_id: number
+      entity_type: string
+      entity_id: string
+      entity_data_1: string
+      entity_data_2: string
+      entity_data_3: string
+      mute_list: number[]
+      date_create: ISODate
+      message_type: string
+      public: string
+      role: string
+      entity_link: { type: string; url: string; id: string }
+      text_field_enabled: boolean
+      background_id: number | null
+      permissions: Record<string, string>
+      is_new: boolean
+      readed_list: Array<{ user_id: number; user_name: string; message_id: number; date: ISODate | null }>
+      manager_list: number[]
+      last_message_views: {
+        message_id: number
+        first_viewers: Array<{ user_id: number; user_name: string; date: ISODate }>
+        count_of_viewers: number
+      }
+      dialog_id: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DialogGetResult>({
+        method: 'imopenlines.dialog.get',
+        params: {
+          USER_CODE: 'livechat|1|1373|211',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.dialog_id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.dialog.get',
+            params: {
+              USER_CODE: 'livechat|1|1373|211',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.dialog_id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-message-session-start.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-message-session-start.md
@@ -58,23 +58,75 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.message.session.start.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.message.session.start',
-            {
-                CHAT_ID: 2043,
-                MESSAGE_ID: 18971,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.message.session.start',
+        params: {
+          CHAT_ID: 2043,
+          MESSAGE_ID: 18971,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Session started:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startSessionFromMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.message.session.start',
+            params: {
+              CHAT_ID: 2043,
+              MESSAGE_ID: 18971,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Session started:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startSessionFromMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-head-vote.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-head-vote.md
@@ -64,24 +64,77 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.head.vote.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.head.vote',
-            {
-                SESSION_ID: 1743,
-                RATING: 5,
-                COMMENT: 'Отличная обработка',
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.session.head.vote',
+        params: {
+          SESSION_ID: 1743,
+          RATING: 5,
+          COMMENT: 'Excellent handling',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Vote saved:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function submitHeadVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.head.vote',
+            params: {
+              SESSION_ID: 1743,
+              RATING: 5,
+              COMMENT: 'Excellent handling',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Vote saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', submitHeadVote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-history-get.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-history-get.md
@@ -65,22 +65,156 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.session.history.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.history.get',
-            {
-                SESSION_ID: 321,
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const { result } = response.getData();
-        console.log(result);
-    } catch (error) {
-        console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SessionHistoryResult = {
+      chatId: number
+      canJoin: string
+      canVoteHead: string
+      sessionId: number
+      sessionVoteHead: number
+      sessionCommentHead: string | null
+      userId: string
+      message: Record<string, {
+        id: string
+        chatid: string
+        senderid: string
+        recipientid: string
+        date: ISODate
+        text: string
+        textlegacy: string
+        params: Record<string, unknown>
+      }>
+      usersMessage: Record<string, string[]>
+      users: Record<string, {
+        id: string
+        name: string
+        firstName: string
+        lastName: string
+        workPosition: string | null
+        avatar: string
+        avatarId: string | null
+        gender: string
+        extranet: boolean
+        connector: boolean
+        profile: string
+        externalAuthId: string
+        status: string | null
+        lastActivityDate: ISODate
+        departments: number[]
+        type: string
+      }>
+      openlines: Record<string, Record<string, boolean>>
+      userInGroup: Record<string, { id: number; users: string[] }>
+      woUserInGroup: string[]
+      chat: Record<string, {
+        id: string
+        name: string
+        owner: string
+        entityType: string
+        entityId: string
+        entityData1: string
+        entityData2: string
+        entityData3: string
+        messageCount: number
+        public: string
+        muteList: Record<string, boolean>
+        managerList: number[]
+        dateCreate: ISODate
+        type: string
+        entityLink: Record<string, unknown>
+        permissions: Record<string, string>
+        textFieldEnabled: boolean
+        backgroundId: number | null
+        messageType: string
+        isNew: boolean
+      }>
+      userBlockChat: Record<string, Record<string, boolean>>
+      userInChat: Record<string, number[]>
+      files: Record<string, {
+        id: number
+        chatid: number
+        date: ISODate
+        type: string
+        name: string
+        extension: string
+        size: number
+        status: string
+        progress: number
+        authorid: number
+        authorname: string
+        urlpreview: string
+        urlshow: string
+        urldownload: string
+      }>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SessionHistoryResult>({
+        method: 'imopenlines.session.history.get',
+        params: {
+          SESSION_ID: 321,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.sessionId, result.chatId, Object.keys(result.message).length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSessionHistory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.history.get',
+            params: {
+              SESSION_ID: 321,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.sessionId, result.chatId, Object.keys(result.message).length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSessionHistory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-intercept.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-intercept.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.intercept.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.intercept',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.session.intercept',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Session intercepted:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function interceptSession() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.intercept',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Session intercepted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', interceptSession)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-join.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-join.md
@@ -54,22 +54,73 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.join.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.join',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.session.join',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Joined session:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function joinSession() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.join',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Joined session:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', joinSession)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-pin-all.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-pin-all.md
@@ -44,20 +44,69 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.mode.pinAll.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.mode.pinAll',
-            {}
-        );
+      const response = await $b24.actions.v2.call.make<number[]>({
+        method: 'imopenlines.session.mode.pinAll',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pinned session IDs:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pinAllSessions() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.mode.pinAll',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pinned session IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pinAllSessions)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-pin.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-pin.md
@@ -60,23 +60,75 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.mode.pin.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.mode.pin',
-            {
-                CHAT_ID: 2043,
-                ACTIVATE: 'Y',
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.session.mode.pin',
+        params: {
+          CHAT_ID: 2043,
+          ACTIVATE: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog pinned/unpinned:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pinDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.mode.pin',
+            params: {
+              CHAT_ID: 2043,
+              ACTIVATE: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog pinned/unpinned:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pinDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-silent.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-silent.md
@@ -62,23 +62,75 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.mode.silent.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.mode.silent',
-            {
-                CHAT_ID: 2043,
-                ACTIVATE: 'Y',
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.session.mode.silent',
+        params: {
+          CHAT_ID: 2043,
+          ACTIVATE: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Silent mode set:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setSilentMode() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.mode.silent',
+            params: {
+              CHAT_ID: 2043,
+              ACTIVATE: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Silent mode set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setSilentMode)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-unpin-all.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-mode-unpin-all.md
@@ -44,20 +44,69 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.mode.unpinAll.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.mode.unpinAll',
-            {}
-        );
+      const response = await $b24.actions.v2.call.make<number[]>({
+        method: 'imopenlines.session.mode.unpinAll',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unpinned session IDs:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unpinAllSessions() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.mode.unpinAll',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unpinned session IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unpinAllSessions)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-open.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-open.md
@@ -60,22 +60,78 @@
       https://your-domain.bitrix24.ru/rest/imopenlines.session.open.json
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.open',
-            {
-                USER_CODE: 'livechat|22|1761|587',
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const { result } = response.getData();
-        console.log(result);
-    } catch (error) {
-        console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SessionOpenResult = {
+      chatId: number
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SessionOpenResult>({
+        method: 'imopenlines.session.open',
+        params: {
+          USER_CODE: 'livechat|22|1761|587',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat ID:', result.chatId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function openSession() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.open',
+            params: {
+              USER_CODE: 'livechat|22|1761|587',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat ID:', result.chatId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', openSession)
+    </script>
     ```
 
 - PHP

--- a/api-reference/imopenlines/openlines/sessions/imopenlines-session-start.md
+++ b/api-reference/imopenlines/openlines/sessions/imopenlines-session-start.md
@@ -54,22 +54,73 @@
       https://**put_your_bitrix24_address**/rest/imopenlines.session.start
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'imopenlines.session.start',
-            {
-                CHAT_ID: 2043,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'imopenlines.session.start',
+        params: {
+          CHAT_ID: 2043,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const { result } = response.getData();
-        console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Session started:', result)
+      }
     } catch (error) {
-        console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startSession() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'imopenlines.session.start',
+            params: {
+              CHAT_ID: 2043,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Session started:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startSession)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.