### PR TITLE
docs(catalog): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/catalog/catalog/catalog-catalog-get-fields.md
+++ b/api-reference/catalog/catalog/catalog-catalog-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.catalog.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.catalog.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogFieldsResult = {
+      catalog: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogFieldsResult>({
+        method: 'catalog.catalog.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Catalog fields:', Object.keys(result.catalog))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCatalogFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.catalog.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Catalog fields:', Object.keys(result.catalog))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCatalogFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/catalog/catalog-catalog-get.md
+++ b/api-reference/catalog/catalog/catalog-catalog-get.md
@@ -52,25 +52,88 @@
     https://**put_your_bitrix24_address**/rest/catalog.catalog.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.catalog.get', {
-    			'id': 23
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogGetResult = {
+      catalog: {
+        iblockId: number
+        iblockTypeId: number
+        id: number
+        lid: string
+        name: string
+        productIblockId: number | null
+        skuPropertyId: number | null
+        subscription: string
+        vatId: number | null
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogGetResult>({
+        method: 'catalog.catalog.get',
+        params: {
+          id: 23,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.catalog)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCatalog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.catalog.get',
+            params: {
+              id: 23,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.catalog)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCatalog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/catalog/catalog-catalog-is-offers.md
+++ b/api-reference/catalog/catalog/catalog-catalog-is-offers.md
@@ -52,26 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.catalog.isOffers
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.catalog.isOffers',
-    		{
-    			id: 23,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.catalog.isOffers',
+        params: {
+          id: 23,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Is offers catalog:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkCatalogIsOffers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.catalog.isOffers',
+            params: {
+              id: 23,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Is offers catalog:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkCatalogIsOffers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/catalog/catalog-catalog-list.md
+++ b/api-reference/catalog/catalog/catalog-catalog-list.md
@@ -102,110 +102,136 @@
     https://**put_your_bitrix24_address**/rest/catalog.catalog.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const parameters = {
-        "select": [
-            "iblockId",
-            "iblockTypeId",
-            "id",
-            "lid",
-            "name",
-            "productIblockId",
-            "skuPropertyId",
-            "subscription",
-            "vatId"
-        ],
-        "filter": {
-            ">id": 10,
-            "@vatId": [1, 2],
-            "skuPropertyId": 121,
-        },
-        "order": {
-            "id": "desc",
-        }
-    };
-    
-    try {
-        const response = await $b24.callListMethod(
-            'catalog.catalog.list',
-            parameters,
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogCatalogListResult = {
+      catalogs: {
+        iblockId: number
+        iblockTypeId: number
+        id: number
+        lid: string
+        name: string
+        productIblockId: number
+        skuPropertyId: number
+        subscription: string
+        vatId: number
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const parameters = {
-        "select": [
-            "iblockId",
-            "iblockTypeId",
-            "id",
-            "lid",
-            "name",
-            "productIblockId",
-            "skuPropertyId",
-            "subscription",
-            "vatId"
-        ],
-        "filter": {
-            ">id": 10,
-            "@vatId": [1, 2],
-            "skuPropertyId": 121,
-        },
-        "order": {
-            "id": "desc",
-        }
-    };
-    
+
     try {
-        const generator = $b24.fetchListMethod('catalog.catalog.list', parameters, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
-        }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const parameters = {
-        "select": [
-            "iblockId",
-            "iblockTypeId",
-            "id",
-            "lid",
-            "name",
-            "productIblockId",
-            "skuPropertyId",
-            "subscription",
-            "vatId"
-        ],
-        "filter": {
-            ">id": 10,
-            "@vatId": [1, 2],
-            "skuPropertyId": 121,
+      // catalog.catalog.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CatalogCatalogListResult>({
+        method: 'catalog.catalog.list',
+        params: {
+          select: [
+            'iblockId',
+            'iblockTypeId',
+            'id',
+            'lid',
+            'name',
+            'productIblockId',
+            'skuPropertyId',
+            'subscription',
+            'vatId',
+          ],
+          filter: {
+            '>id': 10,
+            '@vatId': [1, 2],
+            skuPropertyId: 121,
+          },
+          order: {
+            id: 'desc',
+          },
+          start: 0,
         },
-        "order": {
-            "id": "desc",
-        }
-    };
-    
-    try {
-        const response = await $b24.callMethod('catalog.catalog.list', parameters, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Catalogs count:', result.catalogs.length, 'First:', result.catalogs[0])
+      }
     } catch (error) {
-        console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listCatalogs() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.catalog.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.catalog.list',
+            params: {
+              select: [
+                'iblockId',
+                'iblockTypeId',
+                'id',
+                'lid',
+                'name',
+                'productIblockId',
+                'skuPropertyId',
+                'subscription',
+                'vatId',
+              ],
+              filter: {
+                '>id': 10,
+                '@vatId': [1, 2],
+                skuPropertyId: 121,
+              },
+              order: {
+                id: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Catalogs count:', result.catalogs.length, 'First:', result.catalogs[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listCatalogs)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-add.md
+++ b/api-reference/catalog/document/catalog-document-add.md
@@ -99,34 +99,110 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.document.add',
-            {
-                fields: {
-                    docType: 'A',
-                    currency: 'RUB',
-                    responsibleId: 29,
-                    docNumber: 'IN-00042',
-                    title: 'Поступление от Поставщик-1',
-                    commentary: 'Плановое пополнение склада',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentAddResult = {
+      document: {
+        commentary: string | null,
+        createdBy: number,
+        currency: string,
+        dateCreate: ISODate | null,
+        dateDocument: ISODate | null,
+        dateModify: ISODate | null,
+        dateStatus: ISODate | null,
+        docNumber: string,
+        docType: string,
+        id: number,
+        modifiedBy: number,
+        responsibleId: number,
+        siteId: string,
+        status: string,
+        statusBy: number | null,
+        title: string | null,
+        total: number | null,
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentAddResult>({
+        method: 'catalog.document.add',
+        params: {
+          fields: {
+            docType: 'A',
+            currency: 'RUB',
+            responsibleId: 29,
+            docNumber: 'IN-00042',
+            title: 'Goods receipt from Supplier-1',
+            commentary: 'Planned warehouse replenishment',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created document with ID:', result.document.id, 'status:', result.document.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.add',
+            params: {
+              fields: {
+                docType: 'A',
+                currency: 'RUB',
+                responsibleId: 29,
+                docNumber: 'IN-00042',
+                title: 'Goods receipt from Supplier-1',
+                commentary: 'Planned warehouse replenishment',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created document with ID:', result.document.id, 'status:', result.document.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-cancel-list.md
+++ b/api-reference/catalog/document/catalog-document-cancel-list.md
@@ -58,23 +58,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.cancelList
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.cancelList',
-    		{ documentIds: [142, 143, 144] }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.cancelList',
+        params: {
+          documentIds: [142, 143, 144],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Documents cancelled successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function cancelDocumentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.cancelList',
+            params: {
+              documentIds: [142, 143, 144],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Documents cancelled successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', cancelDocumentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-cancel.md
+++ b/api-reference/catalog/document/catalog-document-cancel.md
@@ -56,23 +56,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.cancel
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.cancel',
-    		{ id: 142 }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.cancel',
+        params: {
+          id: 142,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document cancellation succeeded:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function cancelDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.cancel',
+            params: {
+              id: 142,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document cancellation succeeded:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', cancelDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-conduct-list.md
+++ b/api-reference/catalog/document/catalog-document-conduct-list.md
@@ -58,25 +58,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.conductList
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.conductList',
-    		{
-    			documentIds: [142, 143, 144]
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.conductList',
+        params: {
+          documentIds: [142, 143, 144],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Documents conducted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function conductDocumentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.conductList',
+            params: {
+              documentIds: [142, 143, 144],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Documents conducted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', conductDocumentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-conduct.md
+++ b/api-reference/catalog/document/catalog-document-conduct.md
@@ -56,23 +56,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.conduct
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.conduct',
-    		{ id: 142 }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.conduct',
+        params: {
+          id: 142,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document conducted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function conductDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.conduct',
+            params: {
+              id: 142,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document conducted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', conductDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-delete-list.md
+++ b/api-reference/catalog/document/catalog-document-delete-list.md
@@ -54,23 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.deleteList
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.deleteList',
-    		{ documentIds: [142, 143, 144] }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.deleteList',
+        params: {
+          documentIds: [142, 143, 144],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Documents deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDocumentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.deleteList',
+            params: {
+              documentIds: [142, 143, 144],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Documents deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDocumentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-delete.md
+++ b/api-reference/catalog/document/catalog-document-delete.md
@@ -54,23 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.delete',
-    		{ id: 142 }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.delete',
+        params: {
+          id: 142,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.delete',
+            params: {
+              id: 142,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-get-fields.md
+++ b/api-reference/catalog/document/catalog-document-get-fields.md
@@ -45,23 +45,82 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.getFields',
-    		{}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each field descriptor in result.document
+    type DocumentFieldDescriptor = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentGetFieldsResult = {
+      document: Record<string, DocumentFieldDescriptor>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentGetFieldsResult>({
+        method: 'catalog.document.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document field names:', Object.keys(result.document))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document field names:', Object.keys(result.document))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-list.md
+++ b/api-reference/catalog/document/catalog-document-list.md
@@ -115,60 +115,105 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.list
     ```
 
-- JS
+- JS (TS)
 
-    ```javascript
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentListResult = {
+      documents: {
+        docType: string
+        id: number
+        status: string
+        title: string
+      }[]
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'catalog.document.list',
-        {
-        select: ['id', 'docType', 'title', 'status'],
-        filter: { '>=dateCreate': '2025-10-01T00:00:00+03:00', '<=dateCreate': '2025-10-15T23:59:59+03:00' },
-        order: { id: 'ASC' }
+      // catalog.document.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DocumentListResult>({
+        method: 'catalog.document.list',
+        params: {
+          select: ['id', 'docType', 'title', 'status'],
+          filter: {
+            '>=dateCreate': '2025-10-01T00:00:00+03:00',
+            '<=dateCreate': '2025-10-15T23:59:59+03:00',
+          },
+          order: { id: 'ASC' },
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
-
-    try {
-    const generator = $b24.fetchListMethod('catalog.document.list', {
-        select: ['id', 'docType', 'title', 'status'],
-        filter: { '>=dateCreate': '2025-10-01T00:00:00+03:00', '<=dateCreate': '2025-10-15T23:59:59+03:00' },
-        order: { id: 'ASC' },
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Documents on this page:', result.documents.length, result.documents)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
+- JS (UMD)
 
-    try {
-    const response = await $b24.callMethod('catalog.document.list', {
-        select: ['id', 'docType', 'title', 'status'],
-        filter: { '>=dateCreate': '2025-10-01T00:00:00+03:00', '<=dateCreate': '2025-10-15T23:59:59+03:00' },
-        order: { id: 'ASC' },
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchDocumentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.document.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.list',
+            params: {
+              select: ['id', 'docType', 'title', 'status'],
+              filter: {
+                '>=dateCreate': '2025-10-01T00:00:00+03:00',
+                '<=dateCreate': '2025-10-15T23:59:59+03:00',
+              },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Documents on this page:', result.documents.length, result.documents)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchDocumentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-mode-status.md
+++ b/api-reference/catalog/document/catalog-document-mode-status.md
@@ -45,23 +45,69 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.mode.status
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.mode.status',
-    		{}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'catalog.document.mode.status',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Inventory mode status:', result) // 'Y' = enabled, 'N' = disabled
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkDocumentModeStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.mode.status',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Inventory mode status:', result) // 'Y' = enabled, 'N' = disabled
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkDocumentModeStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/catalog-document-update.md
+++ b/api-reference/catalog/document/catalog-document-update.md
@@ -79,32 +79,106 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.document.update',
-            {
-                id: 142,
-                fields: {
-                    title: 'Поступление от Поставщик-1 (корректировка)',
-                    commentary: 'Обновили ответсвенного',
-                    responsibleId: 21,
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated document with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentUpdateResult = {
+      document: {
+        commentary: string,
+        createdBy: number,
+        currency: string,
+        dateCreate: ISODate,
+        dateDocument: ISODate | null,
+        dateModify: ISODate,
+        dateStatus: ISODate,
+        docNumber: string,
+        docType: string,
+        id: number,
+        modifiedBy: number,
+        responsibleId: number,
+        siteId: string,
+        status: string,
+        statusBy: number | null,
+        title: string,
+        total: number | null,
+      },
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentUpdateResult>({
+        method: 'catalog.document.update',
+        params: {
+          id: 142,
+          fields: {
+            title: 'Product receipt from Supplier-1 (adjustment)',
+            commentary: 'Updated the responsible person',
+            responsibleId: 21,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated document:', result.document.id, result.document.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.update',
+            params: {
+              id: 142,
+              fields: {
+                title: 'Product receipt from Supplier-1 (adjustment)',
+                commentary: 'Updated the responsible person',
+                responsibleId: 21,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated document:', result.document.id, result.document.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/document-element/catalog-document-element-add.md
+++ b/api-reference/catalog/document/document-element/catalog-document-element-add.md
@@ -75,31 +75,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.element.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.element.add',
-    		{
-    			fields: {
-    				docId: 64,
-    				elementId: 312,
-    				storeTo: 2,
-    				amount: 15,
-    				purchasingPrice: 1250.5
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentElementResult = {
+      documentElement: {
+        amount: number
+        docId: number
+        elementId: number
+        id: number
+        purchasingPrice: number
+        storeFrom: number | null
+        storeTo: number
+      }
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentElementResult>({
+        method: 'catalog.document.element.add',
+        params: {
+          fields: {
+            docId: 64,
+            elementId: 312,
+            storeTo: 2,
+            amount: 15,
+            purchasingPrice: 1250.5,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.documentElement)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDocumentElement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.element.add',
+            params: {
+              fields: {
+                docId: 64,
+                elementId: 312,
+                storeTo: 2,
+                amount: 15,
+                purchasingPrice: 1250.5,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.documentElement)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDocumentElement)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/document-element/catalog-document-element-delete.md
+++ b/api-reference/catalog/document/document-element/catalog-document-element-delete.md
@@ -54,23 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.element.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.element.delete',
-    		{ id: 148 }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.element.delete',
+        params: {
+          id: 148,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document element deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDocumentElement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.element.delete',
+            params: {
+              id: 148,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document element deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDocumentElement)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/document-element/catalog-document-element-get-fields.md
+++ b/api-reference/catalog/document/document-element/catalog-document-element-get-fields.md
@@ -45,23 +45,87 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.element.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.element.getFields',
-    		{}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentElementFieldsResult = {
+      documentElement: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentElementFieldsResult>({
+        method: 'catalog.document.element.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          Object.keys(result.documentElement),
+          result.documentElement
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentElementFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.element.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            Object.keys(result.documentElement),
+            result.documentElement
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentElementFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/document-element/catalog-document-element-list.md
+++ b/api-reference/catalog/document/document-element/catalog-document-element-list.md
@@ -87,93 +87,126 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.element.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type DocumentElement = {
+      id: number
+      docId: number
+      elementId: number
+      amount: number
+      purchasingPrice: number
+      storeFrom: number | null
+      storeTo: number | null
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentElementListResult = {
+      documentElements: DocumentElement[]
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'catalog.document.element.list',
-        {
-        select: [
+      // catalog.document.element.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DocumentElementListResult>({
+        method: 'catalog.document.element.list',
+        params: {
+          select: [
             'id',
             'docId',
             'elementId',
             'amount',
             'storeFrom',
-            'storeTo'
-        ],
-        filter: {
-            docId: 64
+            'storeTo',
+          ],
+          filter: {
+            docId: 64,
+          },
+          order: {
+            id: 'ASC',
+          },
+          start: 0,
         },
-        order: {
-            id: 'ASC'
-        }
-        },
-        (progress) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.documentElements.length, result.documentElements)
+      }
     } catch (error) {
-    console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+- JS (UMD)
 
-    try {
-    const generator = $b24.fetchListMethod('catalog.document.element.list', {
-        select: [
-        'id',
-        'docId',
-        'elementId',
-        'amount',
-        'storeFrom',
-        'storeTo'
-        ],
-        filter: {
-        docId: 64
-        },
-        order: {
-        id: 'ASC'
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listDocumentElements() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.document.element.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.element.list',
+            params: {
+              select: [
+                'id',
+                'docId',
+                'elementId',
+                'amount',
+                'storeFrom',
+                'storeTo',
+              ],
+              filter: {
+                docId: 64,
+              },
+              order: {
+                id: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.documentElements.length, result.documentElements)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+      }
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-    const response = await $b24.callMethod('catalog.document.element.list', {
-        select: [
-        'id',
-        'docId',
-        'elementId',
-        'amount',
-        'storeFrom',
-        'storeTo'
-        ],
-        filter: {
-        docId: 64
-        },
-        order: {
-        id: 'ASC'
-        }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+      document.addEventListener('DOMContentLoaded', listDocumentElements)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/document-element/catalog-document-element-update.md
+++ b/api-reference/catalog/document/document-element/catalog-document-element-update.md
@@ -73,30 +73,96 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.element.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.element.update',
-    		{
-    			id: 148,
-    			fields: {
-    				amount: 12,
-    				purchasingPrice: 1180,
-    				storeTo: 2
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentElementUpdateResult = {
+      documentElement: {
+        amount: number
+        docId: number
+        elementId: number
+        id: number
+        purchasingPrice: number
+        storeFrom: number | null
+        storeTo: number
+      }
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentElementUpdateResult>({
+        method: 'catalog.document.element.update',
+        params: {
+          id: 148,
+          fields: {
+            amount: 12,
+            purchasingPrice: 1180,
+            storeTo: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.documentElement)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDocumentElement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.element.update',
+            params: {
+              id: 148,
+              fields: {
+                amount: 12,
+                purchasingPrice: 1180,
+                storeTo: 2,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.documentElement)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDocumentElement)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/outdated/catalog-document-confirm.md
+++ b/api-reference/catalog/document/outdated/catalog-document-confirm.md
@@ -58,29 +58,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.confirm
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.confirm',
-    		{
-    			'id': 42,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.confirm',
+        params: {
+          id: 42,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document confirmed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function confirmDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.confirm',
+            params: {
+              id: 42,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document confirmed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', confirmDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/outdated/catalog-document-element-fields.md
+++ b/api-reference/catalog/document/outdated/catalog-document-element-fields.md
@@ -51,24 +51,82 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.element.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.element.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldInfo = {
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentElementFieldsResult = Record<string, FieldInfo>
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentElementFieldsResult>({
+        method: 'catalog.document.element.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentElementFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.element.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentElementFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/outdated/catalog-document-fields.md
+++ b/api-reference/catalog/document/outdated/catalog-document-fields.md
@@ -51,24 +51,82 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type DocumentField = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentFieldsResult = Record<string, DocumentField>
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentFieldsResult>({
+        method: 'catalog.document.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/document/outdated/catalog-document-unconfirm.md
+++ b/api-reference/catalog/document/outdated/catalog-document-unconfirm.md
@@ -58,26 +58,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.document.unconfirm
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.document.unconfirm',
-    		{
-    			'id': 42,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.document.unconfirm',
+        params: {
+          id: 42,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document unconfirmed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unconfirmDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.document.unconfirm',
+            params: {
+              id: 42,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document unconfirmed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unconfirmDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/documentcontractor/catalog-documentcontractor-add.md
+++ b/api-reference/catalog/documentcontractor/catalog-documentcontractor-add.md
@@ -77,29 +77,91 @@
     https://**put_your_bitrix24_address**/rest/catalog.documentcontractor.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.documentcontractor.add',
-            {
-                fields: {
-                    documentId: 42,
-                    entityTypeId: 3,
-                    entityId: 101
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Created binding:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentContractorAddResult = {
+      documentContractor: {
+        documentId: number
+        entityId: number
+        entityTypeId: number
+        id: number
+      }
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentContractorAddResult>({
+        method: 'catalog.documentcontractor.add',
+        params: {
+          fields: {
+            documentId: 42,
+            entityTypeId: 3,
+            entityId: 101,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.documentContractor.id, result.documentContractor)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDocumentContractor() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.documentcontractor.add',
+            params: {
+              fields: {
+                documentId: 42,
+                entityTypeId: 3,
+                entityId: 101,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.documentContractor.id, result.documentContractor)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDocumentContractor)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/documentcontractor/catalog-documentcontractor-delete.md
+++ b/api-reference/catalog/documentcontractor/catalog-documentcontractor-delete.md
@@ -55,23 +55,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.documentcontractor.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js 
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.documentcontractor.delete',
-            { id: 42 }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.documentcontractor.delete',
+        params: {
+          id: 42,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contractor binding deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDocumentContractor() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.documentcontractor.delete',
+            params: {
+              id: 42,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contractor binding deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDocumentContractor)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/documentcontractor/catalog-documentcontractor-get-fields.md
+++ b/api-reference/catalog/documentcontractor/catalog-documentcontractor-get-fields.md
@@ -48,23 +48,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.documentcontractor.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.documentcontractor.getFields',
-            {}
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentContractorFieldsResult = {
+      documentContractor: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentContractorFieldsResult>({
+        method: 'catalog.documentcontractor.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.documentContractor))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentContractorFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.documentcontractor.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.documentContractor))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentContractorFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/documentcontractor/catalog-documentcontractor-list.md
+++ b/api-reference/catalog/documentcontractor/catalog-documentcontractor-list.md
@@ -107,63 +107,97 @@
     https://**put_your_bitrix24_address**/rest/catalog.documentcontractor.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentContractorResult = {
+      documentContractor: {
+        id: number
+        documentId: number
+      }[]
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'catalog.documentcontractor.list',
-        {
-        select: ["id", "documentId"],
-        filter: { "documentId": 7 },
-        order: { "id": "ASC" },
-        start: 0
+      // catalog.documentcontractor.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DocumentContractorResult>({
+        method: 'catalog.documentcontractor.list',
+        params: {
+          select: ['id', 'documentId'],
+          filter: { documentId: 7 },
+          order: { id: 'ASC' },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.documentContractor.length, result.documentContractor)
+      }
     } catch (error) {
-    console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
+- JS (UMD)
 
-    try {
-    const generator = $b24.fetchListMethod('catalog.documentcontractor.list', {
-        select: ["id", "documentId"],
-        filter: { "documentId": 7 },
-        order: { "id": "ASC" },
-        start: 0
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchDocumentContractorList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
+          // catalog.documentcontractor.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.documentcontractor.list',
+            params: {
+              select: ['id', 'documentId'],
+              filter: { documentId: 7 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-    try {
-    const response = await $b24.callMethod('catalog.documentcontractor.list', {
-        select: ["id", "documentId"],
-        filter: { "documentId": 7 },
-        order: { "id": "ASC" },
-        start: 0
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.documentContractor.length, result.documentContractor)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchDocumentContractorList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/enum/catalog-enum-get-round-types.md
+++ b/api-reference/catalog/enum/catalog-enum-get-round-types.md
@@ -45,23 +45,77 @@
     https://**put_your_bitrix24_address**/rest/catalog.enum.getRoundTypes
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.enum.getRoundTypes',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoundTypesResult = {
+      enum: {
+        id: number
+        name: string
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RoundTypesResult>({
+        method: 'catalog.enum.getRoundTypes',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.enum)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRoundTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.enum.getRoundTypes',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.enum)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRoundTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/enum/catalog-enum-get-store-document-types.md
+++ b/api-reference/catalog/enum/catalog-enum-get-store-document-types.md
@@ -45,23 +45,77 @@
     https://**put_your_bitrix24_address**/rest/catalog.enum.getStoreDocumentTypes
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.enum.getStoreDocumentTypes',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreDocumentTypesResult = {
+      enum: {
+        id: string
+        name: string
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreDocumentTypesResult>({
+        method: 'catalog.enum.getStoreDocumentTypes',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.enum)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStoreDocumentTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.enum.getStoreDocumentTypes',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.enum)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStoreDocumentTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/extra/catalog-extra-get-fields.md
+++ b/api-reference/catalog/extra/catalog-extra-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.extra.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.extra.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExtraGetFieldsResult = {
+      extra: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExtraGetFieldsResult>({
+        method: 'catalog.extra.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Extra fields:', Object.keys(result.extra))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getExtraFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.extra.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Extra fields:', Object.keys(result.extra))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getExtraFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/extra/catalog-extra-get.md
+++ b/api-reference/catalog/extra/catalog-extra-get.md
@@ -52,33 +52,82 @@
     https://**put_your_bitrix24_address**/rest/catalog.extra.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.extra.get',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.log(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExtraGetResult = {
+      extra: {
+        id: number
+        name: string
+        percentage: number
+      }
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ExtraGetResult>({
+        method: 'catalog.extra.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.extra.id, result.extra.name, result.extra.percentage)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getExtra() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.extra.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.extra.id, result.extra.name, result.extra.percentage)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getExtra)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/extra/catalog-extra-list.md
+++ b/api-reference/catalog/extra/catalog-extra-list.md
@@ -102,48 +102,97 @@
     https://**put_your_bitrix24_address**/rest/catalog.extra.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ExtraResult = {
+      extras: {
+        id: number
+        percentage: number
+      }[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'catalog.extra.list',
-        {
+      // catalog.extra.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ExtraResult>({
+        method: 'catalog.extra.list',
+        params: {
           select: ['id', 'percentage'],
           filter: { '>percentage': 5 },
-          order: { 'id': 'ASC' }
+          order: { id: 'ASC' },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('catalog.extra.list', { select: ['id', 'percentage'], filter: { '>percentage': 5 }, order: { 'id': 'ASC' } }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.extras.length, result.extras)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.extra.list', { select: ['id', 'percentage'], filter: { '>percentage': 5 }, order: { 'id': 'ASC' } }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listExtras() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.extra.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.extra.list',
+            params: {
+              select: ['id', 'percentage'],
+              filter: { '>percentage': 5 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.extras.length, result.extras)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listExtras)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/measure/catalog-measure-add.md
+++ b/api-reference/catalog/measure/catalog-measure-add.md
@@ -84,33 +84,100 @@
     https://**put_your_bitrix24_address**/rest/catalog.measure.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.measure.add', 
-    		{
-    			fields: {
-    				code: 715,
-    				measureTitle: "Пара",
-    				symbol: 'пар',
-    				symbolLetterIntl: 'NPR',
-    				symbolIntl: 'pr; 2',
-    				isDefault: 'N'
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeasureAddResult = {
+      measure: {
+        code: number
+        id: number
+        isDefault: string
+        measureTitle: string
+        symbol: string
+        symbolIntl: string
+        symbolLetterIntl: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MeasureAddResult>({
+        method: 'catalog.measure.add',
+        params: {
+          fields: {
+            code: 715,
+            measureTitle: 'Pair',
+            symbol: 'pr',
+            symbolLetterIntl: 'NPR',
+            symbolIntl: 'pr; 2',
+            isDefault: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added measure:', result.measure.id, result.measure.measureTitle)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addMeasure() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.measure.add',
+            params: {
+              fields: {
+                code: 715,
+                measureTitle: 'Pair',
+                symbol: 'pr',
+                symbolLetterIntl: 'NPR',
+                symbolIntl: 'pr; 2',
+                isDefault: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added measure:', result.measure.id, result.measure.measureTitle)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addMeasure)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/measure/catalog-measure-delete.md
+++ b/api-reference/catalog/measure/catalog-measure-delete.md
@@ -52,26 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.measure.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.measure.delete',
-    		{
-    			id: 6
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.measure.delete',
+        params: {
+          id: 6,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Measure deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteMeasure() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.measure.delete',
+            params: {
+              id: 6,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Measure deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteMeasure)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/measure/catalog-measure-get-fields.md
+++ b/api-reference/catalog/measure/catalog-measure-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.measure.getFields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.measure.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeasureFieldsResult = {
+      measure: Record<string, FieldDescriptor>
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    type FieldDescriptor = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<MeasureFieldsResult>({
+        method: 'catalog.measure.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available measure fields:', Object.keys(result.measure))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMeasureFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.measure.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available measure fields:', Object.keys(result.measure))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMeasureFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/measure/catalog-measure-get.md
+++ b/api-reference/catalog/measure/catalog-measure-get.md
@@ -52,26 +52,86 @@
     https://**put_your_bitrix24_address**/rest/catalog.measure.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.measure.get',
-    		{
-    			id: 6
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeasureGetResult = {
+      measure: {
+        code: number
+        id: number
+        isDefault: string
+        measureTitle: string
+        symbol: string
+        symbolIntl: string
+        symbolLetterIntl: string
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MeasureGetResult>({
+        method: 'catalog.measure.get',
+        params: {
+          id: 6,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.measure.id, result.measure.measureTitle, result.measure.symbol)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMeasure() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.measure.get',
+            params: {
+              id: 6,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.measure.id, result.measure.measureTitle, result.measure.symbol)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMeasure)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/measure/catalog-measure-list.md
+++ b/api-reference/catalog/measure/catalog-measure-list.md
@@ -102,50 +102,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.measure.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.measure.list',
-        {
-          select: ["id", "code", "symbolIntl"],
-          filter: {
-            '<=code': 200
-          },
-          order: {'code': 'DESC'}
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeasureListResult = {
+      measures: {
+        id: number
+        code: number
+        symbolIntl: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
+    // catalog.measure.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-      const generator = $b24.fetchListMethod('catalog.measure.list', { select: ["id", "code", "symbolIntl"], filter: {'<=code': 200}, order: {'code': 'DESC'} }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      const response = await $b24.actions.v2.call.make<MeasureListResult>({
+        method: 'catalog.measure.list',
+        params: {
+          select: ['id', 'code', 'symbolIntl'],
+          filter: { '<=code': 200 },
+          order: { code: 'DESC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Measures on this page:', result.measures.length, result.measures)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.measure.list', { select: ["id", "code", "symbolIntl"], filter: {'<=code': 200}, order: {'code': 'DESC'} }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchMeasureList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.measure.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.measure.list',
+            params: {
+              select: ['id', 'code', 'symbolIntl'],
+              filter: { '<=code': 200 },
+              order: { code: 'DESC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Measures on this page:', result.measures.length, result.measures)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchMeasureList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/measure/catalog-measure-update.md
+++ b/api-reference/catalog/measure/catalog-measure-update.md
@@ -82,31 +82,96 @@
     https://**put_your_bitrix24_address**/rest/catalog.measure.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.measure.update', 
-    		{
-    			id: 8,
-    			fields: {
-    				symbol: 'пар',
-    				symbolLetterIntl: 'nrp',
-    				symbolIntl: 'pr. 2'
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MeasureUpdateResult = {
+      measure: {
+        code: number
+        id: number
+        isDefault: string
+        measureTitle: string
+        symbol: string
+        symbolIntl: string
+        symbolLetterIntl: string
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MeasureUpdateResult>({
+        method: 'catalog.measure.update',
+        params: {
+          id: 8,
+          fields: {
+            symbol: 'пар',
+            symbolLetterIntl: 'nrp',
+            symbolIntl: 'pr. 2',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.measure.id, result.measure.symbol)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateMeasure() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.measure.update',
+            params: {
+              id: 8,
+              fields: {
+                symbol: 'пар',
+                symbolLetterIntl: 'nrp',
+                symbolIntl: 'pr. 2',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.measure.id, result.measure.symbol)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateMeasure)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/catalog-price-type-add.md
+++ b/api-reference/catalog/price-type/catalog-price-type-add.md
@@ -85,31 +85,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceType.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceType.add', 
-    		{
-    			fields: {
-    				name: "Wholesale price",
-    				base: "N",
-    				sort: 10,
-    				xmlId: "wholesale"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddPriceTypeResult = {
+      priceType: {
+        base: string
+        createdBy: number
+        dateCreate: ISODate | null
+        id: number
+        modifiedBy: number
+        name: string
+        sort: number
+        timestampX: ISODate | null
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddPriceTypeResult>({
+        method: 'catalog.priceType.add',
+        params: {
+          fields: {
+            name: 'Wholesale price',
+            base: 'N',
+            sort: 10,
+            xmlId: 'wholesale',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created price type id:', result.priceType.id, 'name:', result.priceType.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPriceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceType.add',
+            params: {
+              fields: {
+                name: 'Wholesale price',
+                base: 'N',
+                sort: 10,
+                xmlId: 'wholesale',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created price type id:', result.priceType.id, 'name:', result.priceType.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPriceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/catalog-price-type-delete.md
+++ b/api-reference/catalog/price-type/catalog-price-type-delete.md
@@ -55,26 +55,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceType.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceType.delete',
-    		{
-    			id: 2
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.priceType.delete',
+        params: {
+          id: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price type deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePriceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceType.delete',
+            params: {
+              id: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price type deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePriceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/catalog-price-type-get-fields.md
+++ b/api-reference/catalog/price-type/catalog-price-type-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceType.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceType.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeFieldsResult = {
+      priceType: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeFieldsResult>({
+        method: 'catalog.priceType.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.priceType))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPriceTypeFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceType.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.priceType))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPriceTypeFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/catalog-price-type-get.md
+++ b/api-reference/catalog/price-type/catalog-price-type-get.md
@@ -52,26 +52,88 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceType.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceType.get',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeResult = {
+      priceType: {
+        base: string
+        createdBy: number
+        dateCreate: ISODate | null
+        id: number
+        modifiedBy: number
+        name: string
+        sort: number
+        timestampX: ISODate | null
+        xmlId: string
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeResult>({
+        method: 'catalog.priceType.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.priceType.id, result.priceType.name, result.priceType.base)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPriceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceType.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.priceType.id, result.priceType.name, result.priceType.base)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPriceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/catalog-price-type-list.md
+++ b/api-reference/catalog/price-type/catalog-price-type-list.md
@@ -102,62 +102,100 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceType.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const parameters = {
-        select: ['id', 'name', 'xmlId'],
-        filter: { 'modifiedBy': 1 },
-        order: { 'id': 'ASC' }
-    };
-    
-    try {
-        const response = await $b24.callListMethod(
-            'catalog.priceType.list',
-            parameters,
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeListResult = {
+      priceTypes: PriceType[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const parameters = {
-        select: ['id', 'name', 'xmlId'],
-        filter: { 'modifiedBy': 1 },
-        order: { 'id': 'ASC' }
-    };
-    
+
+    type PriceType = {
+      id: number
+      name: string
+      xmlId: string
+    }
+
     try {
-        const generator = $b24.fetchListMethod('catalog.priceType.list', parameters, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
+      // catalog.priceType.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PriceTypeListResult>({
+        method: 'catalog.priceType.list',
+        params: {
+          select: ['id', 'name', 'xmlId'],
+          filter: { modifiedBy: 1 },
+          order: { id: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price types:', result.priceTypes, 'count:', result.priceTypes.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchPriceTypeList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.priceType.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceType.list',
+            params: {
+              select: ['id', 'name', 'xmlId'],
+              filter: { modifiedBy: 1 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price types:', result.priceTypes, 'count:', result.priceTypes.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const parameters = {
-        select: ['id', 'name', 'xmlId'],
-        filter: { 'modifiedBy': 1 },
-        order: { 'id': 'ASC' }
-    };
-    
-    try {
-        const response = await $b24.callMethod('catalog.priceType.list', parameters, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchPriceTypeList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/catalog-price-type-update.md
+++ b/api-reference/catalog/price-type/catalog-price-type-update.md
@@ -77,32 +77,100 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceType.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceType.update', 
-    		{
-    			id: 2,
-    			fields: {
-    				name: "Base wholesale price",
-    				base: "Y",
-    				sort: 1,
-    				xmlId: "basewholesale"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeUpdateResult = {
+      priceType: {
+        base: string
+        createdBy: number
+        dateCreate: ISODate | null
+        id: number
+        modifiedBy: number
+        name: string
+        sort: number
+        timestampX: ISODate | null
+        xmlId: string
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeUpdateResult>({
+        method: 'catalog.priceType.update',
+        params: {
+          id: 2,
+          fields: {
+            name: 'Base wholesale price',
+            base: 'Y',
+            sort: 1,
+            xmlId: 'basewholesale',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.priceType.id, result.priceType.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePriceType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceType.update',
+            params: {
+              id: 2,
+              fields: {
+                name: 'Base wholesale price',
+                base: 'Y',
+                sort: 1,
+                xmlId: 'basewholesale',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.priceType.id, result.priceType.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePriceType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-add.md
+++ b/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-add.md
@@ -76,29 +76,91 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeGroup.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeGroup.add',
-    		{
-    			fields: {
-    				catalogGroupId: 9,
-    				groupId: 23,
-    				access: "Y"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeGroupAddResult = {
+      priceTypeGroup: {
+        access: string
+        catalogGroupId: number
+        groupId: number
+        id: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeGroupAddResult>({
+        method: 'catalog.priceTypeGroup.add',
+        params: {
+          fields: {
+            catalogGroupId: 9,
+            groupId: 23,
+            access: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.priceTypeGroup)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPriceTypeGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeGroup.add',
+            params: {
+              fields: {
+                catalogGroupId: 9,
+                groupId: 23,
+                access: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.priceTypeGroup)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPriceTypeGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-delete.md
+++ b/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-delete.md
@@ -54,25 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeGroup.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeGroup.delete',
-    		{
-    			id: 109
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.priceTypeGroup.delete',
+        params: {
+          id: 109,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePriceTypeGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeGroup.delete',
+            params: {
+              id: 109,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePriceTypeGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-get-fields.md
+++ b/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-get-fields.md
@@ -45,23 +45,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeGroup.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeGroup.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeGroupFieldsResult = {
+      priceTypeGroup: Record<string, FieldDescription>
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeGroupFieldsResult>({
+        method: 'catalog.priceTypeGroup.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('priceTypeGroup fields:', Object.keys(result.priceTypeGroup))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPriceTypeGroupFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeGroup.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('priceTypeGroup fields:', Object.keys(result.priceTypeGroup))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPriceTypeGroupFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-list.md
+++ b/api-reference/catalog/price-type/price-type-group/catalog-price-type-group-list.md
@@ -96,61 +96,99 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeGroup.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const parameters = {
-        select: ['id', 'catalogGroupId', 'groupId', 'access'],
-        filter: { 'catalogGroupId': 9, 'groupId': 23 },
-        order: { 'id': 'ASC' }
-    };
-    
-    try {
-        const response = await $b24.callListMethod(
-            'catalog.priceTypeGroup.list',
-            parameters,
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeGroupsResult = {
+      priceTypeGroups: {
+        id: number
+        catalogGroupId: number
+        groupId: number
+        access: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const parameters = {
-        select: ['id', 'catalogGroupId', 'groupId', 'access'],
-        filter: { 'catalogGroupId': 9, 'groupId': 23 },
-        order: { 'id': 'ASC' }
-    };
-    
+
     try {
-        const generator = $b24.fetchListMethod('catalog.priceTypeGroup.list', parameters, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
+      // catalog.priceTypeGroup.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PriceTypeGroupsResult>({
+        method: 'catalog.priceTypeGroup.list',
+        params: {
+          select: ['id', 'catalogGroupId', 'groupId', 'access'],
+          filter: { catalogGroupId: 9, groupId: 23 },
+          order: { id: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price type groups:', result.priceTypeGroups, 'Count:', result.priceTypeGroups.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchPriceTypeGroupList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.priceTypeGroup.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeGroup.list',
+            params: {
+              select: ['id', 'catalogGroupId', 'groupId', 'access'],
+              filter: { catalogGroupId: 9, groupId: 23 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price type groups:', result.priceTypeGroups, 'Count:', result.priceTypeGroups.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const parameters = {
-        select: ['id', 'catalogGroupId', 'groupId', 'access'],
-        filter: { 'catalogGroupId': 9, 'groupId': 23 },
-        order: { 'id': 'ASC' }
-    };
-    
-    try {
-        const response = await $b24.callMethod('catalog.priceTypeGroup.list', parameters, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchPriceTypeGroupList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-add.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-add.md
@@ -73,30 +73,91 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeLang.add', 
-    		{
-    			fields: {
-    				catalogGroupId: 1,
-    				lang: "kz",
-    				name: "PRICE"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeLangAddResult = {
+      priceTypeLang: {
+        catalogGroupId: number
+        id: number
+        lang: string
+        name: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeLangAddResult>({
+        method: 'catalog.priceTypeLang.add',
+        params: {
+          fields: {
+            catalogGroupId: 1,
+            lang: 'kz',
+            name: 'PRICE',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.priceTypeLang)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPriceTypeLang() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.add',
+            params: {
+              fields: {
+                catalogGroupId: 1,
+                lang: 'kz',
+                name: 'PRICE',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.priceTypeLang)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPriceTypeLang)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-delete.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-delete.md
@@ -52,26 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeLang.delete',
-    		{
-    			id: 3
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.priceTypeLang.delete',
+        params: {
+          id: 3,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price type language translation deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePriceTypeLang() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.delete',
+            params: {
+              id: 3,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price type language translation deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePriceTypeLang)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-get-fields.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeLang.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeLangGetFieldsResult = {
+      priceTypeLang: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeLangGetFieldsResult>({
+        method: 'catalog.priceTypeLang.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.priceTypeLang), result.priceTypeLang)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.priceTypeLang), result.priceTypeLang)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-get-languages.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-get-languages.md
@@ -45,24 +45,78 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.getLanguages
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeLang.getLanguages',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetLanguagesResult = {
+      languages: {
+        active: string
+        lid: string
+        name: string
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetLanguagesResult>({
+        method: 'catalog.priceTypeLang.getLanguages',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.languages)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLanguages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.getLanguages',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.languages)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLanguages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-get.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-get.md
@@ -52,26 +52,83 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeLang.get',
-    		{
-    			id: 2
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeLangGetResult = {
+      priceTypeLang: {
+        catalogGroupId: number
+        id: number
+        lang: string
+        name: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeLangGetResult>({
+        method: 'catalog.priceTypeLang.get',
+        params: {
+          id: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.priceTypeLang)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPriceTypeLang() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.get',
+            params: {
+              id: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.priceTypeLang)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPriceTypeLang)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-list.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-list.md
@@ -102,53 +102,95 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.priceTypeLang.list',
-        {
-          select: ['name', 'lang'],
-          order: { 'lang': 'ASC' }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeLangListResult = {
+      priceTypeLangs: {
+        lang: string
+        name: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('catalog.priceTypeLang.list', {
-        select: ['name', 'lang'],
-        order: { 'lang': 'ASC' }
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // catalog.priceTypeLang.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PriceTypeLangListResult>({
+        method: 'catalog.priceTypeLang.list',
+        params: {
+          select: ['name', 'lang'],
+          order: { lang: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price type language translations:', result.priceTypeLangs.length, result.priceTypeLangs)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.priceTypeLang.list', {
-        select: ['name', 'lang'],
-        order: { 'lang': 'ASC' }
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchPriceTypeLangList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.priceTypeLang.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.list',
+            params: {
+              select: ['name', 'lang'],
+              order: { lang: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price type language translations:', result.priceTypeLangs.length, result.priceTypeLangs)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchPriceTypeLangList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-update.md
+++ b/api-reference/catalog/price-type/price-type-lang/catalog-price-type-lang-update.md
@@ -75,29 +75,89 @@
     https://**put_your_bitrix24_address**/rest/catalog.priceTypeLang.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.priceTypeLang.update', 
-    		{
-    			id: 6,
-    			fields: {
-    				name: "Base Price",
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceTypeLangUpdateResult = {
+      priceTypeLang: {
+        catalogGroupId: number
+        id: number
+        lang: string
+        name: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceTypeLangUpdateResult>({
+        method: 'catalog.priceTypeLang.update',
+        params: {
+          id: 6,
+          fields: {
+            name: 'Base Price',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.priceTypeLang)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePriceTypeLang() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.priceTypeLang.update',
+            params: {
+              id: 6,
+              fields: {
+                name: 'Base Price',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.priceTypeLang)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePriceTypeLang)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-add.md
+++ b/api-reference/catalog/price/catalog-price-add.md
@@ -69,30 +69,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.price.add',
-    		{
-    			fields: {
-    				catalogGroupId: 1,
-    				currency: "RUB",
-    				price: 2000,
-    				productId: 1
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogPriceAddResult = {
+      price: {
+        catalogGroupId: number
+        currency: string
+        extraId: string | null
+        id: number
+        price: number
+        productId: number
+        quantityFrom: number | null
+        quantityTo: number | null
+        timestampX: ISODate
+      }
     }
-    catch( error )
-    {
-    	console.error(error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogPriceAddResult>({
+        method: 'catalog.price.add',
+        params: {
+          fields: {
+            catalogGroupId: 1,
+            currency: 'RUB',
+            price: 2000,
+            productId: 1,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.price.id, result.price.price, result.price.currency)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCatalogPrice() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.add',
+            params: {
+              fields: {
+                catalogGroupId: 1,
+                currency: 'RUB',
+                price: 2000,
+                productId: 1,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.price.id, result.price.price, result.price.currency)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCatalogPrice)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-delete.md
+++ b/api-reference/catalog/price/catalog-price-delete.md
@@ -52,25 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.price.delete',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.price.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price deleted successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCatalogPrice() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price deleted successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCatalogPrice)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-get-fields.md
+++ b/api-reference/catalog/price/catalog-price-get-fields.md
@@ -45,23 +45,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.price.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceFieldsResult = {
+      price: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceFieldsResult>({
+        method: 'catalog.price.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Price fields:', Object.keys(result.price))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPriceFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Price fields:', Object.keys(result.price))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPriceFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-get.md
+++ b/api-reference/catalog/price/catalog-price-get.md
@@ -52,25 +52,88 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.price.get',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceResult = {
+      price: {
+        catalogGroupId: number
+        currency: string
+        extraId: number | null
+        id: number
+        price: number
+        productId: number
+        quantityFrom: number | null
+        quantityTo: number | null
+        timestampX: ISODate | null
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceResult>({
+        method: 'catalog.price.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.price.id, result.price.price, result.price.currency)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPriceById() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.price.id, result.price.price, result.price.currency)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPriceById)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-list.md
+++ b/api-reference/catalog/price/catalog-price-list.md
@@ -102,61 +102,100 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const parameters = {
-        select: ['id', 'productId', 'catalogGroupId', 'price', 'currency'],
-        filter: { 'productId': 1 },
-        order: { 'id': 'ASC' }
-    };
-    
-    try {
-        const response = await $b24.callListMethod(
-            'catalog.price.list',
-            parameters,
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceListResult = {
+      prices: {
+        id: number
+        productId: number
+        catalogGroupId: number
+        price: number
+        currency: string
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const parameters = {
-        select: ['id', 'productId', 'catalogGroupId', 'price', 'currency'],
-        filter: { 'productId': 1 },
-        order: { 'id': 'ASC' }
-    };
-    
+
     try {
-        const generator = $b24.fetchListMethod('catalog.price.list', parameters, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
+      // catalog.price.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PriceListResult>({
+        method: 'catalog.price.list',
+        params: {
+          select: ['id', 'productId', 'catalogGroupId', 'price', 'currency'],
+          filter: { productId: 1 },
+          order: { id: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Prices count:', result.prices.length, result.prices)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchPriceList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.price.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.list',
+            params: {
+              select: ['id', 'productId', 'catalogGroupId', 'price', 'currency'],
+              filter: { productId: 1 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Prices count:', result.prices.length, result.prices)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const parameters = {
-        select: ['id', 'productId', 'catalogGroupId', 'price', 'currency'],
-        filter: { 'productId': 1 },
-        order: { 'id': 'ASC' }
-    };
-    
-    try {
-        const response = await $b24.callMethod('catalog.price.list', parameters, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchPriceList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-modify.md
+++ b/api-reference/catalog/price/catalog-price-modify.md
@@ -94,45 +94,133 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.modify
     ```
 
-- JS
+- JS (TS)
 
-    ```javascript
-    try {
-        const response = await $b24.callMethod(
-            'catalog.price.modify',
-            {
-                fields: {
-                    product: {
-                        id: 8,
-                        prices: [
-                            {
-                                catalogGroupId: 1,
-                                currency: 'RUB',
-                                price: 2001
-                            },
-                            {
-                                catalogGroupId: 3,
-                                currency: 'RUB',
-                                price: 2001
-                            },
-                            {
-                                catalogGroupId: 5,
-                                currency: 'RUB',
-                                price: 2001,
-                                id: 122
-                            },
-                        ]
-                    },
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Modified prices:', result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ModifyPricesResult = {
+      prices: {
+        catalogGroupId: number
+        currency: string
+        extraId: string | null
+        id: number
+        price: number
+        priceScale: number
+        productId: number
+        quantityFrom: number | null
+        quantityTo: number | null
+        timestampX: ISODate | null
+      }[]
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ModifyPricesResult>({
+        method: 'catalog.price.modify',
+        params: {
+          fields: {
+            product: {
+              id: 8,
+              prices: [
+                {
+                  catalogGroupId: 1,
+                  currency: 'RUB',
+                  price: 2001,
+                },
+                {
+                  catalogGroupId: 3,
+                  currency: 'RUB',
+                  price: 2001,
+                },
+                {
+                  catalogGroupId: 5,
+                  currency: 'RUB',
+                  price: 2001,
+                  id: 122,
+                },
+              ],
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Modified prices:', result.prices)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function modifyPrices() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.modify',
+            params: {
+              fields: {
+                product: {
+                  id: 8,
+                  prices: [
+                    {
+                      catalogGroupId: 1,
+                      currency: 'RUB',
+                      price: 2001,
+                    },
+                    {
+                      catalogGroupId: 3,
+                      currency: 'RUB',
+                      price: 2001,
+                    },
+                    {
+                      catalogGroupId: 5,
+                      currency: 'RUB',
+                      price: 2001,
+                      id: 122,
+                    },
+                  ],
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Modified prices:', result.prices)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', modifyPrices)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/price/catalog-price-update.md
+++ b/api-reference/catalog/price/catalog-price-update.md
@@ -67,29 +67,96 @@
     https://**put_your_bitrix24_address**/rest/catalog.price.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.price.update',
-    		{
-    			id: 1,
-    			fields: {
-    				currency: "RUB",
-    				price: 5000
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PriceUpdateResult = {
+      price: {
+        catalogGroupId: number
+        currency: string
+        extraId: number | null
+        id: number
+        price: number
+        productId: number
+        quantityFrom: number | null
+        quantityTo: number | null
+        timestampX: ISODate | null
+      }
     }
-    catch( error )
-    {
-    	console.error(error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PriceUpdateResult>({
+        method: 'catalog.price.update',
+        params: {
+          id: 1,
+          fields: {
+            currency: 'RUB',
+            price: 5000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.price.id, result.price.currency, result.price.price)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePrice() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.update',
+            params: {
+              id: 1,
+              fields: {
+                currency: 'RUB',
+                price: 5000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.price.id, result.price.currency, result.price.price)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePrice)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-image/catalog-product-image-add.md
+++ b/api-reference/catalog/product-image/catalog-product-image-add.md
@@ -85,33 +85,100 @@
     https://**put_your_bitrix24_address**/rest/catalog.productImage.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.productImage.add',
-    		{
-    			'fields': {
-    				'productId': 1,
-    				'type': 'MORE_PHOTO'
-    			},
-    			'fileContent': [
-    				'test.jpeg',
-    				'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductImageAddResult = {
+      productImage: {
+        createTime: ISODate,
+        detailUrl: string,
+        downloadUrl: string,
+        id: number,
+        name: string,
+        productId: number,
+        type: string,
+      },
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductImageAddResult>({
+        method: 'catalog.productImage.add',
+        params: {
+          fields: {
+            productId: 1,
+            type: 'MORE_PHOTO',
+          },
+          fileContent: [
+            'test.jpeg',
+            'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productImage.id, result.productImage.name, result.productImage.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProductImage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productImage.add',
+            params: {
+              fields: {
+                productId: 1,
+                type: 'MORE_PHOTO',
+              },
+              fileContent: [
+                'test.jpeg',
+                'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productImage.id, result.productImage.name, result.productImage.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProductImage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-image/catalog-product-image-delete.md
+++ b/api-reference/catalog/product-image/catalog-product-image-delete.md
@@ -64,27 +64,75 @@
     https://**put_your_bitrix24_address**/rest/catalog.productImage.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.productImage.delete',
-    		{
-    			productId: 1,
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.productImage.delete',
+        params: {
+          productId: 1,
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Image deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProductImage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productImage.delete',
+            params: {
+              productId: 1,
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Image deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProductImage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-image/catalog-product-image-get-fields.md
+++ b/api-reference/catalog/product-image/catalog-product-image-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.productImage.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.productImage.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductImageFieldsResult = {
+      productImage: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductImageFieldsResult>({
+        method: 'catalog.productImage.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productImage)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductImageFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productImage.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productImage)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductImageFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-image/catalog-product-image-get.md
+++ b/api-reference/catalog/product-image/catalog-product-image-get.md
@@ -64,27 +64,88 @@
     https://**put_your_bitrix24_address**/rest/catalog.productImage.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.productImage.get', 
-    		{
-    			productId: 1,
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductImageGetResult = {
+      productImage: {
+        createTime: ISODate | null,
+        detailUrl: string,
+        downloadUrl: string,
+        id: number,
+        name: string,
+        productId: number,
+        type: string,
+      },
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductImageGetResult>({
+        method: 'catalog.productImage.get',
+        params: {
+          productId: 1,
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productImage.id, result.productImage.name, result.productImage.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductImage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productImage.get',
+            params: {
+              productId: 1,
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productImage.id, result.productImage.name, result.productImage.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductImage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-image/catalog-product-image-list.md
+++ b/api-reference/catalog/product-image/catalog-product-image-list.md
@@ -64,16 +64,38 @@
     https://**put_your_bitrix24_address**/rest/catalog.productImage.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductImageListResult = {
+      productImages: {
+        id: number
+        name: string
+        productId: number
+        type: string
+        createTime: ISODate | null
+        downloadUrl: string
+        detailUrl: string
+      }[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'catalog.productImage.list',
-        {
+      // catalog.productImage.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProductImageListResult>({
+        method: 'catalog.productImage.list',
+        params: {
           productId: 1,
           select: [
             'id',
@@ -84,35 +106,74 @@
             'downloadUrl',
             'detailUrl',
           ],
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('catalog.productImage.list', { productId: 1, select: ['id', 'name', 'productId', 'type', 'createTime', 'downloadUrl', 'detailUrl'] }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product images:', result.productImages, 'Count:', result.productImages.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.productImage.list', { productId: 1, select: ['id', 'name', 'productId', 'type', 'createTime', 'downloadUrl', 'detailUrl'] }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listProductImages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.productImage.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productImage.list',
+            params: {
+              productId: 1,
+              select: [
+                'id',
+                'name',
+                'productId',
+                'type',
+                'createTime',
+                'downloadUrl',
+                'detailUrl',
+              ],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product images:', result.productImages, 'Count:', result.productImages.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listProductImages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-add.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-add.md
@@ -81,24 +81,97 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyEnum.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyEnumAddResult = {
+      productPropertyEnum: {
+        def: string
+        id: number
+        propertyId: number
+        sort: number
+        value: string
+        xmlId: string
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyEnum.add', {
-            fields: {
+      const response = await $b24.actions.v2.call.make<ProductPropertyEnumAddResult>({
+        method: 'catalog.productPropertyEnum.add',
+        params: {
+          fields: {
+            propertyId: 431,
+            value: 'Medium',
+            xmlId: 'M',
+            def: 'Y',
+            sort: 100,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyEnum)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProductPropertyEnum() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyEnum.add',
+            params: {
+              fields: {
                 propertyId: 431,
-                value: 'Средний',
+                value: 'Medium',
                 xmlId: 'M',
                 def: 'Y',
                 sort: 100,
-            }
-        });
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    } catch (error) {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyEnum)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProductPropertyEnum)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-delete.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-delete.md
@@ -54,18 +54,73 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyEnum.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyEnum.delete', {
-            id: 122,
-        });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.productPropertyEnum.delete',
+        params: {
+          id: 122,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        console.log(response.getData().result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
     } catch (error) {
-        console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProductPropertyEnum() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyEnum.delete',
+            params: {
+              id: 122,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProductPropertyEnum)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-get-fields.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-get-fields.md
@@ -45,15 +45,81 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyEnum.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod('catalog.productPropertyEnum.getFields', {});
-        console.log(response.getData().result);
-    } catch (error) {
-        console.error('Error:', error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldInfo = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyEnumFieldsResult = {
+      productPropertyEnum: Record<string, FieldInfo>
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductPropertyEnumFieldsResult>({
+        method: 'catalog.productPropertyEnum.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.productPropertyEnum), result.productPropertyEnum)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchProductPropertyEnumFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyEnum.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.productPropertyEnum), result.productPropertyEnum)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchProductPropertyEnumFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-get.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-get.md
@@ -54,18 +54,85 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyEnum.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod('catalog.productPropertyEnum.get', {
-            id: 1739,
-        });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyEnumGetResult = {
+      productPropertyEnum: {
+        def: string
+        id: number
+        propertyId: number
+        sort: number
+        value: string
+        xmlId: string
+      }
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductPropertyEnumGetResult>({
+        method: 'catalog.productPropertyEnum.get',
+        params: {
+          id: 1739,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyEnum)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductPropertyEnum() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyEnum.get',
+            params: {
+              id: 1739,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyEnum)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductPropertyEnum)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-list.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-list.md
@@ -95,55 +95,103 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyEnum.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type ProductPropertyEnumItem = {
+      def: string
+      id: number
+      propertyId: number
+      sort: number
+      value: string
+      xmlId: string
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyEnumListResult = {
+      productPropertyEnums: ProductPropertyEnumItem[]
+    }
 
     try {
-        const response = await $b24.callListMethod(
-            'catalog.productPropertyEnum.list',
-            {
-                select: ['id', 'propertyId', 'value', 'def', 'sort', 'xmlId'],
-                filter: { propertyId: 431 },
-                order: { id: 'ASC' }
+      // catalog.productPropertyEnum.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProductPropertyEnumListResult>({
+        method: 'catalog.productPropertyEnum.list',
+        params: {
+          select: ['id', 'propertyId', 'value', 'def', 'sort', 'xmlId'],
+          filter: { propertyId: 431 },
+          order: { id: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Property enum values:', result.productPropertyEnums, 'count:', result.productPropertyEnums.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchProductPropertyEnumList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.productPropertyEnum.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyEnum.list',
+            params: {
+              select: ['id', 'propertyId', 'value', 'def', 'sort', 'xmlId'],
+              filter: { propertyId: 431 },
+              order: { id: 'ASC' },
+              start: 0,
             },
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-        console.error('Request failed', error)
-    }
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
 
-    try {
-        const generator = $b24.fetchListMethod('catalog.productPropertyEnum.list', {
-            select: ['id', 'propertyId', 'value', 'def', 'sort', 'xmlId'],
-            filter: { propertyId: 431 },
-            order: { id: 'ASC' }
-        }, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity) }
+          const result = response.getData().result
+          console.info('Property enum values:', result.productPropertyEnums, 'count:', result.productPropertyEnums.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error)
-    }
+      }
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-        const response = await $b24.callMethod('catalog.productPropertyEnum.list', {
-            select: ['id', 'propertyId', 'value', 'def', 'sort', 'xmlId'],
-            filter: { propertyId: 431 },
-            order: { id: 'ASC' }
-        }, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-        console.error('Request failed', error)
-    }
+      document.addEventListener('DOMContentLoaded', fetchProductPropertyEnumList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-enum/catalog-product-property-enum-update.md
+++ b/api-reference/catalog/product-property-enum/catalog-product-property-enum-update.md
@@ -79,25 +79,99 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyEnum.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyEnumUpdateResult = {
+      productPropertyEnum: {
+        def: string,
+        id: number,
+        propertyId: number,
+        sort: number,
+        value: string,
+        xmlId: string,
+      },
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyEnum.update', {
-            id: 1739,
-            fields: {
+      const response = await $b24.actions.v2.call.make<ProductPropertyEnumUpdateResult>({
+        method: 'catalog.productPropertyEnum.update',
+        params: {
+          id: 1739,
+          fields: {
+            propertyId: 431,
+            value: 'Medium',
+            xmlId: 'M',
+            def: 'N',
+            sort: 110,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyEnum)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateProductPropertyEnum() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyEnum.update',
+            params: {
+              id: 1739,
+              fields: {
                 propertyId: 431,
-                value: 'Средний',
+                value: 'Medium',
                 xmlId: 'M',
                 def: 'N',
                 sort: 110,
-            }
-        });
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    } catch (error) {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyEnum)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateProductPropertyEnum)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-feature/catalog-product-property-feature-add.md
+++ b/api-reference/catalog/product-property-feature/catalog-product-property-feature-add.md
@@ -83,24 +83,94 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyFeature.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddProductPropertyFeatureResult = {
+      productPropertyFeature: {
+        featureId: string
+        id: number
+        isEnabled: string
+        moduleId: string
+        propertyId: number
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyFeature.add', {
-            fields: {
+      const response = await $b24.actions.v2.call.make<AddProductPropertyFeatureResult>({
+        method: 'catalog.productPropertyFeature.add',
+        params: {
+          fields: {
+            propertyId: 901,
+            moduleId: 'iblock',
+            featureId: 'LIST_PAGE_SHOW',
+            isEnabled: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyFeature)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProductPropertyFeature() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyFeature.add',
+            params: {
+              fields: {
                 propertyId: 901,
                 moduleId: 'iblock',
                 featureId: 'LIST_PAGE_SHOW',
                 isEnabled: 'Y',
-            }
-        });
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    }
-    catch (error) {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyFeature)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProductPropertyFeature)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-feature/catalog-product-property-feature-get-available-features-by-property.md
+++ b/api-reference/catalog/product-property-feature/catalog-product-property-feature-get-available-features-by-property.md
@@ -54,22 +54,82 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyFeature.getAvailableFeaturesByProperty
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetAvailableFeaturesByPropertyResult = {
+      features: Array<{
+        featureId: string,
+        featureName: string,
+        moduleId: string,
+      }>,
+    }
+
     try {
-        const response = await $b24.callMethod(
-            'catalog.productPropertyFeature.getAvailableFeaturesByProperty',
-            {
-                propertyId: 901
-            }
-        );
+      const response = await $b24.actions.v2.call.make<GetAvailableFeaturesByPropertyResult>({
+        method: 'catalog.productPropertyFeature.getAvailableFeaturesByProperty',
+        params: {
+          propertyId: 901,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        console.log(response.getData().result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.features)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error) {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAvailableFeaturesByProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyFeature.getAvailableFeaturesByProperty',
+            params: {
+              propertyId: 901,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.features)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAvailableFeaturesByProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-feature/catalog-product-property-feature-get-fields.md
+++ b/api-reference/catalog/product-property-feature/catalog-product-property-feature-get-fields.md
@@ -45,16 +45,81 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyFeature.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldDescriptionItem = {
+      isImmutable: boolean,
+      isReadOnly: boolean,
+      isRequired: boolean,
+      type: string,
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyFeatureFieldsResult = {
+      productPropertyFeature: Record<string, FieldDescriptionItem>,
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyFeature.getFields', {});
-        console.log(response.getData().result);
+      const response = await $b24.actions.v2.call.make<ProductPropertyFeatureFieldsResult>({
+        method: 'catalog.productPropertyFeature.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.productPropertyFeature))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error) {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductPropertyFeatureFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyFeature.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.productPropertyFeature))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductPropertyFeatureFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-feature/catalog-product-property-feature-get.md
+++ b/api-reference/catalog/product-property-feature/catalog-product-property-feature-get.md
@@ -54,19 +54,84 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyFeature.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyFeatureGetResult = {
+      productPropertyFeature: {
+        featureId: string
+        id: number
+        isEnabled: string
+        moduleId: string
+        propertyId: number
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyFeature.get', {
-            id: 101
-        });
+      const response = await $b24.actions.v2.call.make<ProductPropertyFeatureGetResult>({
+        method: 'catalog.productPropertyFeature.get',
+        params: {
+          id: 101,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        console.log(response.getData().result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyFeature)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error) {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductPropertyFeature() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyFeature.get',
+            params: {
+              id: 101,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyFeature)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductPropertyFeature)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-feature/catalog-product-property-feature-list.md
+++ b/api-reference/catalog/product-property-feature/catalog-product-property-feature-list.md
@@ -95,55 +95,100 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyFeature.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyFeatureListResult = {
+      productPropertyFeatures: {
+        id: number
+        propertyId: number
+        moduleId: string
+        featureId: string
+        isEnabled: string
+      }[]
+    }
+
+    // catalog.productPropertyFeature.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-    const response = await $b24.callListMethod(
-        'catalog.productPropertyFeature.list',
-        {
-        select: ['id', 'propertyId', 'moduleId', 'featureId', 'isEnabled'],
-        filter: { propertyId: 901 },
-        order: { id: 'ASC' }
+      const response = await $b24.actions.v2.call.make<ProductPropertyFeatureListResult>({
+        method: 'catalog.productPropertyFeature.list',
+        params: {
+          select: ['id', 'propertyId', 'moduleId', 'featureId', 'isEnabled'],
+          filter: { propertyId: 901 },
+          order: { id: 'ASC' },
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-
-    try {
-    const generator = $b24.fetchListMethod('catalog.productPropertyFeature.list', {
-        select: ['id', 'propertyId', 'moduleId', 'featureId', 'isEnabled'],
-        filter: { propertyId: 901 },
-        order: { id: 'ASC' }
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyFeatures.length, result.productPropertyFeatures)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
+- JS (UMD)
 
-    try {
-    const response = await $b24.callMethod('catalog.productPropertyFeature.list', {
-        select: ['id', 'propertyId', 'moduleId', 'featureId', 'isEnabled'],
-        filter: { propertyId: 901 },
-        order: { id: 'ASC' }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listProductPropertyFeatures() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.productPropertyFeature.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyFeature.list',
+            params: {
+              select: ['id', 'propertyId', 'moduleId', 'featureId', 'isEnabled'],
+              filter: { propertyId: 901 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyFeatures.length, result.productPropertyFeatures)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listProductPropertyFeatures)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-feature/catalog-product-property-feature-update.md
+++ b/api-reference/catalog/product-property-feature/catalog-product-property-feature-update.md
@@ -81,25 +81,96 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertyFeature.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateProductPropertyFeatureResult = {
+      productPropertyFeature: {
+        featureId: string
+        id: number
+        isEnabled: string
+        moduleId: string
+        propertyId: number
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertyFeature.update', {
-            id: 101,
-            fields: {
+      const response = await $b24.actions.v2.call.make<UpdateProductPropertyFeatureResult>({
+        method: 'catalog.productPropertyFeature.update',
+        params: {
+          id: 101,
+          fields: {
+            propertyId: 901,
+            moduleId: 'iblock',
+            featureId: 'LIST_PAGE_SHOW',
+            isEnabled: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertyFeature)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateProductPropertyFeature() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertyFeature.update',
+            params: {
+              id: 101,
+              fields: {
                 propertyId: 901,
                 moduleId: 'iblock',
                 featureId: 'LIST_PAGE_SHOW',
                 isEnabled: 'N',
-            }
-        });
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    }
-    catch (error) {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertyFeature)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateProductPropertyFeature)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-section/catalog-product-property-section-get.md
+++ b/api-reference/catalog/product-property-section/catalog-product-property-section-get.md
@@ -54,19 +54,84 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertySection.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertySectionResult = {
+      productPropertySection: {
+        displayExpanded: string
+        displayType: string
+        filterHint: string
+        propertyId: number
+        smartFilter: string
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertySection.get', {
-            propertyId: 901
-        });
+      const response = await $b24.actions.v2.call.make<ProductPropertySectionResult>({
+        method: 'catalog.productPropertySection.get',
+        params: {
+          propertyId: 901,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        console.log(response.getData().result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertySection)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error) {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductPropertySection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertySection.get',
+            params: {
+              propertyId: 901,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertySection)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductPropertySection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-section/catalog-product-property-section-list.md
+++ b/api-reference/catalog/product-property-section/catalog-product-property-section-list.md
@@ -103,55 +103,100 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertySection.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertySectionListResult = {
+      productPropertySections: {
+        displayExpanded: string
+        displayType: string
+        filterHint: string
+        propertyId: number
+        smartFilter: string
+      }[]
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'catalog.productPropertySection.list',
-        {
-        select: ['propertyId', 'smartFilter', 'displayType', 'displayExpanded', 'filterHint'],
-        filter: { propertyId: 901 },
-        order: { propertyId: 'ASC' }
+      // catalog.productPropertySection.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProductPropertySectionListResult>({
+        method: 'catalog.productPropertySection.list',
+        params: {
+          select: ['propertyId', 'smartFilter', 'displayType', 'displayExpanded', 'filterHint'],
+          filter: { propertyId: 901 },
+          order: { propertyId: 'ASC' },
+          start: 0,
         },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-
-    try {
-    const generator = $b24.fetchListMethod('catalog.productPropertySection.list', {
-        select: ['propertyId', 'smartFilter', 'displayType', 'displayExpanded', 'filterHint'],
-        filter: { propertyId: 901 },
-        order: { propertyId: 'ASC' }
-    }, 'PROPERTY_ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertySections.length, result.productPropertySections)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
+- JS (UMD)
 
-    try {
-    const response = await $b24.callMethod('catalog.productPropertySection.list', {
-        select: ['propertyId', 'smartFilter', 'displayType', 'displayExpanded', 'filterHint'],
-        filter: { propertyId: 901 },
-        order: { propertyId: 'ASC' }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listProductPropertySections() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.productPropertySection.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertySection.list',
+            params: {
+              select: ['propertyId', 'smartFilter', 'displayType', 'displayExpanded', 'filterHint'],
+              filter: { propertyId: 901 },
+              order: { propertyId: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertySections.length, result.productPropertySections)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listProductPropertySections)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property-section/catalog-product-property-section-set.md
+++ b/api-reference/catalog/product-property-section/catalog-product-property-section-set.md
@@ -80,25 +80,98 @@
       https://**put_your_bitrix24_address**/rest/catalog.productPropertySection.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertySectionSetResult = {
+      productPropertySection: {
+        displayExpanded: string
+        displayType: string
+        filterHint: string
+        iblockId: string
+        propertyId: string
+        sectionId: string
+        smartFilter: string
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productPropertySection.set', {
-            propertyId: 901,
-            fields: {
+      const response = await $b24.actions.v2.call.make<ProductPropertySectionSetResult>({
+        method: 'catalog.productPropertySection.set',
+        params: {
+          propertyId: 901,
+          fields: {
+            smartFilter: 'Y',
+            displayType: 'F',
+            displayExpanded: 'N',
+            filterHint: 'Filter hint',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productPropertySection)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setProductPropertySection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productPropertySection.set',
+            params: {
+              propertyId: 901,
+              fields: {
                 smartFilter: 'Y',
                 displayType: 'F',
                 displayExpanded: 'N',
-                filterHint: 'Подсказка для фильтра'
-            }
-        });
+                filterHint: 'Filter hint',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    }
-    catch (error) {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productPropertySection)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setProductPropertySection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property/catalog-product-property-add.md
+++ b/api-reference/catalog/product-property/catalog-product-property-add.md
@@ -147,14 +147,98 @@
       https://**put_your_bitrix24_address**/rest/catalog.productProperty.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyResult = {
+      productProperty: {
+        active: string,
+        code: string | null,
+        colCount: number,
+        defaultValue: string | null,
+        fileType: string | null,
+        filtrable: string,
+        hint: string | null,
+        iblockId: number,
+        id: number,
+        isRequired: string,
+        linkIblockId: number | null,
+        listType: string,
+        multiple: string,
+        multipleCnt: number | null,
+        name: string,
+        propertyType: string,
+        rowCount: number,
+        searchable: string,
+        sort: number,
+        timestampX: ISODate,
+        userType: string | null,
+        userTypeSettings: Record<string, unknown> | null,
+        withDescription: string | null,
+        xmlId: string | null,
+      },
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productProperty.add', {
-            fields: {
+      const response = await $b24.actions.v2.call.make<ProductPropertyResult>({
+        method: 'catalog.productProperty.add',
+        params: {
+          fields: {
+            iblockId: 19,
+            name: 'Category',
+            code: 'CATEGORY',
+            propertyType: 'S',
+            userType: 'directory',
+            multiple: 'N',
+            isRequired: 'N',
+            active: 'Y',
+            sort: 100,
+            userTypeSettings: {
+              tableName: 'b_hlbd_categories', // existing catalog in Bitrix24
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productProperty.id, result.productProperty.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProductProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productProperty.add',
+            params: {
+              fields: {
                 iblockId: 19,
-                name: 'Рубрика',
+                name: 'Category',
                 code: 'CATEGORY',
                 propertyType: 'S',
                 userType: 'directory',
@@ -163,16 +247,29 @@
                 active: 'Y',
                 sort: 100,
                 userTypeSettings: {
-                    tableName: 'b_hlbd_categories', // существующий справочник в Битрикс24
-                }
-            }
-        });
+                  tableName: 'b_hlbd_categories', // existing catalog in Bitrix24
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    }
-    catch (error) {
-    	console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productProperty.id, result.productProperty.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProductProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property/catalog-product-property-delete.md
+++ b/api-reference/catalog/product-property/catalog-product-property-delete.md
@@ -54,16 +54,73 @@
       https://**put_your_bitrix24_address**/rest/catalog.productProperty.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod('catalog.productProperty.delete', { id: 659 });
-        console.log(response.getData().result);
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.productProperty.delete',
+        params: {
+          id: 659,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Property deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error) {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProductProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productProperty.delete',
+            params: {
+              id: 659,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Property deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProductProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property/catalog-product-property-get-fields.md
+++ b/api-reference/catalog/product-property/catalog-product-property-get-fields.md
@@ -45,15 +45,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.productProperty.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod('catalog.productProperty.getFields', {});
-        console.log(response.getData().result);
-    } catch (error) {
-        console.error('Error:', error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = {
+      productProperty: Record<string, FieldDescription>
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'catalog.productProperty.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product property fields:', Object.keys(result.productProperty))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductPropertyFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productProperty.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product property fields:', Object.keys(result.productProperty))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductPropertyFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property/catalog-product-property-get.md
+++ b/api-reference/catalog/product-property/catalog-product-property-get.md
@@ -54,16 +54,109 @@
       https://**put_your_bitrix24_address**/rest/catalog.productProperty.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetProductPropertyResult = {
+      productProperty: {
+        active: string
+        code: string
+        colCount: number
+        defaultValue: string | null
+        fileType: string | null
+        filtrable: string
+        hint: string | null
+        iblockId: number
+        id: number
+        isRequired: string
+        linkIblockId: number | null
+        listType: string
+        multiple: string
+        multipleCnt: number | null
+        name: string
+        propertyType: string
+        rowCount: number
+        searchable: string
+        sort: number | null
+        timestampX: ISODate | null
+        userType: string
+        userTypeSettings: {
+          group: string
+          multiple: string
+          size: number
+          tableName: string
+          width: number
+        }
+        withDescription: string | null
+        xmlId: string | null
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productProperty.get', { id: 659 });
-        console.log(response.getData().result);
+      const response = await $b24.actions.v2.call.make<GetProductPropertyResult>({
+        method: 'catalog.productProperty.get',
+        params: {
+          id: 659,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productProperty.id, result.productProperty.name, result.productProperty.propertyType)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error) {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productProperty.get',
+            params: {
+              id: 659,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productProperty.id, result.productProperty.name, result.productProperty.propertyType)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property/catalog-product-property-list.md
+++ b/api-reference/catalog/product-property/catalog-product-property-list.md
@@ -95,20 +95,99 @@
       https://**put_your_bitrix24_address**/rest/catalog.productProperty.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod('catalog.productProperty.list', {
-            select: ['id', 'name', 'iblockId', 'propertyType'],
-            filter: { iblockId: 19 },
-            order: { id: 'ASC' }
-        });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
-    } catch (error) {
-        console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyListResult = {
+      productProperties: {
+        iblockId: number
+        id: number
+        name: string
+        propertyType: string
+      }[]
     }
+
+    try {
+      // catalog.productProperty.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProductPropertyListResult>({
+        method: 'catalog.productProperty.list',
+        params: {
+          select: ['id', 'name', 'iblockId', 'propertyType'],
+          filter: { iblockId: 19 },
+          order: { id: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productProperties.length, result.productProperties)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchProductPropertyList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.productProperty.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productProperty.list',
+            params: {
+              select: ['id', 'name', 'iblockId', 'propertyType'],
+              filter: { iblockId: 19 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productProperties.length, result.productProperties)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchProductPropertyList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product-property/catalog-product-property-update.md
+++ b/api-reference/catalog/product-property/catalog-product-property-update.md
@@ -129,26 +129,117 @@
       https://**put_your_bitrix24_address**/rest/catalog.productProperty.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductPropertyUpdateResult = {
+      productProperty: {
+        active: 'Y' | 'N'
+        code: string | null
+        colCount: number
+        defaultValue: string | null
+        fileType: string | null
+        filtrable: 'Y' | 'N'
+        hint: string | null
+        iblockId: number
+        id: number
+        isRequired: 'Y' | 'N'
+        linkIblockId: number | null
+        listType: string | null
+        multiple: 'Y' | 'N'
+        multipleCnt: number | null
+        name: string
+        propertyType: string
+        rowCount: number
+        searchable: 'Y' | 'N'
+        sort: number
+        timestampX: ISODate
+        userType: string | null
+        userTypeSettings: Record<string, unknown> | null
+        withDescription: 'Y' | 'N' | null
+        xmlId: string | null
+      }
+    }
+
     try {
-        const response = await $b24.callMethod('catalog.productProperty.update', {
-            id: 115,
-            fields: {
+      const response = await $b24.actions.v2.call.make<ProductPropertyUpdateResult>({
+        method: 'catalog.productProperty.update',
+        params: {
+          id: 115,
+          fields: {
+            iblockId: 19,
+            name: 'Size',
+            propertyType: 'L',
+            isRequired: 'Y',
+            active: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productProperty.id, result.productProperty.name, result.productProperty.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateProductProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.productProperty.update',
+            params: {
+              id: 115,
+              fields: {
                 iblockId: 19,
-                name: 'Размер',
+                name: 'Size',
                 propertyType: 'L',
                 isRequired: 'Y',
-                active: 'Y'
-            }
-        });
+                active: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.log(response.getData().result);
-    }
-    catch (error) {
-    	console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productProperty.id, result.productProperty.name, result.productProperty.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateProductProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-add.md
+++ b/api-reference/catalog/product/catalog-product-add.md
@@ -295,79 +295,224 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.add', 
-    		{
-    			'fields': {
-    				iblockId: 23,
-    				name: 'Товар',
-    				active: 'Y',
-    				barcodeMulti: 'Y',
-    				canBuyZero: 'Y',
-    				code: 'Tovar',
-    				createdBy: 1,
-    				dateActiveFrom: '2024-05-28T10:00:00',
-    				dateActiveTo: '2024-05-29T10:00:00',
-    				dateCreate: '2024-05-27T10:00:00',
-    				detailPicture: {
-    					'fileData': [
-    						'detailPicture.png',
-    						'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'
-    					]
-    				},
-    				detailText: '',
-    				detailTextType: 'text',
-    				height: 100,
-    				iblockSectionId: 47,
-    				length: 100,
-    				measure: 5,
-    				modifiedBy: 1,
-    				previewPicture: {
-    					'fileData': [
-    						'previewPicture.png',
-    						'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'
-    					]
-    				},
-    				previewText: '',
-    				previewTextType: 'text',
-    				purchasingCurrency: 'RUB',
-    				purchasingPrice: 1000,
-    				quantity: 10,
-    				quantityReserved: 1,
-    				quantityTrace: 'Y',
-    				recurSchemeLength: 1,
-    				recurSchemeType: 'D',
-    				sort: 100,
-    				subscribe: 'Y',
-    				trialPriceId: 175,
-    				vatId: 1,
-    				vatIncluded: 'Y',
-    				weight: 100,
-    				width: 100,
-    				withoutOrder: 'Y',
-    				xmlId: '',
-    				property258: 'test',
-    				property259: [
-    					'test1',
-    					'test2'
-    				],
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductAddResult = {
+      element: {
+        id: number,
+        iblockId: number,
+        iblockSectionId: number,
+        name: string,
+        active: string,
+        available: string,
+        bundle: string,
+        canBuyZero: string,
+        code: string,
+        createdBy: number,
+        modifiedBy: number,
+        dateActiveFrom: ISODate | null,
+        dateActiveTo: ISODate | null,
+        dateCreate: ISODate | null,
+        timestampX: ISODate | null,
+        detailPicture: { id: string, url: string, urlMachine: string } | null,
+        detailText: string | null,
+        detailTextType: string,
+        height: number,
+        length: number,
+        measure: number,
+        previewPicture: { id: string, url: string, urlMachine: string } | null,
+        previewText: string | null,
+        previewTextType: string,
+        purchasingCurrency: string,
+        purchasingPrice: string,
+        quantity: number,
+        quantityReserved: number,
+        quantityTrace: string,
+        sort: number,
+        subscribe: string,
+        type: number,
+        vatId: number,
+        vatIncluded: string,
+        weight: number,
+        width: number,
+        xmlId: string,
+        property258: { value: string, valueId: string } | null,
+        property259: Array<{ value: string, valueId: string }>,
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductAddResult>({
+        method: 'catalog.product.add',
+        params: {
+          fields: {
+            iblockId: 23,
+            name: 'Product',
+            active: 'Y',
+            barcodeMulti: 'Y',
+            canBuyZero: 'Y',
+            code: 'Tovar',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: [
+                'detailPicture.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+              ],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            height: 100,
+            iblockSectionId: 47,
+            length: 100,
+            measure: 5,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: [
+                'previewPicture.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+              ],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            purchasingCurrency: 'RUB',
+            purchasingPrice: 1000,
+            quantity: 10,
+            quantityReserved: 1,
+            quantityTrace: 'Y',
+            recurSchemeLength: 1,
+            recurSchemeType: 'D',
+            sort: 100,
+            subscribe: 'Y',
+            trialPriceId: 175,
+            vatId: 1,
+            vatIncluded: 'Y',
+            weight: 100,
+            width: 100,
+            withoutOrder: 'Y',
+            xmlId: '',
+            property258: 'test',
+            property259: [
+              'test1',
+              'test2',
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added product id:', result.element.id, 'name:', result.element.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.add',
+            params: {
+              fields: {
+                iblockId: 23,
+                name: 'Product',
+                active: 'Y',
+                barcodeMulti: 'Y',
+                canBuyZero: 'Y',
+                code: 'Tovar',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: [
+                    'detailPicture.png',
+                    'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+                  ],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                height: 100,
+                iblockSectionId: 47,
+                length: 100,
+                measure: 5,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: [
+                    'previewPicture.png',
+                    'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+                  ],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                purchasingCurrency: 'RUB',
+                purchasingPrice: 1000,
+                quantity: 10,
+                quantityReserved: 1,
+                quantityTrace: 'Y',
+                recurSchemeLength: 1,
+                recurSchemeType: 'D',
+                sort: 100,
+                subscribe: 'Y',
+                trialPriceId: 175,
+                vatId: 1,
+                vatIncluded: 'Y',
+                weight: 100,
+                width: 100,
+                withoutOrder: 'Y',
+                xmlId: '',
+                property258: 'test',
+                property259: [
+                  'test1',
+                  'test2',
+                ],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added product id:', result.element.id, 'name:', result.element.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-delete.md
+++ b/api-reference/catalog/product/catalog-product-delete.md
@@ -55,26 +55,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.delete',
-    		{
-    			id: 1242,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.delete',
+        params: {
+          id: 1242,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.delete',
+            params: {
+              id: 1242,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-download.md
+++ b/api-reference/catalog/product/catalog-product-download.md
@@ -82,30 +82,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.download
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.download',
-    		{
-    			fields: {
-    				fileId: 6439,
-    				productId: 1243,
-    				fieldName: 'detailPicture',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.download',
+        params: {
+          fields: {
+            fileId: 6439,
+            productId: 1243,
+            fieldName: 'detailPicture',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Download result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function downloadProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.download',
+            params: {
+              fields: {
+                fileId: 6439,
+                productId: 1243,
+                fieldName: 'detailPicture',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Download result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', downloadProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-get-fields-by-filter.md
+++ b/api-reference/catalog/product/catalog-product-get-fields-by-filter.md
@@ -66,28 +66,94 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.getFieldsByFilter
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.getFieldsByFilter', 
-    		{
-    			filter: {
-    				iblockId: 23,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      name: string
+      type: string
+      isDynamic?: boolean
+      isMultiple?: boolean
+      propertyType?: string
+      userType?: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductFieldsByFilterResult = {
+      product: Record<string, FieldItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductFieldsByFilterResult>({
+        method: 'catalog.product.getFieldsByFilter',
+        params: {
+          filter: {
+            iblockId: 23,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.product)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductFieldsByFilter() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.getFieldsByFilter',
+            params: {
+              filter: {
+                iblockId: 23,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.product)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductFieldsByFilter)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-get.md
+++ b/api-reference/catalog/product/catalog-product-get.md
@@ -61,26 +61,116 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.get',
-    		{
-    			'id': 1243
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductGetResult = {
+      product: {
+        id: number
+        name: string
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        sort: number
+        iblockId: number
+        iblockSectionId: number
+        type: number
+        vatId: number
+        vatIncluded: string
+        weight: number
+        width: number
+        height: number
+        length: number
+        measure: number
+        quantity: number
+        quantityReserved: number
+        quantityTrace: string
+        purchasingPrice: string
+        purchasingCurrency: string
+        subscribe: string
+        xmlId: string
+        createdBy: number
+        modifiedBy: number
+        dateCreate: ISODate | null
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        timestampX: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        previewText: string | null
+        previewTextType: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductGetResult>({
+        method: 'catalog.product.get',
+        params: {
+          id: 1243,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.product.id, result.product.name, result.product.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.get',
+            params: {
+              id: 1243,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.product.id, result.product.name, result.product.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-list.md
+++ b/api-reference/catalog/product/catalog-product-list.md
@@ -130,209 +130,254 @@ filter: {
     https://**put_your_bitrix24_address**/rest/catalog.product.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.product.list',
-        {
-          "select": [
-            "id",
-            "iblockId",
-            "name",
-            "active",
-            "available",
-            "barcodeMulti",
-            "bundle",
-            "canBuyZero",
-            "code",
-            "createdBy",
-            "dateActiveFrom",
-            "dateActiveTo",
-            "dateCreate",
-            "detailPicture",
-            "detailText",
-            "detailTextType",
-            "height",
-            "iblockSectionId",
-            "length",
-            "measure",
-            "modifiedBy",
-            "previewPicture",
-            "previewText",
-            "previewTextType",
-            "purchasingCurrency",
-            "purchasingPrice",
-            "quantity",
-            "quantityReserved",
-            "quantityTrace",
-            "recurSchemeLength",
-            "recurSchemeType",
-            "sort",
-            "subscribe",
-            "timestampX",
-            "trialPriceId",
-            "type",
-            "vatId",
-            "vatIncluded",
-            "weight",
-            "width",
-            "withoutOrder",
-            "xmlId",
-            "property258",
-            "property259",
-          ],
-          "filter": {
-            "iblockId": 23,
-            ">id": 10,
-            "vatId": [1, 2],
-          },
-          "order": {
-            "id": "desc",
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    type CatalogProductFile = {
+      id: string,
+      url: string,
+      urlMachine: string,
     }
-    
-    // fetchListMethod предпочтительн при работе с крупными наборами данных. Метод реализует итеративную выборку с использованием генератора, что позволяет обрабатывать данные по частям и эффективно использовать память.
-    
+
+    type CatalogProductProperty = {
+      value: string,
+      valueId: string,
+    }
+
+    type CatalogProduct = {
+      id: number,
+      iblockId: number,
+      name: string,
+      active: string,
+      available: string,
+      barcodeMulti: string,
+      bundle: string,
+      canBuyZero: string,
+      code: string,
+      createdBy: number,
+      dateActiveFrom: ISODate | null,
+      dateActiveTo: ISODate | null,
+      dateCreate: ISODate | null,
+      detailPicture: CatalogProductFile | null,
+      detailText: string | null,
+      detailTextType: string,
+      height: number,
+      iblockSectionId: number | null,
+      length: number,
+      measure: number | null,
+      modifiedBy: number,
+      previewPicture: CatalogProductFile | null,
+      previewText: string | null,
+      previewTextType: string,
+      property258: CatalogProductProperty | null,
+      property259: CatalogProductProperty[] | null,
+      purchasingCurrency: string | null,
+      purchasingPrice: number | null,
+      quantity: number,
+      quantityReserved: number,
+      quantityTrace: string,
+      recurSchemeLength: number | null,
+      recurSchemeType: string | null,
+      sort: number,
+      subscribe: string | null,
+      timestampX: ISODate | null,
+      trialPriceId: number | null,
+      type: number,
+      vatId: number | null,
+      vatIncluded: string | null,
+      weight: number,
+      width: number,
+      withoutOrder: string | null,
+      xmlId: string | null,
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogProductListResult = {
+      products: CatalogProduct[],
+    }
+
     try {
-      const generator = $b24.fetchListMethod('catalog.product.list', {
-        "select": [
-          "id",
-          "iblockId",
-          "name",
-          "active",
-          "available",
-          "barcodeMulti",
-          "bundle",
-          "canBuyZero",
-          "code",
-          "createdBy",
-          "dateActiveFrom",
-          "dateActiveTo",
-          "dateCreate",
-          "detailPicture",
-          "detailText",
-          "detailTextType",
-          "height",
-          "iblockSectionId",
-          "length",
-          "measure",
-          "modifiedBy",
-          "previewPicture",
-          "previewText",
-          "previewTextType",
-          "purchasingCurrency",
-          "purchasingPrice",
-          "quantity",
-          "quantityReserved",
-          "quantityTrace",
-          "recurSchemeLength",
-          "recurSchemeType",
-          "sort",
-          "subscribe",
-          "timestampX",
-          "trialPriceId",
-          "type",
-          "vatId",
-          "vatIncluded",
-          "weight",
-          "width",
-          "withoutOrder",
-          "xmlId",
-          "property258",
-          "property259",
-        ],
-        "filter": {
-          "iblockId": 23,
-          ">id": 10,
-          "vatId": [1, 2],
+      // catalog.product.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CatalogProductListResult>({
+        method: 'catalog.product.list',
+        params: {
+          select: [
+            'id',
+            'iblockId',
+            'name',
+            'active',
+            'available',
+            'barcodeMulti',
+            'bundle',
+            'canBuyZero',
+            'code',
+            'createdBy',
+            'dateActiveFrom',
+            'dateActiveTo',
+            'dateCreate',
+            'detailPicture',
+            'detailText',
+            'detailTextType',
+            'height',
+            'iblockSectionId',
+            'length',
+            'measure',
+            'modifiedBy',
+            'previewPicture',
+            'previewText',
+            'previewTextType',
+            'purchasingCurrency',
+            'purchasingPrice',
+            'quantity',
+            'quantityReserved',
+            'quantityTrace',
+            'recurSchemeLength',
+            'recurSchemeType',
+            'sort',
+            'subscribe',
+            'timestampX',
+            'trialPriceId',
+            'type',
+            'vatId',
+            'vatIncluded',
+            'weight',
+            'width',
+            'withoutOrder',
+            'xmlId',
+            'property258',
+            'property259',
+          ],
+          filter: {
+            iblockId: 23,
+            '>id': 10,
+            vatId: [1, 2],
+          },
+          order: {
+            id: 'desc',
+          },
+          start: 0,
         },
-        "order": {
-          "id": "desc",
-        }
-      }, 'id');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Products fetched:', result.products.length, result.products)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.product.list', {
-        "select": [
-          "id",
-          "iblockId",
-          "name",
-          "active",
-          "available",
-          "barcodeMulti",
-          "bundle",
-          "canBuyZero",
-          "code",
-          "createdBy",
-          "dateActiveFrom",
-          "dateActiveTo",
-          "dateCreate",
-          "detailPicture",
-          "detailText",
-          "detailTextType",
-          "height",
-          "iblockSectionId",
-          "length",
-          "measure",
-          "modifiedBy",
-          "previewPicture",
-          "previewText",
-          "previewTextType",
-          "purchasingCurrency",
-          "purchasingPrice",
-          "quantity",
-          "quantityReserved",
-          "quantityTrace",
-          "recurSchemeLength",
-          "recurSchemeType",
-          "sort",
-          "subscribe",
-          "timestampX",
-          "trialPriceId",
-          "type",
-          "vatId",
-          "vatIncluded",
-          "weight",
-          "width",
-          "withoutOrder",
-          "xmlId",
-          "property258",
-          "property259",
-        ],
-        "filter": {
-          "iblockId": 23,
-          ">id": 10,
-          "vatId": [1, 2],
-        },
-        "order": {
-          "id": "desc",
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchProductList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.product.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.list',
+            params: {
+              select: [
+                'id',
+                'iblockId',
+                'name',
+                'active',
+                'available',
+                'barcodeMulti',
+                'bundle',
+                'canBuyZero',
+                'code',
+                'createdBy',
+                'dateActiveFrom',
+                'dateActiveTo',
+                'dateCreate',
+                'detailPicture',
+                'detailText',
+                'detailTextType',
+                'height',
+                'iblockSectionId',
+                'length',
+                'measure',
+                'modifiedBy',
+                'previewPicture',
+                'previewText',
+                'previewTextType',
+                'purchasingCurrency',
+                'purchasingPrice',
+                'quantity',
+                'quantityReserved',
+                'quantityTrace',
+                'recurSchemeLength',
+                'recurSchemeType',
+                'sort',
+                'subscribe',
+                'timestampX',
+                'trialPriceId',
+                'type',
+                'vatId',
+                'vatIncluded',
+                'weight',
+                'width',
+                'withoutOrder',
+                'xmlId',
+                'property258',
+                'property259',
+              ],
+              filter: {
+                iblockId: 23,
+                '>id': 10,
+                vatId: [1, 2],
+              },
+              order: {
+                id: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Products fetched:', result.products.length, result.products)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchProductList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/catalog-product-update.md
+++ b/api-reference/catalog/product/catalog-product-update.md
@@ -306,88 +306,240 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.update', 
-    		{
-    			'id': 1267,
-    			'fields': {
-    				name: 'Товар',
-    				active: 'Y',
-    				barcodeMulti: 'Y',
-    				canBuyZero: 'Y',
-    				code: 'Tovar',
-    				createdBy: 1,
-    				dateActiveFrom: '2024-05-28T10:00:00',
-    				dateActiveTo: '2024-05-29T10:00:00',
-    				dateCreate: '2024-05-27T10:00:00',
-    				detailPicture: {
-    					'fileData': [
-    						'detailPicture.png',
-    						'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'
-    					]
-    				},
-    				detailText: '',
-    				detailTextType: 'text',
-    				height: 100,
-    				iblockSectionId: 47,
-    				length: 100,
-    				measure: 5,
-    				modifiedBy: 1,
-    				previewPicture: {
-    					'fileData': [
-    						'previewPicture.png',
-    						'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'
-    					]
-    				},
-    				previewText: '',
-    				previewTextType: 'text',
-    				purchasingCurrency: 'RUB',
-    				purchasingPrice: 1000,
-    				quantity: 10,
-    				quantityReserved: 1,
-    				quantityTrace: 'Y',
-    				recurSchemeLength: 1,
-    				recurSchemeType: 'D',
-    				sort: 100,
-    				subscribe: 'Y',
-    				trialPriceId: 175,
-    				vatId: 1,
-    				vatIncluded: 'Y',
-    				weight: 100,
-    				width: 100,
-    				withoutOrder: 'Y',
-    				xmlId: '1243',
-    				property258: {
-    					value: 'test',
-    					valueId: 9816
-    				},
-    				property259: [
-    					{
-    						value: 'test1',
-    						valueId: 9817
-    					},
-    					{
-    						value: 'test2',
-    						valueId: 9818
-    					}
-    				],
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductUpdateResult = {
+      element: {
+        id: number
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        height: number
+        iblockId: number
+        iblockSectionId: number
+        length: number
+        measure: number
+        modifiedBy: number
+        name: string
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        quantityReserved: number
+        quantityTrace: string
+        sort: number
+        subscribe: string
+        timestampX: ISODate | null
+        type: number
+        vatId: number
+        vatIncluded: string
+        weight: number
+        width: number
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductUpdateResult>({
+        method: 'catalog.product.update',
+        params: {
+          id: 1267,
+          fields: {
+            name: 'Product',
+            active: 'Y',
+            barcodeMulti: 'Y',
+            canBuyZero: 'Y',
+            code: 'Tovar',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: [
+                'detailPicture.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+              ],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            height: 100,
+            iblockSectionId: 47,
+            length: 100,
+            measure: 5,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: [
+                'previewPicture.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+              ],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            purchasingCurrency: 'RUB',
+            purchasingPrice: 1000,
+            quantity: 10,
+            quantityReserved: 1,
+            quantityTrace: 'Y',
+            recurSchemeLength: 1,
+            recurSchemeType: 'D',
+            sort: 100,
+            subscribe: 'Y',
+            trialPriceId: 175,
+            vatId: 1,
+            vatIncluded: 'Y',
+            weight: 100,
+            width: 100,
+            withoutOrder: 'Y',
+            xmlId: '1243',
+            property258: {
+              value: 'test',
+              valueId: 9816,
+            },
+            property259: [
+              {
+                value: 'test1',
+                valueId: 9817,
+              },
+              {
+                value: 'test2',
+                valueId: 9818,
+              },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated product id:', result.element.id, 'name:', result.element.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.update',
+            params: {
+              id: 1267,
+              fields: {
+                name: 'Product',
+                active: 'Y',
+                barcodeMulti: 'Y',
+                canBuyZero: 'Y',
+                code: 'Tovar',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: [
+                    'detailPicture.png',
+                    'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+                  ],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                height: 100,
+                iblockSectionId: 47,
+                length: 100,
+                measure: 5,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: [
+                    'previewPicture.png',
+                    'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+                  ],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                purchasingCurrency: 'RUB',
+                purchasingPrice: 1000,
+                quantity: 10,
+                quantityReserved: 1,
+                quantityTrace: 'Y',
+                recurSchemeLength: 1,
+                recurSchemeType: 'D',
+                sort: 100,
+                subscribe: 'Y',
+                trialPriceId: 175,
+                vatId: 1,
+                vatIncluded: 'Y',
+                weight: 100,
+                width: 100,
+                withoutOrder: 'Y',
+                xmlId: '1243',
+                property258: {
+                  value: 'test',
+                  valueId: 9816,
+                },
+                property259: [
+                  {
+                    value: 'test1',
+                    valueId: 9817,
+                  },
+                  {
+                    value: 'test2',
+                    valueId: 9818,
+                  },
+                ],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated product id:', result.element.id, 'name:', result.element.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-add.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-add.md
@@ -240,69 +240,208 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'catalog.product.offer.add',
-            {
-                fields: {
-                    iblockId: 24,
-                    name: 'Вариация товара',
-                    active: 'Y',
-                    barcodeMulti: 'Y',
-                    canBuyZero: 'Y',
-                    code: 'Tovar',
-                    createdBy: 1,
-                    dateActiveFrom: '2024-05-28T10:00:00',
-                    dateActiveTo: '2024-05-29T10:00:00',
-                    dateCreate: '2024-05-27T10:00:00',
-                    detailPicture: {
-                        fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']
-                    },
-                    detailText: '',
-                    detailTextType: 'text',
-                    height: 100,
-                    iblockSectionId: 47,
-                    length: 100,
-                    measure: 5,
-                    modifiedBy: 1,
-                    previewPicture: {
-                        fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']
-                    },
-                    previewText: '',
-                    previewTextType: 'text',
-                    purchasingCurrency: 'RUB',
-                    purchasingPrice: 1000,
-                    quantity: 10,
-                    quantityReserved: 1,
-                    quantityTrace: 'Y',
-                    recurSchemeLength: 1,
-                    recurSchemeType: 'D',
-                    sort: 100,
-                    subscribe: 'Y',
-                    trialPriceId: 175,
-                    vatId: 1,
-                    vatIncluded: 'Y',
-                    weight: 100,
-                    width: 100,
-                    withoutOrder: 'Y',
-                    xmlId: '',
-                    parentId: 1275,
-                    property258: 'test',
-                    property259: ['test1', 'test2'],
-                }
-            }
-        );
-    
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OfferAddResult = {
+      offer: {
+        id: number
+        iblockId: number
+        name: string
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        modifiedBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        timestampX: ISODate
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        previewText: string | null
+        previewTextType: string
+        height: number
+        length: number
+        weight: number
+        width: number
+        iblockSectionId: number | null
+        measure: number
+        parentId: { value: string; valueId: string }
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        quantityReserved: number
+        quantityTrace: string
+        sort: number
+        subscribe: string
+        type: number
+        vatId: number
+        vatIncluded: string
+        xmlId: string
+        [key: string]: unknown
+      }
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<OfferAddResult>({
+        method: 'catalog.product.offer.add',
+        params: {
+          fields: {
+            iblockId: 24,
+            name: 'Product offer',
+            active: 'Y',
+            barcodeMulti: 'Y',
+            canBuyZero: 'Y',
+            code: 'Tovar',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            height: 100,
+            iblockSectionId: 47,
+            length: 100,
+            measure: 5,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            purchasingCurrency: 'RUB',
+            purchasingPrice: 1000,
+            quantity: 10,
+            quantityReserved: 1,
+            quantityTrace: 'Y',
+            recurSchemeLength: 1,
+            recurSchemeType: 'D',
+            sort: 100,
+            subscribe: 'Y',
+            trialPriceId: 175,
+            vatId: 1,
+            vatIncluded: 'Y',
+            weight: 100,
+            width: 100,
+            withoutOrder: 'Y',
+            xmlId: '',
+            parentId: 1275,
+            property258: 'test',
+            property259: ['test1', 'test2'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added offer ID:', result.offer.id, 'name:', result.offer.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProductOffer() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.add',
+            params: {
+              fields: {
+                iblockId: 24,
+                name: 'Product offer',
+                active: 'Y',
+                barcodeMulti: 'Y',
+                canBuyZero: 'Y',
+                code: 'Tovar',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                height: 100,
+                iblockSectionId: 47,
+                length: 100,
+                measure: 5,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                purchasingCurrency: 'RUB',
+                purchasingPrice: 1000,
+                quantity: 10,
+                quantityReserved: 1,
+                quantityTrace: 'Y',
+                recurSchemeLength: 1,
+                recurSchemeType: 'D',
+                sort: 100,
+                subscribe: 'Y',
+                trialPriceId: 175,
+                vatId: 1,
+                vatIncluded: 'Y',
+                weight: 100,
+                width: 100,
+                withoutOrder: 'Y',
+                xmlId: '',
+                parentId: 1275,
+                property258: 'test',
+                property259: ['test1', 'test2'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added offer ID:', result.offer.id, 'name:', result.offer.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProductOffer)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-delete.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.offer.delete',
-    		{
-    			id: 1285,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.offer.delete',
+        params: {
+          id: 1285,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product offer deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProductOffer() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.delete',
+            params: {
+              id: 1285,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product offer deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProductOffer)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-download.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-download.md
@@ -79,30 +79,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.download
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.offer.download',
-    		{
-    			fields: {
-    				fileId: 6538,
-    				productId: 1286,
-    				fieldName: 'detailPicture',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.offer.download',
+        params: {
+          fields: {
+            fileId: 6538,
+            productId: 1286,
+            fieldName: 'detailPicture',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function downloadOfferFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.download',
+            params: {
+              fields: {
+                fileId: 6538,
+                productId: 1286,
+                fieldName: 'detailPicture',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', downloadOfferFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-get-fields-by-filter.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-get-fields-by-filter.md
@@ -66,28 +66,94 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.getFieldsByFilter
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.offer.getFieldsByFilter', 
-    		{
-    			filter: {
-    				iblockId: 24,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type OfferFieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      name: string
+      type: string
+      isDynamic?: boolean
+      isMultiple?: boolean
+      propertyType?: string
+      userType?: string | null
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OfferFieldsResult = {
+      offer: Record<string, OfferFieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<OfferFieldsResult>({
+        method: 'catalog.product.offer.getFieldsByFilter',
+        params: {
+          filter: {
+            iblockId: 24,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Offer fields:', Object.keys(result.offer).length, result.offer)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOfferFieldsByFilter() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.getFieldsByFilter',
+            params: {
+              filter: {
+                iblockId: 24,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Offer fields:', Object.keys(result.offer).length, result.offer)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOfferFieldsByFilter)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-get.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-get.md
@@ -61,25 +61,117 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.offer.get', {
-    			'id': 1286
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OfferResult = {
+      offer: {
+        id: number
+        name: string
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        height: number
+        iblockId: number
+        iblockSectionId: number | null
+        length: number
+        measure: number
+        modifiedBy: number
+        parentId: { value: string; valueId: string }
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        quantityReserved: number
+        quantityTrace: string
+        sort: number
+        subscribe: string
+        timestampX: ISODate | null
+        type: number
+        vatId: number
+        vatIncluded: string
+        weight: number
+        width: number
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<OfferResult>({
+        method: 'catalog.product.offer.get',
+        params: {
+          id: 1286,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product offer:', result.offer.id, result.offer.name, result.offer.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductOffer() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.get',
+            params: {
+              id: 1286,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product offer:', result.offer.id, result.offer.name, result.offer.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductOffer)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-list.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-list.md
@@ -131,122 +131,244 @@ filter: {
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const selectFields = [
-        "id",
-        "iblockId",
-        "name",
-        "active",
-        "available",
-        "barcodeMulti",
-        "bundle",
-        "canBuyZero",
-        "code",
-        "createdBy",
-        "dateActiveFrom",
-        "dateActiveTo",
-        "dateCreate",
-        "detailPicture",
-        "detailText",
-        "detailTextType",
-        "height",
-        "iblockSectionId",
-        "length",
-        "measure",
-        "modifiedBy",
-        "previewPicture",
-        "previewText",
-        "previewTextType",
-        "purchasingCurrency",
-        "purchasingPrice",
-        "quantity",
-        "quantityReserved",
-        "quantityTrace",
-        "recurSchemeLength",
-        "recurSchemeType",
-        "sort",
-        "subscribe",
-        "timestampX",
-        "trialPriceId",
-        "type",
-        "vatId",
-        "vatIncluded",
-        "weight",
-        "width",
-        "withoutOrder",
-        "xmlId",
-        "parentId",
-        "property258",
-        "property259",
-    ];
-    
-    try {
-        const response = await $b24.callListMethod(
-            'catalog.product.offer.list',
-            {
-                "select": selectFields,
-                "filter": {
-                    "iblockId": 24,
-                    ">id": 10,
-                    "vatId": [1, 2],
-                },
-                "order": {
-                    "id": "desc",
-                }
-            },
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    type ProductOffer = {
+      id: number
+      iblockId: number
+      name: string
+      active: string
+      available: string
+      barcodeMulti: string
+      bundle: string
+      canBuyZero: string
+      code: string
+      createdBy: number
+      dateActiveFrom: ISODate | null
+      dateActiveTo: ISODate | null
+      dateCreate: ISODate | null
+      detailPicture: { id: string; url: string; urlMachine: string } | null
+      detailText: string | null
+      detailTextType: string
+      height: number
+      iblockSectionId: number | null
+      length: number
+      measure: number
+      modifiedBy: number
+      parentId: { value: string; valueId: string }
+      previewPicture: { id: string; url: string; urlMachine: string } | null
+      previewText: string | null
+      previewTextType: string
+      purchasingCurrency: string
+      purchasingPrice: number
+      quantity: number
+      quantityReserved: number
+      quantityTrace: string
+      recurSchemeLength: number | null
+      recurSchemeType: string
+      sort: number
+      subscribe: string
+      timestampX: ISODate | null
+      trialPriceId: number | null
+      type: number
+      vatId: number
+      vatIncluded: string
+      weight: number
+      width: number
+      withoutOrder: string
+      xmlId: string
     }
-    
-    // fetchListMethod предпочтительно использовать при работе с крупными наборами данных. Метод реализует итеративную выборку с использованием генератора, что позволяет обрабатывать данные по частям и эффективно использовать память.
-    
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductOfferListResult = {
+      offers: ProductOffer[]
+    }
+
     try {
-        const generator = $b24.fetchListMethod('catalog.product.offer.list', {
-            "select": selectFields,
-            "filter": {
-                "iblockId": 24,
-                ">id": 10,
-                "vatId": [1, 2],
+      // catalog.product.offer.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProductOfferListResult>({
+        method: 'catalog.product.offer.list',
+        params: {
+          select: [
+            'id',
+            'iblockId',
+            'name',
+            'active',
+            'available',
+            'barcodeMulti',
+            'bundle',
+            'canBuyZero',
+            'code',
+            'createdBy',
+            'dateActiveFrom',
+            'dateActiveTo',
+            'dateCreate',
+            'detailPicture',
+            'detailText',
+            'detailTextType',
+            'height',
+            'iblockSectionId',
+            'length',
+            'measure',
+            'modifiedBy',
+            'previewPicture',
+            'previewText',
+            'previewTextType',
+            'purchasingCurrency',
+            'purchasingPrice',
+            'quantity',
+            'quantityReserved',
+            'quantityTrace',
+            'recurSchemeLength',
+            'recurSchemeType',
+            'sort',
+            'subscribe',
+            'timestampX',
+            'trialPriceId',
+            'type',
+            'vatId',
+            'vatIncluded',
+            'weight',
+            'width',
+            'withoutOrder',
+            'xmlId',
+            'parentId',
+            'property258',
+            'property259',
+          ],
+          filter: {
+            iblockId: 24,
+            '>id': 10,
+            vatId: [1, 2],
+          },
+          order: {
+            id: 'desc',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Offers count:', result.offers.length, 'First offer:', result.offers[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listProductOffers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.product.offer.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.list',
+            params: {
+              select: [
+                'id',
+                'iblockId',
+                'name',
+                'active',
+                'available',
+                'barcodeMulti',
+                'bundle',
+                'canBuyZero',
+                'code',
+                'createdBy',
+                'dateActiveFrom',
+                'dateActiveTo',
+                'dateCreate',
+                'detailPicture',
+                'detailText',
+                'detailTextType',
+                'height',
+                'iblockSectionId',
+                'length',
+                'measure',
+                'modifiedBy',
+                'previewPicture',
+                'previewText',
+                'previewTextType',
+                'purchasingCurrency',
+                'purchasingPrice',
+                'quantity',
+                'quantityReserved',
+                'quantityTrace',
+                'recurSchemeLength',
+                'recurSchemeType',
+                'sort',
+                'subscribe',
+                'timestampX',
+                'trialPriceId',
+                'type',
+                'vatId',
+                'vatIncluded',
+                'weight',
+                'width',
+                'withoutOrder',
+                'xmlId',
+                'parentId',
+                'property258',
+                'property259',
+              ],
+              filter: {
+                iblockId: 24,
+                '>id': 10,
+                vatId: [1, 2],
+              },
+              order: {
+                id: 'desc',
+              },
+              start: 0,
             },
-            "order": {
-                "id": "desc",
-            }
-        }, 'id');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Offers count:', result.offers.length, 'First offer:', result.offers[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-        const response = await $b24.callMethod('catalog.product.offer.list', {
-            "select": selectFields,
-            "filter": {
-                "iblockId": 24,
-                ">id": 10,
-                "vatId": [1, 2],
-            },
-            "order": {
-                "id": "desc",
-            }
-        }, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listProductOffers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/offer/catalog-product-offer-update.md
+++ b/api-reference/catalog/product/offer/catalog-product-offer-update.md
@@ -221,72 +221,207 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.offer.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.offer.update', 
-    		{
-    			'id': 1286,
-    			'fields':{
-    				iblockId: 24,
-    				name: 'Вариация товара',
-    				active: 'Y',
-    				barcodeMulti: 'Y',
-    				canBuyZero: 'Y',
-    				code: 'Tovar',
-    				createdBy: 1,
-    				dateActiveFrom: '2024-05-28T10:00:00',
-    				dateActiveTo: '2024-05-29T10:00:00',
-    				dateCreate: '2024-05-27T10:00:00',
-    				detailPicture: {
-    					'fileData':  ['detailPicture.png','iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElF­TkSuQmCC']},
-    				detailText: '',
-    				detailTextType: 'text',
-    				height: 100,
-    				iblockSectionId: 47,
-    				length: 100,
-    				measure: 5,
-    				modifiedBy: 1,
-    				previewPicture: {
-    					'fileData':['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElF­TkSuQmCC']},
-    				previewText: '',
-    				previewTextType: 'text',
-    				purchasingCurrency: 'RUB',
-    				purchasingPrice: 1000,
-    				quantity: 10,
-    				quantityReserved: 1,
-    				quantityTrace: 'Y',
-    				recurSchemeLength: 1,
-    				recurSchemeType: 'D',
-    				sort: 100,
-    				subscribe: 'Y',
-    				trialPriceId: 175,
-    				vatId: 1,
-    				vatIncluded: 'Y',
-    				weight: 100,
-    				width: 100,
-    				withoutOrder: 'Y',
-    				xmlId: '1286',
-    				property261: {value: 'test', valueId: 9868},
-    				property262: [{value: 'test1', valueId: 9869}, {value: 'test2', valueId: 9870}],
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductOfferUpdateResult = {
+      offer: {
+        id: number
+        iblockId: number
+        iblockSectionId: number | null
+        name: string
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        modifiedBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        timestampX: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        height: number
+        length: number
+        weight: number
+        width: number
+        measure: number
+        parentId: { value: string; valueId: string } | null
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        quantityReserved: number
+        quantityTrace: string
+        sort: number
+        subscribe: string
+        type: number
+        vatId: number
+        vatIncluded: string
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductOfferUpdateResult>({
+        method: 'catalog.product.offer.update',
+        params: {
+          id: 1286,
+          fields: {
+            iblockId: 24,
+            name: 'Product variation',
+            active: 'Y',
+            barcodeMulti: 'Y',
+            canBuyZero: 'Y',
+            code: 'Tovar',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: ['detailPicture.png', '<base64-encoded-image>'],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            height: 100,
+            iblockSectionId: 47,
+            length: 100,
+            measure: 5,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: ['previewPicture.png', '<base64-encoded-image>'],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            purchasingCurrency: 'RUB',
+            purchasingPrice: 1000,
+            quantity: 10,
+            quantityReserved: 1,
+            quantityTrace: 'Y',
+            recurSchemeLength: 1,
+            recurSchemeType: 'D',
+            sort: 100,
+            subscribe: 'Y',
+            trialPriceId: 175,
+            vatId: 1,
+            vatIncluded: 'Y',
+            weight: 100,
+            width: 100,
+            withoutOrder: 'Y',
+            xmlId: '1286',
+            property261: { value: 'test', valueId: 9868 },
+            property262: [{ value: 'test1', valueId: 9869 }, { value: 'test2', valueId: 9870 }],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.offer.id, result.offer.name, result.offer.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateProductOffer() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.offer.update',
+            params: {
+              id: 1286,
+              fields: {
+                iblockId: 24,
+                name: 'Product variation',
+                active: 'Y',
+                barcodeMulti: 'Y',
+                canBuyZero: 'Y',
+                code: 'Tovar',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: ['detailPicture.png', '<base64-encoded-image>'],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                height: 100,
+                iblockSectionId: 47,
+                length: 100,
+                measure: 5,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: ['previewPicture.png', '<base64-encoded-image>'],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                purchasingCurrency: 'RUB',
+                purchasingPrice: 1000,
+                quantity: 10,
+                quantityReserved: 1,
+                quantityTrace: 'Y',
+                recurSchemeLength: 1,
+                recurSchemeType: 'D',
+                sort: 100,
+                subscribe: 'Y',
+                trialPriceId: 175,
+                vatId: 1,
+                vatIncluded: 'Y',
+                weight: 100,
+                width: 100,
+                withoutOrder: 'Y',
+                xmlId: '1286',
+                property261: { value: 'test', valueId: 9868 },
+                property262: [{ value: 'test1', valueId: 9869 }, { value: 'test2', valueId: 9870 }],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.offer.id, result.offer.name, result.offer.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateProductOffer)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-add.md
+++ b/api-reference/catalog/product/service/catalog-product-service-add.md
@@ -142,51 +142,160 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.service.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ServiceAddResult = {
+      service: {
+        active: string
+        available: string
+        bundle: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        iblockId: number
+        iblockSectionId: number | null
+        id: number
+        modifiedBy: number
+        name: string
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        property258: { value: string; valueId: string } | null
+        property259: Array<{ value: string; valueId: string }>
+        sort: number
+        timestampX: ISODate | null
+        type: number
+        vatId: number | null
+        vatIncluded: string
+        xmlId: string
+      }
+    }
+
     try {
-        const response = await $b24.callMethod(
-            'catalog.product.service.add',
-            {
-                fields: {
-                    iblockId: 23,
-                    name: 'Услуга',
-                    active: 'Y',
-                    code: 'service',
-                    createdBy: 1,
-                    dateActiveFrom: '2024-05-28T10:00:00',
-                    dateActiveTo: '2024-05-29T10:00:00',
-                    dateCreate: '2024-05-27T10:00:00',
-                    detailPicture: {
-                        fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']
-                    },
-                    detailText: '',
-                    detailTextType: 'text',
-                    iblockSectionId: 47,
-                    modifiedBy: 1,
-                    previewPicture: {
-                        fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']
-                    },
-                    previewText: '',
-                    previewTextType: 'text',
-                    sort: 100,
-                    vatId: 1,
-                    vatIncluded: 'Y',
-                    xmlId: '',
-                    property258: 'test',
-                    property259: ['test1', 'test2'],
-                }
-            }
-        );
-    
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        processResult(result);
+      const response = await $b24.actions.v2.call.make<ServiceAddResult>({
+        method: 'catalog.product.service.add',
+        params: {
+          fields: {
+            iblockId: 23,
+            name: 'Service',
+            active: 'Y',
+            code: 'service',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            iblockSectionId: 47,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            sort: 100,
+            vatId: 1,
+            vatIncluded: 'Y',
+            xmlId: '',
+            property258: 'test',
+            property259: ['test1', 'test2'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added service ID:', result.service.id, 'name:', result.service.name)
+      }
     } catch (error) {
-        console.error('Error:', error);
-    }    
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.add',
+            params: {
+              fields: {
+                iblockId: 23,
+                name: 'Service',
+                active: 'Y',
+                code: 'service',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                iblockSectionId: 47,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                sort: 100,
+                vatId: 1,
+                vatIncluded: 'Y',
+                xmlId: '',
+                property258: 'test',
+                property259: ['test1', 'test2'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added service ID:', result.service.id, 'name:', result.service.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-delete.md
+++ b/api-reference/catalog/product/service/catalog-product-service-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.service.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.service.delete',
-    		{
-    			id: 1264,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.service.delete',
+        params: {
+          id: 1264,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Service deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.delete',
+            params: {
+              id: 1264,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Service deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-download.md
+++ b/api-reference/catalog/product/service/catalog-product-service-download.md
@@ -79,30 +79,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.service.download
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.service.download',
-    		{
-    			fields: {
-    				fileId: 6497,
-    				productId: 1265,
-    				fieldName: 'detailPicture',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.service.download',
+        params: {
+          fields: {
+            fileId: 6497,
+            productId: 1265,
+            fieldName: 'detailPicture',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File downloaded successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function downloadServiceFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.download',
+            params: {
+              fields: {
+                fileId: 6497,
+                productId: 1265,
+                fieldName: 'detailPicture',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File downloaded successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', downloadServiceFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-get-fields-by-filter.md
+++ b/api-reference/catalog/product/service/catalog-product-service-get-fields-by-filter.md
@@ -66,28 +66,94 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.service.getFieldsByFilter
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.service.getFieldsByFilter',
-    		{
-    			filter: {
-    				iblockId: 14,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type ServiceFieldItem = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      name: string
+      type: string
+      isDynamic?: boolean
+      isMultiple?: boolean
+      propertyType?: string
+      userType?: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsByFilterResult = {
+      service: Record<string, ServiceFieldItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsByFilterResult>({
+        method: 'catalog.product.service.getFieldsByFilter',
+        params: {
+          filter: {
+            iblockId: 14,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Service fields:', Object.keys(result.service))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getServiceFieldsByFilter() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.getFieldsByFilter',
+            params: {
+              filter: {
+                iblockId: 14,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Service fields:', Object.keys(result.service))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getServiceFieldsByFilter)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-get.md
+++ b/api-reference/catalog/product/service/catalog-product-service-get.md
@@ -61,25 +61,104 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.service.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.service.get', {
-    			id: 1265
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetServiceResult = {
+      service: {
+        id: number
+        name: string
+        active: string
+        available: string
+        bundle: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        iblockId: number
+        iblockSectionId: number | null
+        modifiedBy: number
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        sort: number
+        timestampX: ISODate | null
+        type: number
+        vatId: number | null
+        vatIncluded: string
+        xmlId: string | null
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetServiceResult>({
+        method: 'catalog.product.service.get',
+        params: {
+          id: 1265,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Service:', result.service.id, result.service.name, result.service.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.get',
+            params: {
+              id: 1265,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Service:', result.service.id, result.service.name, result.service.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-list.md
+++ b/api-reference/catalog/product/service/catalog-product-service-list.md
@@ -130,158 +130,190 @@ filter: {
     https://**put_your_bitrix24_address**/rest/catalog.product.service.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.product.service.list',
-        {
-          "select": [
-            "id",
-            "iblockId",
-            "name",
-            "active",
-            "available",
-            "bundle",
-            "code",
-            "createdBy",
-            "dateActiveFrom",
-            "dateActiveTo",
-            "dateCreate",
-            "detailPicture",
-            "detailText",
-            "detailTextType",
-            "iblockSectionId",
-            "modifiedBy",
-            "previewPicture",
-            "previewText",
-            "previewTextType",
-            "sort",
-            "timestampX",
-            "type",
-            "vatId",
-            "vatIncluded",
-            "xmlId",
-            "property94",
-            "property95",
-          ],
-          "filter": {
-            "iblockId": 23,
-            ">id": 10,
-            "vatId": [1, 2],
-          },
-          "order": {
-            "id": "desc",
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    type ServiceItem = {
+      id: number
+      iblockId: number
+      name: string
+      active: string
+      available: string
+      bundle: string
+      code: string
+      createdBy: number
+      dateActiveFrom: ISODate | null
+      dateActiveTo: ISODate | null
+      dateCreate: ISODate | null
+      detailPicture: { id: string; url: string; urlMachine: string } | null
+      detailText: string | null
+      detailTextType: string
+      iblockSectionId: number
+      modifiedBy: number
+      previewPicture: { id: string; url: string; urlMachine: string } | null
+      previewText: string | null
+      previewTextType: string
+      sort: number
+      timestampX: ISODate | null
+      type: number
+      vatId: number
+      vatIncluded: string
+      xmlId: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ServiceListResult = {
+      services: ServiceItem[]
+    }
+
     try {
-      const generator = $b24.fetchListMethod('catalog.product.service.list', {
-        "select": [
-          "id",
-          "iblockId",
-          "name",
-          "active",
-          "available",
-          "bundle",
-          "code",
-          "createdBy",
-          "dateActiveFrom",
-          "dateActiveTo",
-          "dateCreate",
-          "detailPicture",
-          "detailText",
-          "detailTextType",
-          "iblockSectionId",
-          "modifiedBy",
-          "previewPicture",
-          "previewText",
-          "previewTextType",
-          "sort",
-          "timestampX",
-          "type",
-          "vatId",
-          "vatIncluded",
-          "xmlId",
-          "property94",
-          "property95",
-        ],
-        "filter": {
-          "iblockId": 23,
-          ">id": 10,
-          "vatId": [1, 2],
+      // catalog.product.service.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ServiceListResult>({
+        method: 'catalog.product.service.list',
+        params: {
+          select: [
+            'id',
+            'iblockId',
+            'name',
+            'active',
+            'available',
+            'bundle',
+            'code',
+            'createdBy',
+            'dateActiveFrom',
+            'dateActiveTo',
+            'dateCreate',
+            'detailPicture',
+            'detailText',
+            'detailTextType',
+            'iblockSectionId',
+            'modifiedBy',
+            'previewPicture',
+            'previewText',
+            'previewTextType',
+            'sort',
+            'timestampX',
+            'type',
+            'vatId',
+            'vatIncluded',
+            'xmlId',
+            'property94',
+            'property95',
+          ],
+          filter: {
+            iblockId: 23,
+            '>id': 10,
+            vatId: [1, 2],
+          },
+          order: {
+            id: 'desc',
+          },
+          start: 0,
         },
-        "order": {
-          "id": "desc",
-        }
-      }, 'id');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Services on this page:', result.services.length, result.services)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.product.service.list', {
-        "select": [
-          "id",
-          "iblockId",
-          "name",
-          "active",
-          "available",
-          "bundle",
-          "code",
-          "createdBy",
-          "dateActiveFrom",
-          "dateActiveTo",
-          "dateCreate",
-          "detailPicture",
-          "detailText",
-          "detailTextType",
-          "iblockSectionId",
-          "modifiedBy",
-          "previewPicture",
-          "previewText",
-          "previewTextType",
-          "sort",
-          "timestampX",
-          "type",
-          "vatId",
-          "vatIncluded",
-          "xmlId",
-          "property94",
-          "property95",
-        ],
-        "filter": {
-          "iblockId": 23,
-          ">id": 10,
-          "vatId": [1, 2],
-        },
-        "order": {
-          "id": "desc",
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listServices() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.product.service.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.list',
+            params: {
+              select: [
+                'id',
+                'iblockId',
+                'name',
+                'active',
+                'available',
+                'bundle',
+                'code',
+                'createdBy',
+                'dateActiveFrom',
+                'dateActiveTo',
+                'dateCreate',
+                'detailPicture',
+                'detailText',
+                'detailTextType',
+                'iblockSectionId',
+                'modifiedBy',
+                'previewPicture',
+                'previewText',
+                'previewTextType',
+                'sort',
+                'timestampX',
+                'type',
+                'vatId',
+                'vatIncluded',
+                'xmlId',
+                'property94',
+                'property95',
+              ],
+              filter: {
+                iblockId: 23,
+                '>id': 10,
+                vatId: [1, 2],
+              },
+              order: {
+                id: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Services on this page:', result.services.length, result.services)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listServices)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/service/catalog-product-service-update.md
+++ b/api-reference/catalog/product/service/catalog-product-service-update.md
@@ -137,54 +137,166 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.service.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'catalog.product.service.update',
-            {
-                id: 1265,
-                fields: {
-                    name: 'Услуга',
-                    active: 'Y',
-                    code: 'service',
-                    createdBy: 1,
-                    dateActiveFrom: '2024-05-28T10:00:00',
-                    dateActiveTo: '2024-05-29T10:00:00',
-                    dateCreate: '2024-05-27T10:00:00',
-                    detailPicture: {
-                        fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']
-                    },
-                    detailText: '',
-                    detailTextType: 'text',
-                    iblockSectionId: 47,
-                    modifiedBy: 1,
-                    previewPicture: {
-                        fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']
-                    },
-                    previewText: '',
-                    previewTextType: 'text',
-                    sort: 100,
-                    vatId: 1,
-                    vatIncluded: 'Y',
-                    xmlId: '216',
-                    property258: { value: 'test', valueId: 9809 },
-                    property259: [
-                        { value: 'test1', valueId: 9810 },
-                        { value: 'test2', valueId: 9811 }
-                    ],
-                }
-            }
-        );
-    
-        const result = response.getData().result;
-        console.log('Updated element with ID:', result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ServiceUpdateResult = {
+      service: {
+        active: string,
+        available: string,
+        bundle: string,
+        code: string,
+        createdBy: number,
+        dateActiveFrom: ISODate | null,
+        dateActiveTo: ISODate | null,
+        dateCreate: ISODate | null,
+        detailPicture: { id: string, url: string, urlMachine: string } | null,
+        detailText: string | null,
+        detailTextType: string,
+        iblockId: number,
+        iblockSectionId: number,
+        id: number,
+        modifiedBy: number,
+        name: string,
+        previewPicture: { id: string, url: string, urlMachine: string } | null,
+        previewText: string | null,
+        previewTextType: string,
+        property258: { value: string, valueId: string } | null,
+        property259: Array<{ value: string, valueId: string }> | null,
+        sort: number,
+        timestampX: ISODate,
+        type: number,
+        vatId: number,
+        vatIncluded: string,
+        xmlId: string,
+      },
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ServiceUpdateResult>({
+        method: 'catalog.product.service.update',
+        params: {
+          id: 1265,
+          fields: {
+            name: 'Service',
+            active: 'Y',
+            code: 'service',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            iblockSectionId: 47,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            sort: 100,
+            vatId: 1,
+            vatIncluded: 'Y',
+            xmlId: '216',
+            property258: { value: 'test', valueId: 9809 },
+            property259: [
+              { value: 'test1', valueId: 9810 },
+              { value: 'test2', valueId: 9811 },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated service:', result.service.id, result.service.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.service.update',
+            params: {
+              id: 1265,
+              fields: {
+                name: 'Service',
+                active: 'Y',
+                code: 'service',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                iblockSectionId: 47,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nо3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                sort: 100,
+                vatId: 1,
+                vatIncluded: 'Y',
+                xmlId: '216',
+                property258: { value: 'test', valueId: 9809 },
+                property259: [
+                  { value: 'test1', valueId: 9810 },
+                  { value: 'test2', valueId: 9811 },
+                ],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated service:', result.service.id, result.service.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-add.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-add.md
@@ -201,62 +201,190 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.product.sku.add',
-            {
-                fields: {
-                    iblockId: 23,
-                    name: 'Головной товар',
-                    active: 'Y',
-                    canBuyZero: 'Y',
-                    code: 'product_sku',
-                    createdBy: 1,
-                    dateActiveFrom: '2024-05-28T10:00:00',
-                    dateActiveTo: '2024-05-29T10:00:00',
-                    dateCreate: '2024-05-27T10:00:00',
-                    detailPicture: {
-                        'fileData':  ['detailPicture.png','iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']},
-                    detailText: '',
-                    detailTextType: 'text',
-                    height: 100,
-                    iblockSectionId: 47,
-                    length: 100,
-                    measure: 5,
-                    modifiedBy: 1,
-                    previewPicture: {
-                        'fileData':['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']},
-                    previewText: '',
-                    previewTextType: 'text',
-                    purchasingCurrency: 'RUB',
-                    purchasingPrice: 1000,
-                    quantity: 10,
-                    sort: 100,
-                    subscribe: 'Y',
-                    vatId: 1,
-                    vatIncluded: 'Y',
-                    weight: 100,
-                    width: 100,
-                    xmlId: '',
-                    property258: 'test',
-                    property259: ['test1', 'test2'],
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created SKU with ID:', result);
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogProductSkuAddResult = {
+      sku: {
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        height: number
+        iblockId: number
+        iblockSectionId: number
+        id: number
+        length: number
+        measure: number
+        modifiedBy: number
+        name: string
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        property258: { value: string; valueId: string }
+        property259: Array<{ value: string; valueId: string }>
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        sort: number
+        subscribe: string
+        timestampX: ISODate | null
+        type: number
+        vatId: number
+        vatIncluded: string
+        weight: number
+        width: number
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogProductSkuAddResult>({
+        method: 'catalog.product.sku.add',
+        params: {
+          fields: {
+            iblockId: 23,
+            name: 'Parent product',
+            active: 'Y',
+            canBuyZero: 'Y',
+            code: 'product_sku',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            height: 100,
+            iblockSectionId: 47,
+            length: 100,
+            measure: 5,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            purchasingCurrency: 'RUB',
+            purchasingPrice: 1000,
+            quantity: 10,
+            sort: 100,
+            subscribe: 'Y',
+            vatId: 1,
+            vatIncluded: 'Y',
+            weight: 100,
+            width: 100,
+            xmlId: '',
+            property258: 'test',
+            property259: ['test1', 'test2'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added SKU product:', result.sku.id, result.sku.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSkuProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.add',
+            params: {
+              fields: {
+                iblockId: 23,
+                name: 'Parent product',
+                active: 'Y',
+                canBuyZero: 'Y',
+                code: 'product_sku',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                height: 100,
+                iblockSectionId: 47,
+                length: 100,
+                measure: 5,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                purchasingCurrency: 'RUB',
+                purchasingPrice: 1000,
+                quantity: 10,
+                sort: 100,
+                subscribe: 'Y',
+                vatId: 1,
+                vatIncluded: 'Y',
+                weight: 100,
+                width: 100,
+                xmlId: '',
+                property258: 'test',
+                property259: ['test1', 'test2'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added SKU product:', result.sku.id, result.sku.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSkuProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-delete.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.sku.delete',
-    		{
-    			id: 1288,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.sku.delete',
+        params: {
+          id: 1288,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product SKU deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProductSku() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.delete',
+            params: {
+              id: 1288,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product SKU deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProductSku)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-download.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-download.md
@@ -79,30 +79,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.download
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.sku.download',
-    		{
-    			fields: {
-    				fileId: 6546,
-    				productId: 1289,
-    				fieldName: 'detailPicture',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.product.sku.download',
+        params: {
+          fields: {
+            fileId: 6546,
+            productId: 1289,
+            fieldName: 'detailPicture',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function downloadProductSku() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.download',
+            params: {
+              fields: {
+                fileId: 6546,
+                productId: 1289,
+                fieldName: 'detailPicture',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', downloadProductSku)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-get-fields-by-filter.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-get-fields-by-filter.md
@@ -66,28 +66,94 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.getFieldsByFilter
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.sku.getFieldsByFilter',
-    		{
-    			filter: {
-    				iblockId: 23,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      name: string
+      type: string
+      isDynamic?: boolean
+      isMultiple?: boolean
+      propertyType?: string
+      userType?: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SkuFieldsResult = {
+      sku: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SkuFieldsResult>({
+        method: 'catalog.product.sku.getFieldsByFilter',
+        params: {
+          filter: {
+            iblockId: 23,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.sku), result.sku)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSkuFieldsByFilter() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.getFieldsByFilter',
+            params: {
+              filter: {
+                iblockId: 23,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.sku), result.sku)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSkuFieldsByFilter)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-get.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-get.md
@@ -54,25 +54,116 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.product.sku.get', {
-    			'id': 1289
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SkuGetResult = {
+      sku: {
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        height: number
+        iblockId: number
+        iblockSectionId: number
+        id: number
+        length: number
+        measure: number
+        modifiedBy: number
+        name: string
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        property258: { value: string; valueId: string }
+        property259: { value: string; valueId: string }[]
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        sort: number
+        subscribe: string
+        timestampX: ISODate | null
+        type: number
+        vatId: number
+        vatIncluded: string
+        weight: number
+        width: number
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SkuGetResult>({
+        method: 'catalog.product.sku.get',
+        params: {
+          id: 1289,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.sku.id, result.sku.name, result.sku.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductSku() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.get',
+            params: {
+              id: 1289,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.sku.id, result.sku.name, result.sku.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductSku)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-list.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-list.md
@@ -102,188 +102,222 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.product.sku.list',
-        {
-          "select": [
-            "id",
-            "iblockId",
-            "name",
-            "active",
-            "available",
-            "bundle",
-            "canBuyZero",
-            "code",
-            "createdBy",
-            "dateActiveFrom",
-            "dateActiveTo",
-            "dateCreate",
-            "detailPicture",
-            "detailText",
-            "detailTextType",
-            "height",
-            "iblockSectionId",
-            "length",
-            "measure",
-            "modifiedBy",
-            "previewPicture",
-            "previewText",
-            "previewTextType",
-            "purchasingCurrency",
-            "purchasingPrice",
-            "quantity",
-            "sort",
-            "subscribe",
-            "timestampX",
-            "type",
-            "vatId",
-            "vatIncluded",
-            "weight",
-            "width",
-            "xmlId",
-            "property258",
-            "property259",
-          ],
-          "filter": {
-            "iblockId": 23,
-            ">id": 10,
-            "vatId": [1, 2],
-          },
-          "order": {
-            "id": "desc",
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    type SkuItem = {
+      id: number
+      iblockId: number
+      iblockSectionId: number | null
+      name: string
+      active: string
+      available: string
+      bundle: string
+      canBuyZero: string
+      code: string
+      createdBy: number
+      dateActiveFrom: ISODate | null
+      dateActiveTo: ISODate | null
+      dateCreate: ISODate | null
+      detailPicture: { id: string; url: string; urlMachine: string } | null
+      detailText: string | null
+      detailTextType: string
+      height: number | null
+      length: number | null
+      measure: number | null
+      modifiedBy: number
+      previewPicture: { id: string; url: string; urlMachine: string } | null
+      previewText: string | null
+      previewTextType: string
+      purchasingCurrency: string | null
+      purchasingPrice: string | null
+      quantity: number | null
+      sort: number
+      subscribe: string
+      timestampX: ISODate | null
+      type: number
+      vatId: number | null
+      vatIncluded: string
+      weight: number | null
+      width: number | null
+      xmlId: string
+      property258: { value: string; valueId: string } | null
+      property259: Array<{ value: string; valueId: string }>
     }
-    
-    // fetchListMethod предпочтительно использовать при работе с крупными наборами данных. Метод реализует итеративную выборку с использованием генератора, что позволяет обрабатывать данные по частям и эффективно использовать память.
-    
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SkuListResult = {
+      units: SkuItem[]
+    }
+
     try {
-      const generator = $b24.fetchListMethod('catalog.product.sku.list', {
-        "select": [
-          "id",
-          "iblockId",
-          "name",
-          "active",
-          "available",
-          "bundle",
-          "canBuyZero",
-          "code",
-          "createdBy",
-          "dateActiveFrom",
-          "dateActiveTo",
-          "dateCreate",
-          "detailPicture",
-          "detailText",
-          "detailTextType",
-          "height",
-          "iblockSectionId",
-          "length",
-          "measure",
-          "modifiedBy",
-          "previewPicture",
-          "previewText",
-          "previewTextType",
-          "purchasingCurrency",
-          "purchasingPrice",
-          "quantity",
-          "sort",
-          "subscribe",
-          "timestampX",
-          "type",
-          "vatId",
-          "vatIncluded",
-          "weight",
-          "width",
-          "xmlId",
-          "property258",
-          "property259",
-        ],
-        "filter": {
-          "iblockId": 23,
-          ">id": 10,
-          "vatId": [1, 2],
+      // catalog.product.sku.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SkuListResult>({
+        method: 'catalog.product.sku.list',
+        params: {
+          select: [
+            'id',
+            'iblockId',
+            'name',
+            'active',
+            'available',
+            'bundle',
+            'canBuyZero',
+            'code',
+            'createdBy',
+            'dateActiveFrom',
+            'dateActiveTo',
+            'dateCreate',
+            'detailPicture',
+            'detailText',
+            'detailTextType',
+            'height',
+            'iblockSectionId',
+            'length',
+            'measure',
+            'modifiedBy',
+            'previewPicture',
+            'previewText',
+            'previewTextType',
+            'purchasingCurrency',
+            'purchasingPrice',
+            'quantity',
+            'sort',
+            'subscribe',
+            'timestampX',
+            'type',
+            'vatId',
+            'vatIncluded',
+            'weight',
+            'width',
+            'xmlId',
+            'property258',
+            'property259',
+          ],
+          filter: {
+            iblockId: 23,
+            '>id': 10,
+            vatId: [1, 2],
+          },
+          order: {
+            id: 'desc',
+          },
+          start: 0,
         },
-        "order": {
-          "id": "desc",
-        }
-      }, 'id');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('SKUs on this page:', result.units.length, result.units)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.product.sku.list', {
-        "select": [
-          "id",
-          "iblockId",
-          "name",
-          "active",
-          "available",
-          "bundle",
-          "canBuyZero",
-          "code",
-          "createdBy",
-          "dateActiveFrom",
-          "dateActiveTo",
-          "dateCreate",
-          "detailPicture",
-          "detailText",
-          "detailTextType",
-          "height",
-          "iblockSectionId",
-          "length",
-          "measure",
-          "modifiedBy",
-          "previewPicture",
-          "previewText",
-          "previewTextType",
-          "purchasingCurrency",
-          "purchasingPrice",
-          "quantity",
-          "sort",
-          "subscribe",
-          "timestampX",
-          "type",
-          "vatId",
-          "vatIncluded",
-          "weight",
-          "width",
-          "xmlId",
-          "property258",
-          "property259",
-        ],
-        "filter": {
-          "iblockId": 23,
-          ">id": 10,
-          "vatId": [1, 2],
-        },
-        "order": {
-          "id": "desc",
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listProductSkus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.product.sku.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.list',
+            params: {
+              select: [
+                'id',
+                'iblockId',
+                'name',
+                'active',
+                'available',
+                'bundle',
+                'canBuyZero',
+                'code',
+                'createdBy',
+                'dateActiveFrom',
+                'dateActiveTo',
+                'dateCreate',
+                'detailPicture',
+                'detailText',
+                'detailTextType',
+                'height',
+                'iblockSectionId',
+                'length',
+                'measure',
+                'modifiedBy',
+                'previewPicture',
+                'previewText',
+                'previewTextType',
+                'purchasingCurrency',
+                'purchasingPrice',
+                'quantity',
+                'sort',
+                'subscribe',
+                'timestampX',
+                'type',
+                'vatId',
+                'vatIncluded',
+                'weight',
+                'width',
+                'xmlId',
+                'property258',
+                'property259',
+              ],
+              filter: {
+                iblockId: 23,
+                '>id': 10,
+                vatId: [1, 2],
+              },
+              order: {
+                id: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('SKUs on this page:', result.units.length, result.units)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listProductSkus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/product/sku/catalog-product-sku-update.md
+++ b/api-reference/catalog/product/sku/catalog-product-sku-update.md
@@ -203,59 +203,188 @@
     https://**put_your_bitrix24_address**/rest/catalog.product.sku.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SkuUpdateResult = {
+      sku: {
+        id: number
+        name: string
+        active: string
+        available: string
+        bundle: string
+        canBuyZero: string
+        code: string
+        createdBy: number
+        dateActiveFrom: ISODate | null
+        dateActiveTo: ISODate | null
+        dateCreate: ISODate | null
+        detailPicture: { id: string; url: string; urlMachine: string } | null
+        detailText: string | null
+        detailTextType: string
+        height: number
+        iblockId: number
+        iblockSectionId: number
+        length: number
+        measure: number
+        modifiedBy: number
+        previewPicture: { id: string; url: string; urlMachine: string } | null
+        previewText: string | null
+        previewTextType: string
+        purchasingCurrency: string
+        purchasingPrice: string
+        quantity: number
+        sort: number
+        subscribe: string
+        timestampX: ISODate | null
+        type: number
+        vatId: number
+        vatIncluded: string
+        weight: number
+        width: number
+        xmlId: string
+      }
+    }
+
     try {
-        const response = await $b24.callMethod(
-            'catalog.product.sku.update',
-            {
-                id: 1291,
-                fields: {
-                    name: 'Головной товар',
-                    active: 'Y',
-                    canBuyZero: 'Y',
-                    code: 'product_sku',
-                    createdBy: 1,
-                    dateActiveFrom: '2024-05-28T10:00:00',
-                    dateActiveTo: '2024-05-29T10:00:00',
-                    dateCreate: '2024-05-27T10:00:00',
-                    detailPicture: {
-                        'fileData':  ['detailPicture.png','iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']},
-                    detailText: '',
-                    detailTextType: 'text',
-                    height: 100,
-                    iblockSectionId: 47,
-                    length: 100,
-                    measure: 5,
-                    modifiedBy: 1,
-                    previewPicture: {
-                        'fileData':['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC']},
-                    previewText: '',
-                    previewTextType: 'text',
-                    purchasingCurrency: 'RUB',
-                    purchasingPrice: 1000,
-                    quantity: 10,
-                    sort: 100,
-                    subscribe: 'Y',
-                    vatId: 1,
-                    vatIncluded: 'Y',
-                    weight: 100,
-                    width: 100,
-                    xmlId: '1291',
-                    property258: { value: 'test', valueId: 9883 },
-                    property259: [{ value: 'test1', valueId: 9884 }, { value: 'test2', valueId: 9885 }],
-                }
-            }
-        );
-    
-        const result = response.getData().result;
-        console.log('Updated SKU with ID:', result);
-        processResult(result);
+      const response = await $b24.actions.v2.call.make<SkuUpdateResult>({
+        method: 'catalog.product.sku.update',
+        params: {
+          id: 1291,
+          fields: {
+            name: 'Main product',
+            active: 'Y',
+            canBuyZero: 'Y',
+            code: 'product_sku',
+            createdBy: 1,
+            dateActiveFrom: '2024-05-28T10:00:00',
+            dateActiveTo: '2024-05-29T10:00:00',
+            dateCreate: '2024-05-27T10:00:00',
+            detailPicture: {
+              fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            detailText: '',
+            detailTextType: 'text',
+            height: 100,
+            iblockSectionId: 47,
+            length: 100,
+            measure: 5,
+            modifiedBy: 1,
+            previewPicture: {
+              fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            previewText: '',
+            previewTextType: 'text',
+            purchasingCurrency: 'RUB',
+            purchasingPrice: 1000,
+            quantity: 10,
+            sort: 100,
+            subscribe: 'Y',
+            vatId: 1,
+            vatIncluded: 'Y',
+            weight: 100,
+            width: 100,
+            xmlId: '1291',
+            property258: { value: 'test', valueId: 9883 },
+            property259: [{ value: 'test1', valueId: 9884 }, { value: 'test2', valueId: 9885 }],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated SKU:', result.sku.id, result.sku.name)
+      }
     } catch (error) {
-        console.error('Error:', error);
-    }    
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSku() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.sku.update',
+            params: {
+              id: 1291,
+              fields: {
+                name: 'Main product',
+                active: 'Y',
+                canBuyZero: 'Y',
+                code: 'product_sku',
+                createdBy: 1,
+                dateActiveFrom: '2024-05-28T10:00:00',
+                dateActiveTo: '2024-05-29T10:00:00',
+                dateCreate: '2024-05-27T10:00:00',
+                detailPicture: {
+                  fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                detailText: '',
+                detailTextType: 'text',
+                height: 100,
+                iblockSectionId: 47,
+                length: 100,
+                measure: 5,
+                modifiedBy: 1,
+                previewPicture: {
+                  fileData: ['previewPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                previewText: '',
+                previewTextType: 'text',
+                purchasingCurrency: 'RUB',
+                purchasingPrice: 1000,
+                quantity: 10,
+                sort: 100,
+                subscribe: 'Y',
+                vatId: 1,
+                vatIncluded: 'Y',
+                weight: 100,
+                width: 100,
+                xmlId: '1291',
+                property258: { value: 'test', valueId: 9883 },
+                property259: [{ value: 'test1', valueId: 9884 }, { value: 'test2', valueId: 9885 }],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated SKU:', result.sku.id, result.sku.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSku)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/ratio/catalog-ratio-get-fields.md
+++ b/api-reference/catalog/ratio/catalog-ratio-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.ratio.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.ratio.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RatioFieldsResult = {
+      ratio: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<RatioFieldsResult>({
+        method: 'catalog.ratio.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('ratio fields:', Object.keys(result.ratio))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRatioFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.ratio.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('ratio fields:', Object.keys(result.ratio))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRatioFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/ratio/catalog-ratio-get.md
+++ b/api-reference/catalog/ratio/catalog-ratio-get.md
@@ -55,25 +55,83 @@
     https://**put_your_bitrix24_address**/rest/catalog.ratio.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.ratio.get', {
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RatioGetResult = {
+      ratio: {
+        id: number
+        isDefault: string
+        productId: number
+        ratio: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RatioGetResult>({
+        method: 'catalog.ratio.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ratio)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRatio() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.ratio.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ratio)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRatio)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/ratio/catalog-ratio-list.md
+++ b/api-reference/catalog/ratio/catalog-ratio-list.md
@@ -100,74 +100,113 @@
     https://**put_your_bitrix24_address**/rest/catalog.ratio.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    type CatalogRatioItem = {
+      id: number,
+      productId: number,
+      ratio: number,
+      isDefault: 'Y' | 'N',
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RatioListResult = {
+      ratios: CatalogRatioItem[],
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'catalog.ratio.list',
-        {
+      // catalog.ratio.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<RatioListResult>({
+        method: 'catalog.ratio.list',
+        params: {
           select: ['id', 'productId', 'ratio', 'isDefault'],
           filter: {
             '@productId': [1, 2],
             '>ratio': 0.5,
-            'isDefault': 'Y',
+            isDefault: 'Y',
           },
           order: {
             id: 'desc',
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('catalog.ratio.list', {
-        select: ['id', 'productId', 'ratio', 'isDefault'],
-        filter: {
-          '@productId': [1, 2],
-          '>ratio': 0.5,
-          'isDefault': 'Y',
-        },
-        order: {
-          id: 'desc',
-        },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Ratios:', result.ratios, 'Count:', result.ratios.length)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.ratio.list', {
-        select: ['id', 'productId', 'ratio', 'isDefault'],
-        filter: {
-          '@productId': [1, 2],
-          '>ratio': 0.5,
-          'isDefault': 'Y',
-        },
-        order: {
-          id: 'desc',
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchRatioList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.ratio.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.ratio.list',
+            params: {
+              select: ['id', 'productId', 'ratio', 'isDefault'],
+              filter: {
+                '@productId': [1, 2],
+                '>ratio': 0.5,
+                isDefault: 'Y',
+              },
+              order: {
+                id: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Ratios:', result.ratios, 'Count:', result.ratios.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchRatioList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/rounding-rule/catalog-rounding-rule-add.md
+++ b/api-reference/catalog/rounding-rule/catalog-rounding-rule-add.md
@@ -73,31 +73,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.roundingRule.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.roundingRule.add',
-    		{
-    			fields: {
-    				catalogGroupId: 14,
-    				price: 1000,
-    				roundType: 4,
-    				roundPrecision: 100
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoundingRuleAddResult = {
+      roundingRule: {
+        catalogGroupId: number
+        createdBy: number
+        dateCreate: ISODate | null
+        dateModify: ISODate | null
+        id: number
+        modifiedBy: number
+        price: number
+        roundPrecision: number
+        roundType: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RoundingRuleAddResult>({
+        method: 'catalog.roundingRule.add',
+        params: {
+          fields: {
+            catalogGroupId: 14,
+            price: 1000,
+            roundType: 4,
+            roundPrecision: 100,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.roundingRule.id, result.roundingRule.roundType, result.roundingRule.roundPrecision)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRoundingRule() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.roundingRule.add',
+            params: {
+              fields: {
+                catalogGroupId: 14,
+                price: 1000,
+                roundType: 4,
+                roundPrecision: 100,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.roundingRule.id, result.roundingRule.roundType, result.roundingRule.roundPrecision)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRoundingRule)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/rounding-rule/catalog-rounding-rule-delete.md
+++ b/api-reference/catalog/rounding-rule/catalog-rounding-rule-delete.md
@@ -52,33 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.roundingRule.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.roundingRule.delete',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.log(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.roundingRule.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Rounding rule deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteRoundingRule() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.roundingRule.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Rounding rule deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteRoundingRule)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/rounding-rule/catalog-rounding-rule-get-fields.md
+++ b/api-reference/catalog/rounding-rule/catalog-rounding-rule-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.roundingRule.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.roundingRule.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoundingRuleGetFieldsResult = {
+      roundingRule: Record<string, FieldInfo>
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    type FieldInfo = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<RoundingRuleGetFieldsResult>({
+        method: 'catalog.roundingRule.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.roundingRule))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRoundingRuleFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.roundingRule.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.roundingRule))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRoundingRuleFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/rounding-rule/catalog-rounding-rule-get.md
+++ b/api-reference/catalog/rounding-rule/catalog-rounding-rule-get.md
@@ -52,26 +52,88 @@
     https://**put_your_bitrix24_address**/rest/catalog.roundingRule.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.roundingRule.get',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoundingRuleResult = {
+      roundingRule: {
+        catalogGroupId: number
+        createdBy: number
+        dateCreate: ISODate | null
+        dateModify: ISODate | null
+        id: number
+        modifiedBy: number
+        price: number
+        roundPrecision: number
+        roundType: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RoundingRuleResult>({
+        method: 'catalog.roundingRule.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.roundingRule.id, result.roundingRule.price, result.roundingRule.roundType)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRoundingRule() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.roundingRule.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.roundingRule.id, result.roundingRule.price, result.roundingRule.roundType)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRoundingRule)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/rounding-rule/catalog-rounding-rule-list.md
+++ b/api-reference/catalog/rounding-rule/catalog-rounding-rule-list.md
@@ -102,56 +102,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.roundingrule.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.roundingrule.list',
-        {
-          select: ['id', 'price', 'roundType'],
-          filter: { 'modifiedBy': 1 },
-          order: { 'id': 'ASC' }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RoundingRuleListResult = {
+      roundingRules: {
+        id: number
+        price: number
+        roundType: number
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('catalog.roundingrule.list', {
-        select: ['id', 'price', 'roundType'],
-        filter: { 'modifiedBy': 1 },
-        order: { 'id': 'ASC' }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+      // catalog.roundingrule.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<RoundingRuleListResult>({
+        method: 'catalog.roundingrule.list',
+        params: {
+          select: ['id', 'price', 'roundType'],
+          filter: { modifiedBy: 1 },
+          order: { id: 'ASC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.roundingRules.length, result.roundingRules)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.roundingrule.list', {
-        select: ['id', 'price', 'roundType'],
-        filter: { 'modifiedBy': 1 },
-        order: { 'id': 'ASC' }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listRoundingRules() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.roundingrule.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.roundingrule.list',
+            params: {
+              select: ['id', 'price', 'roundType'],
+              filter: { modifiedBy: 1 },
+              order: { id: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.roundingRules.length, result.roundingRules)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listRoundingRules)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/rounding-rule/catalog-rounding-rule-update.md
+++ b/api-reference/catalog/rounding-rule/catalog-rounding-rule-update.md
@@ -75,32 +75,100 @@
     https://**put_your_bitrix24_address**/rest/catalog.roundingRule.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.roundingRule.update', 
-    		{
-    			id: 1,
-    			fields: {
-    				catalogGroupId: 14,
-    				price: 1500,
-    				roundType: 2,
-    				roundPrecision: 10,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateRoundingRuleResult = {
+      roundingRule: {
+        catalogGroupId: number
+        createdBy: number
+        dateCreate: ISODate | null
+        dateModify: ISODate | null
+        id: number
+        modifiedBy: number
+        price: number
+        roundPrecision: number
+        roundType: number
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateRoundingRuleResult>({
+        method: 'catalog.roundingRule.update',
+        params: {
+          id: 1,
+          fields: {
+            catalogGroupId: 14,
+            price: 1500,
+            roundType: 2,
+            roundPrecision: 10,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.roundingRule)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateRoundingRule() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.roundingRule.update',
+            params: {
+              id: 1,
+              fields: {
+                catalogGroupId: 14,
+                price: 1500,
+                roundType: 2,
+                roundPrecision: 10,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.roundingRule)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateRoundingRule)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/section/catalog-section-add.md
+++ b/api-reference/catalog/section/catalog-section-add.md
@@ -118,36 +118,109 @@
     https://**put_your_bitrix24_address**/rest/catalog.section.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.section.add', 
-    		{
-    			fields: {
-    				name: 'Детские игрушки',
-    				iblockId: 14,
-    				iblockSectionId: 13,
-    				sort: '100',
-    				active: 'Y',
-    				code: 'toys',
-    				xmlId: 'myXmlId',
-    				description: "Товары для детей - игрушки",
-    				descriptionType: "text"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SectionAddResult = {
+      section: {
+        active: string
+        code: string
+        description: string
+        descriptionType: string
+        iblockId: number
+        iblockSectionId: number
+        id: number
+        name: string
+        sort: number
+        xmlId: string
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SectionAddResult>({
+        method: 'catalog.section.add',
+        params: {
+          fields: {
+            name: "Kids Toys",
+            iblockId: 14,
+            iblockSectionId: 13,
+            sort: '100',
+            active: 'Y',
+            code: 'toys',
+            xmlId: 'myXmlId',
+            description: "Products for children - toys",
+            descriptionType: "text",
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.section.id, result.section.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCatalogSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.section.add',
+            params: {
+              fields: {
+                name: "Kids Toys",
+                iblockId: 14,
+                iblockSectionId: 13,
+                sort: '100',
+                active: 'Y',
+                code: 'toys',
+                xmlId: 'myXmlId',
+                description: "Products for children - toys",
+                descriptionType: "text",
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.section.id, result.section.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCatalogSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/section/catalog-section-delete.md
+++ b/api-reference/catalog/section/catalog-section-delete.md
@@ -52,33 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.section.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.section.delete',
-    		{
-    			id: 31
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.log(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.section.delete',
+        params: {
+          id: 31,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Section deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCatalogSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.section.delete',
+            params: {
+              id: 31,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Section deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCatalogSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/section/catalog-section-get-fields.md
+++ b/api-reference/catalog/section/catalog-section-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.section.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.section.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SectionFieldsResult = {
+      section: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SectionFieldsResult>({
+        method: 'catalog.section.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.section)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSectionFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.section.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.section)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSectionFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/section/catalog-section-get.md
+++ b/api-reference/catalog/section/catalog-section-get.md
@@ -52,26 +52,89 @@
     https://**put_your_bitrix24_address**/rest/catalog.section.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.section.get',
-    		{
-    			id: 31
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogSectionGetResult = {
+      section: {
+        active: string
+        code: string
+        description: string
+        descriptionType: string
+        iblockId: number
+        iblockSectionId: number
+        id: number
+        name: string
+        sort: number
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogSectionGetResult>({
+        method: 'catalog.section.get',
+        params: {
+          id: 31,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.section.id, result.section.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCatalogSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.section.get',
+            params: {
+              id: 31,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.section.id, result.section.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCatalogSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/section/catalog-section-list.md
+++ b/api-reference/catalog/section/catalog-section-list.md
@@ -119,51 +119,108 @@
     https://**put_your_bitrix24_address**/rest/catalog.section.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'catalog.section.list',
-        {
-          select: ["id", "name", "sort"],
-          filter: {
-            'iblockId': 14,
-            '<=sort': 100
-          },
-          order: {'sort': 'DESC'}
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogSectionListResult = {
+      sections: {
+        id: number
+        name: string
+        sort: number
+      }[]
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('catalog.section.list', { select: ["id", "name", "sort"], filter: { 'iblockId': 14, '<=sort': 100 }, order: {'sort': 'DESC'} }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // catalog.section.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CatalogSectionListResult>({
+        method: 'catalog.section.list',
+        params: {
+          select: ['id', 'name', 'sort'],
+          filter: {
+            iblockId: 14,
+            '<=sort': 100,
+          },
+          order: {
+            sort: 'DESC',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sections on this page:', result.sections.length, result.sections)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.section.list', { select: ["id", "name", "sort"], filter: { 'iblockId': 14, '<=sort': 100 }, order: {'sort': 'DESC'} }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCatalogSections() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.section.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.section.list',
+            params: {
+              select: ['id', 'name', 'sort'],
+              filter: {
+                iblockId: 14,
+                '<=sort': 100,
+              },
+              order: {
+                sort: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sections on this page:', result.sections.length, result.sections)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCatalogSections)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/section/catalog-section-update.md
+++ b/api-reference/catalog/section/catalog-section-update.md
@@ -107,32 +107,101 @@
     https://**put_your_bitrix24_address**/rest/catalog.section.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.section.update', 
-    		{
-    			id: 32,
-    			fields: {
-    				iblockId: 14,
-    				name: 'Детские игрушки',
-    				description: "<H1>Детские игрушки</H1> <p>Товары для детей</p>",
-    				descriptionType: "html"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogSectionUpdateResult = {
+      section: {
+        active: string
+        code: string
+        description: string
+        descriptionType: string
+        iblockId: number
+        iblockSectionId: number
+        id: number
+        name: string
+        sort: number
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogSectionUpdateResult>({
+        method: 'catalog.section.update',
+        params: {
+          id: 32,
+          fields: {
+            iblockId: 14,
+            name: 'Toy products for children',
+            description: '<H1>Toy products for children</H1> <p>Products for kids</p>',
+            descriptionType: 'html',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated section:', result.section.id, result.section.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCatalogSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.section.update',
+            params: {
+              id: 32,
+              fields: {
+                iblockId: 14,
+                name: 'Toy products for children',
+                description: '<H1>Toy products for children</H1> <p>Products for kids</p>',
+                descriptionType: 'html',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated section:', result.section.id, result.section.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCatalogSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store-product/catalog-store-product-get-fields.md
+++ b/api-reference/catalog/store-product/catalog-store-product-get-fields.md
@@ -45,23 +45,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.storeproduct.getFields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-      const response = await $b24.callMethod(
-        'catalog.storeproduct.getFields',
-        {}
-      );
-      
-      const result = response.getData().result;
-      console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-      console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreProductFieldsResult = {
+      storeProduct: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreProductFieldsResult>({
+        method: 'catalog.storeproduct.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.storeProduct))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStoreProductFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.storeproduct.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.storeProduct))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStoreProductFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store-product/catalog-store-product-get.md
+++ b/api-reference/catalog/store-product/catalog-store-product-get.md
@@ -52,25 +52,84 @@
     https://**put_your_bitrix24_address**/rest/catalog.storeproduct.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.storeproduct.get',
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreProductGetResult = {
+      storeProduct: {
+        amount: number
+        id: number
+        productId: number
+        quantityReserved: number | null
+        storeId: number
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreProductGetResult>({
+        method: 'catalog.storeproduct.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.storeProduct)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStoreProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.storeproduct.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.storeProduct)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStoreProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store-product/catalog-store-product-list.md
+++ b/api-reference/catalog/store-product/catalog-store-product-list.md
@@ -90,87 +90,117 @@
     https://**put_your_bitrix24_address**/rest/catalog.storeproduct.list
     ```
 
-- JS
-  
-    ```javascript
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+- JS (TS)
+
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreProductListResult = {
+      storeProducts: {
+        id: number
+        productId: number
+        storeId: number
+        amount: number
+      }[]
+    }
 
     try {
-    const response = await $b24.callListMethod(
-        'catalog.storeproduct.list',
-        {
-        select: [
+      // catalog.storeproduct.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<StoreProductListResult>({
+        method: 'catalog.storeproduct.list',
+        params: {
+          select: [
             'id',
             'productId',
             'storeId',
-            'amount'
-        ],
-        filter: {
-            'productId': 6973
+            'amount',
+          ],
+          filter: {
+            productId: 6973,
+          },
+          order: {
+            id: 'ASC',
+          },
+          start: 0,
         },
-        order: {
-            'id': 'ASC'
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Store products count:', result.storeProducts.length, result.storeProducts)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchStoreProducts() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.storeproduct.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.storeproduct.list',
+            params: {
+              select: [
+                'id',
+                'productId',
+                'storeId',
+                'amount',
+              ],
+              filter: {
+                productId: 6973,
+              },
+              order: {
+                id: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Store products count:', result.storeProducts.length, result.storeProducts)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-        },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+      }
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
-
-    try {
-    const generator = $b24.fetchListMethod('catalog.storeproduct.list', {
-        select: [
-        'id',
-        'productId',
-        'storeId',
-        'amount'
-        ],
-        filter: {
-        'productId': 6973
-        },
-        order: {
-        'id': 'ASC'
-        }
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
-
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-    const response = await $b24.callMethod('catalog.storeproduct.list', {
-        select: [
-        'id',
-        'productId',
-        'storeId',
-        'amount'
-        ],
-        filter: {
-        'productId': 6973
-        },
-        order: {
-        'id': 'ASC'
-        }
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+      document.addEventListener('DOMContentLoaded', fetchStoreProducts)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store/catalog-store-add.md
+++ b/api-reference/catalog/store/catalog-store-add.md
@@ -113,49 +113,149 @@
     https://**put_your_bitrix24_address**/rest/catalog.store.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.store.add',
-    		{
-    			fields: {
-    				'address': 'пр. Московский д. 52',
-    				'title': 'Склад 1',
-    				'active': 'Y',
-    				'description': 'Описание',
-    				'gpsN': '54.71411',
-    				'gpsS': '21.56675',
-    				'imageId': {
-    					'fileData': ['detailPicture.png','iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
-    				},
-    				'dateModify': '2024-10-21T10:00:00',
-    				'dateCreate': '2024-10-21T10:00:00',
-    				'userId': 1,
-    				'modifiedBy': 1,
-    				'phone': '8 (495) 212 85 06',
-    				'schedule': 'Пн.-Пт. с 9:00 до 20:00, Сб.-Вс. с 11:00 до 18:00',
-    				'xmlId': '',
-    				'sort': 100,
-    				'email': 'test@test.ru',
-    				'issuingCenter': 'N',
-    				'code': 'store_1',
-    			},
-    		}
-    	);
-    	
-    	if(response.error())
-    		console.error(response.error());
-    	else
-    		console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreAddResult = {
+      store: {
+        active: string
+        address: string
+        code: string
+        dateCreate: ISODate
+        dateModify: ISODate
+        description: string
+        email: string
+        gpsN: number
+        gpsS: number
+        id: number
+        imageId: {
+          id: number
+          url: string
+        }
+        issuingCenter: string
+        modifiedBy: number
+        phone: string
+        schedule: string
+        sort: number
+        title: string
+        userId: number
+        xmlId: string | null
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreAddResult>({
+        method: 'catalog.store.add',
+        params: {
+          fields: {
+            address: 'Moscow Ave., 52',
+            title: 'Warehouse 1',
+            active: 'Y',
+            description: 'Description',
+            gpsN: '54.71411',
+            gpsS: '21.56675',
+            imageId: {
+              fileData: [
+                'detailPicture.png',
+                'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+              ],
+            },
+            dateModify: '2024-10-21T10:00:00',
+            dateCreate: '2024-10-21T10:00:00',
+            userId: 1,
+            modifiedBy: 1,
+            phone: '8 (495) 212 85 06',
+            schedule: 'Mon-Fri 9:00-20:00, Sat-Sun 11:00-18:00',
+            xmlId: '',
+            sort: 100,
+            email: 'test@test.ru',
+            issuingCenter: 'N',
+            code: 'store_1',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.store.id, result.store.title, result.store.address)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addStore() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.store.add',
+            params: {
+              fields: {
+                address: 'Moscow Ave., 52',
+                title: 'Warehouse 1',
+                active: 'Y',
+                description: 'Description',
+                gpsN: '54.71411',
+                gpsS: '21.56675',
+                imageId: {
+                  fileData: [
+                    'detailPicture.png',
+                    'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC',
+                  ],
+                },
+                dateModify: '2024-10-21T10:00:00',
+                dateCreate: '2024-10-21T10:00:00',
+                userId: 1,
+                modifiedBy: 1,
+                phone: '8 (495) 212 85 06',
+                schedule: 'Mon-Fri 9:00-20:00, Sat-Sun 11:00-18:00',
+                xmlId: '',
+                sort: 100,
+                email: 'test@test.ru',
+                issuingCenter: 'N',
+                code: 'store_1',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.store.id, result.store.title, result.store.address)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addStore)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store/catalog-store-delete.md
+++ b/api-reference/catalog/store/catalog-store-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.store.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.store.delete',
-    		{
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.store.delete',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Store deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteStore() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.store.delete',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Store deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteStore)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store/catalog-store-get-fields.md
+++ b/api-reference/catalog/store/catalog-store-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.store.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.store.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreFieldsResult = {
+      store: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreFieldsResult>({
+        method: 'catalog.store.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Store fields:', Object.keys(result.store))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStoreFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.store.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Store fields:', Object.keys(result.store))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStoreFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store/catalog-store-get.md
+++ b/api-reference/catalog/store/catalog-store-get.md
@@ -54,25 +54,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.store.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.store.get', {
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreGetResult = {
+      store: {
+        active: string
+        address: string
+        code: string
+        dateCreate: ISODate | null
+        dateModify: ISODate | null
+        description: string
+        email: string
+        gpsN: number
+        gpsS: number
+        id: number
+        imageId: { id: number; url: string } | null
+        issuingCenter: string
+        modifiedBy: number
+        phone: string
+        schedule: string
+        sort: number
+        title: string
+        userId: number
+        xmlId: string | null
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreGetResult>({
+        method: 'catalog.store.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.store.id, result.store.title, result.store.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStore() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.store.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.store.id, result.store.title, result.store.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStore)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store/catalog-store-list.md
+++ b/api-reference/catalog/store/catalog-store-list.md
@@ -100,96 +100,164 @@
     https://**put_your_bitrix24_address**/rest/catalog.store.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const selectFields = [
-        'id',
-        'title',
-        'active',
-        'address',
-        'description',
-        'gpsN',
-        'gpsS',
-        'imageId',
-        'dateModify',
-        'dateCreate',
-        'userId',
-        'modifiedBy',
-        'phone',
-        'schedule',
-        'xmlId',
-        'sort',
-        'email',
-        'issuingCenter',
-        'code',
-    ];
-    
-    try {
-        const response = await $b24.callListMethod(
-            'catalog.store.list',
-            {
-                select: selectFields,
-                filter: {
-                    '@userId': [1, 2],
-                    '<sort': 200,
-                    'modifiedBy': 1,
-                },
-                order: {
-                    id: 'desc',
-                },
-            },
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreResult = {
+      id: number
+      title: string
+      active: string
+      address: string
+      description: string
+      gpsN: number
+      gpsS: number
+      imageId: { id: number; url: string } | null
+      dateModify: ISODate | null
+      dateCreate: ISODate | null
+      userId: number
+      modifiedBy: number
+      phone: string
+      schedule: string
+      xmlId: string | null
+      sort: number
+      email: string
+      issuingCenter: string
+      code: string | null
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-        const generator = $b24.fetchListMethod('catalog.store.list', {
-            select: selectFields,
-            filter: {
+      // catalog.store.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<{ stores: StoreResult[] }>({
+        method: 'catalog.store.list',
+        params: {
+          select: [
+            'id',
+            'title',
+            'active',
+            'address',
+            'description',
+            'gpsN',
+            'gpsS',
+            'imageId',
+            'dateModify',
+            'dateCreate',
+            'userId',
+            'modifiedBy',
+            'phone',
+            'schedule',
+            'xmlId',
+            'sort',
+            'email',
+            'issuingCenter',
+            'code',
+          ],
+          filter: {
+            '@userId': [1, 2],
+            '<sort': 200,
+            modifiedBy: 1,
+          },
+          order: {
+            id: 'desc',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Stores count:', result.stores.length, 'First store:', result.stores[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getStoreList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.store.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.store.list',
+            params: {
+              select: [
+                'id',
+                'title',
+                'active',
+                'address',
+                'description',
+                'gpsN',
+                'gpsS',
+                'imageId',
+                'dateModify',
+                'dateCreate',
+                'userId',
+                'modifiedBy',
+                'phone',
+                'schedule',
+                'xmlId',
+                'sort',
+                'email',
+                'issuingCenter',
+                'code',
+              ],
+              filter: {
                 '@userId': [1, 2],
                 '<sort': 200,
-                'modifiedBy': 1,
-            },
-            order: {
+                modifiedBy: 1,
+              },
+              order: {
                 id: 'desc',
+              },
+              start: 0,
             },
-        }, 'id');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Stores count:', result.stores.length, 'First store:', result.stores[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-        const response = await $b24.callMethod('catalog.store.list', {
-            select: selectFields,
-            filter: {
-                '@userId': [1, 2],
-                '<sort': 200,
-                'modifiedBy': 1,
-            },
-            order: {
-                id: 'desc',
-            },
-        }, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', getStoreList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/store/catalog-store-update.md
+++ b/api-reference/catalog/store/catalog-store-update.md
@@ -111,54 +111,142 @@
     https://**put_your_bitrix24_address**/rest/catalog.store.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.store.update',
-    		{
-    			id: 1,
-    			fields: {
-    				'address': 'пр. Московский д. 52',
-    				'title': 'Склад 1',
-    				'active': 'Y',
-    				'description': 'Описание',
-    				'gpsN': '54.71411',
-    				'gpsS': '21.56675',
-    				'imageId': {
-    					'fileData': ['detailPicture.png','iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
-    				},
-    				'dateModify': '2024-10-21T10:00:00',
-    				'dateCreate': '2024-10-21T10:00:00',
-    				'userId': 1,
-    				'modifiedBy': 1,
-    				'phone': '8 (495) 212 85 06',
-    				'schedule': 'Пн.-Пт. с 9:00 до 20:00, Сб.-Вс. с 11:00 до 18:00',
-    				'xmlId': '',
-    				'sort': 100,
-    				'email': 'test@test.ru',
-    				'issuingCenter': 'N',
-    				'code': 'store_1',
-    			},
-    		}
-    	);
-    	
-    	if(response.error())
-    	{
-    		console.error(response.error());
-    	}
-    	else
-    	{
-    		console.log(response.getData().result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StoreUpdateResult = {
+      store: {
+        active: string
+        address: string
+        code: string
+        dateCreate: ISODate | null
+        dateModify: ISODate | null
+        description: string
+        email: string
+        gpsN: number
+        gpsS: number
+        id: number
+        imageId: { id: number; url: string }
+        issuingCenter: string
+        modifiedBy: number
+        phone: string
+        schedule: string
+        sort: number
+        title: string
+        userId: number
+        xmlId: string | null
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<StoreUpdateResult>({
+        method: 'catalog.store.update',
+        params: {
+          id: 1,
+          fields: {
+            address: 'Moscow Ave, 52',
+            title: 'Warehouse 1',
+            active: 'Y',
+            description: 'Description',
+            gpsN: '54.71411',
+            gpsS: '21.56675',
+            imageId: {
+              fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+            },
+            dateModify: '2024-10-21T10:00:00',
+            dateCreate: '2024-10-21T10:00:00',
+            userId: 1,
+            modifiedBy: 1,
+            phone: '8 (495) 212 85 06',
+            schedule: 'Mon-Fri 9:00-20:00, Sat-Sun 11:00-18:00',
+            xmlId: '',
+            sort: 100,
+            email: 'test@test.ru',
+            issuingCenter: 'N',
+            code: 'store_1',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.store.id, result.store.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateStore() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.store.update',
+            params: {
+              id: 1,
+              fields: {
+                address: 'Moscow Ave, 52',
+                title: 'Warehouse 1',
+                active: 'Y',
+                description: 'Description',
+                gpsN: '54.71411',
+                gpsS: '21.56675',
+                imageId: {
+                  fileData: ['detailPicture.png', 'iVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BMVEX37ff/­///58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7EAAAOxAGV­Kw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCocSfQFGKP3­+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA/q2TwrXZ­ib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt3qSQtwdJ­Ssku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+28tICq4rT­qXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQEFhV3CCN­Tph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKrihqje7Y9­iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guvayybW1i3­Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWtJSyP21r+­FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0hPtw86hMX­99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xfAAAAAElF­TkSuQmCCiVBORw0KGgoAAAANSUhEUgAAAMgAAADIBAMAAABfdrOtAAAAG1BM­VEX37ff////58fn9+v3+/P779vv8+Pz47/j68/oDfe+3AAAACXBIWXMAAA7E­AAAOxAGVKw4bAAABrUlEQVR4nO3UT0/CMBjH8ccx2I56IFynkHg1SgxHHCoc­SfQFGKP3+e++xL1wn7bPUCAeKF5Mvp+EluX3ZN3ariIAAAAAAAAAAAAAAAAA­/q2TwrXZib94LTbj5GdgVbtKxhdXS+2uL270ajQbL9fz4WzcXwVWtbNeIdmt­3qSQtwdJSsku1/NHkfdVEKriHFey0G4haS3+ty4ZtEGoipMW+VS7T2m0zc+2­8tICq4rTqXtuJV7kWdvsUJtuoc1Hm08ssKo4B1Wn1i6tJu5qrj9dA8lWEzOQ­EFhV3CCNTph2naJ0V+eu0SV+ry3WWQqBVcUNsgiP16ndS4SnzuffL5LWEgKr­ihqje7Y9iDTN6mZ38geDNNX2dEm338b5XPafrmRuj/dj4fULfGoXeFTJ/guv­ayybW1i3Vl7aM7h+3y2c+y07FfeZjaT9GHVrNYXPG/fkIbCqCPf+9d1WKiWt­JSyP21r+FaTrZ8+CULW7XliCUe0PyIUdkD29qQzdv7A0FoSq3R0fqaU78d0h­Ptw86hMX99vAqqJlp757/W3vhMCqAAAAAAAAAAAAAAAAAPxbX82/SILlk9xf­AAAAAElFTkSuQmCC'],
+                },
+                dateModify: '2024-10-21T10:00:00',
+                dateCreate: '2024-10-21T10:00:00',
+                userId: 1,
+                modifiedBy: 1,
+                phone: '8 (495) 212 85 06',
+                schedule: 'Mon-Fri 9:00-20:00, Sat-Sun 11:00-18:00',
+                xmlId: '',
+                sort: 100,
+                email: 'test@test.ru',
+                issuingCenter: 'N',
+                code: 'store_1',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.store.id, result.store.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateStore)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/userfield-document/catalog-userfield-document-list.md
+++ b/api-reference/catalog/userfield-document/catalog-userfield-document-list.md
@@ -98,58 +98,98 @@
     https://**put_your_bitrix24_address**/rest/catalog.userfield.document.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserfieldDocumentListResult = {
+      documents: Array<{
+        documentId: number
+        documentType: string
+        field7097: string
+      }>
+    }
+
+    // catalog.userfield.document.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-    const response = await $b24.callListMethod(
-        'catalog.userfield.document.list',
-        {
-        select: ['documentType', 'documentId', 'field7097'],
-        filter: { documentType: 'A', documentId: 81 },
-        order: { documentId: 'ASC' },
-        start: 0
+      const response = await $b24.actions.v2.call.make<UserfieldDocumentListResult>({
+        method: 'catalog.userfield.document.list',
+        params: {
+          select: ['documentType', 'documentId', 'field7097'],
+          filter: { documentType: 'A', documentId: 81 },
+          order: { documentId: 'ASC' },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.documents, `page size: ${result.documents.length}`)
+      }
     } catch (error) {
-    console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
+- JS (UMD)
 
-    try {
-    const generator = $b24.fetchListMethod('catalog.userfield.document.list', {
-        select: ['documentType', 'documentId', 'field7097'],
-        filter: { documentType: 'A', documentId: 81 },
-        order: { documentId: 'ASC' },
-        start: 0
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listUserfieldDocuments() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
+          // catalog.userfield.document.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.userfield.document.list',
+            params: {
+              select: ['documentType', 'documentId', 'field7097'],
+              filter: { documentType: 'A', documentId: 81 },
+              order: { documentId: 'ASC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-    try {
-    const response = await $b24.callMethod('catalog.userfield.document.list', {
-        select: ['documentType', 'documentId', 'field7097'],
-        filter: { documentType: 'A', documentId: 81 },
-        order: { documentId: 'ASC' },
-        start: 0
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-    console.error('Request failed', error)
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.documents, `page size: ${result.documents.length}`)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listUserfieldDocuments)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/userfield-document/catalog-userfield-document-update.md
+++ b/api-reference/catalog/userfield-document/catalog-userfield-document-update.md
@@ -72,29 +72,90 @@
     https://**put_your_bitrix24_address**/rest/catalog.userfield.document.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'catalog.userfield.document.update',
-            {
-                documentId: 81,
-                fields: {
-                    documentType: 'A',
-                    field7097: 'Тестовое поле',
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log(result.document);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateUserfieldDocumentResult = {
+      document: {
+        documentId: number
+        documentType: string
+        [field: string]: unknown
+      }
     }
-    catch (error)
-    {
-        console.error('Error updating document user fields:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateUserfieldDocumentResult>({
+        method: 'catalog.userfield.document.update',
+        params: {
+          documentId: 81,
+          fields: {
+            documentType: 'A',
+            field7097: 'Test field value',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateUserfieldDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.userfield.document.update',
+            params: {
+              documentId: 81,
+              fields: {
+                documentType: 'A',
+                field7097: 'Test field value',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.document)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateUserfieldDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/vat/catalog-vat-add.md
+++ b/api-reference/catalog/vat/catalog-vat-add.md
@@ -77,31 +77,95 @@
     https://**put_your_bitrix24_address**/rest/catalog.vat.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.vat.add',
-    		{
-    			fields: {
-    				name: 'Налог 13%',
-    				rate: 13,
-    				sort: 10,
-    				active: "Y",
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogVatAddResult = {
+      vat: {
+        active: string
+        id: number
+        name: string
+        rate: number
+        sort: number
+        timestampX: ISODate
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogVatAddResult>({
+        method: 'catalog.vat.add',
+        params: {
+          fields: {
+            name: 'Tax 13%',
+            rate: 13,
+            sort: 10,
+            active: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added VAT rate:', result.vat.id, result.vat.name, result.vat.rate)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addVatRate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.vat.add',
+            params: {
+              fields: {
+                name: 'Tax 13%',
+                rate: 13,
+                sort: 10,
+                active: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added VAT rate:', result.vat.id, result.vat.name, result.vat.rate)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addVatRate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/vat/catalog-vat-delete.md
+++ b/api-reference/catalog/vat/catalog-vat-delete.md
@@ -52,33 +52,73 @@
     https://**put_your_bitrix24_address**/rest/catalog.vat.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.vat.delete',
-    		{
-    			id: 7
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.log(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'catalog.vat.delete',
+        params: {
+          id: 7,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('VAT rate deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteVat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.vat.delete',
+            params: {
+              id: 7,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('VAT rate deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteVat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/vat/catalog-vat-get-fields.md
+++ b/api-reference/catalog/vat/catalog-vat-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/catalog.vat.getFields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.vat.getFields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type VatFieldDescriptor = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogVatGetFieldsResult = {
+      vat: Record<string, VatFieldDescriptor>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogVatGetFieldsResult>({
+        method: 'catalog.vat.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.vat), result.vat)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getVatFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.vat.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.vat), result.vat)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getVatFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/vat/catalog-vat-get.md
+++ b/api-reference/catalog/vat/catalog-vat-get.md
@@ -52,26 +52,85 @@
     https://**put_your_bitrix24_address**/rest/catalog.vat.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.vat.get',
-    		{
-    			id: 7
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type VatGetResult = {
+      vat: {
+        active: string
+        id: number
+        name: string
+        rate: number
+        sort: number
+        timestampX: ISODate | null
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<VatGetResult>({
+        method: 'catalog.vat.get',
+        params: {
+          id: 7,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.vat.id, result.vat.name, result.vat.rate)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getVat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.vat.get',
+            params: {
+              id: 7,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.vat.id, result.vat.name, result.vat.rate)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getVat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/vat/catalog-vat-list.md
+++ b/api-reference/catalog/vat/catalog-vat-list.md
@@ -102,80 +102,114 @@
     https://**put_your_bitrix24_address**/rest/catalog.vat.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogVatListResult = {
+      vats: {
+        id: number
+        name: string
+        rate: number
+      }[]
+    }
+
+    // catalog.vat.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-      const response = await $b24.callListMethod(
-        'catalog.vat.list',
-        {
+      const response = await $b24.actions.v2.call.make<CatalogVatListResult>({
+        method: 'catalog.vat.list',
+        params: {
           select: [
             'id',
             'name',
-            'rate'
+            'rate',
           ],
           filter: {
-            '>=sort': 200
+            '>=sort': 200,
           },
           order: {
-            'id': "ASC"
-          }
+            id: 'ASC',
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('catalog.vat.list', {
-        select: [
-          'id',
-          'name',
-          'rate'
-        ],
-        filter: {
-          '>=sort': 200
-        },
-        order: {
-          'id': "ASC"
-        }
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('VAT rates:', result.vats, 'count:', result.vats.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('catalog.vat.list', {
-        select: [
-          'id',
-          'name',
-          'rate'
-        ],
-        filter: {
-          '>=sort': 200
-        },
-        order: {
-          'id': "ASC"
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchVatList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // catalog.vat.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.vat.list',
+            params: {
+              select: [
+                'id',
+                'name',
+                'rate',
+              ],
+              filter: {
+                '>=sort': 200,
+              },
+              order: {
+                id: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('VAT rates:', result.vats, 'count:', result.vats.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchVatList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/catalog/vat/catalog-vat-update.md
+++ b/api-reference/catalog/vat/catalog-vat-update.md
@@ -75,32 +75,97 @@
     https://**put_your_bitrix24_address**/rest/catalog.vat.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'catalog.vat.update', 
-    		{
-    			id: 6,
-    			fields: {
-    				name: "Налог 23%",
-    				rate: 23,
-    				sort: 20,
-    				active: "Y"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CatalogVatUpdateResult = {
+      vat: {
+        active: string
+        id: number
+        name: string
+        rate: number
+        sort: number
+        timestampX: ISODate | null
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CatalogVatUpdateResult>({
+        method: 'catalog.vat.update',
+        params: {
+          id: 6,
+          fields: {
+            name: 'Tax 23%',
+            rate: 23,
+            sort: 20,
+            active: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.vat)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateVat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'catalog.vat.update',
+            params: {
+              id: 6,
+              fields: {
+                name: 'Tax 23%',
+                rate: 23,
+                sort: 20,
+                active: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.vat)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateVat)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<раздел>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced
  by `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, structural check).
- One section per PR to keep review small.

No breaking changes — documentation examples only.