### PR TITLE
docs(crm/automated-solution): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/automated-solution/crm-automated-solution-add.md
+++ b/api-reference/crm/automated-solution/crm-automated-solution-add.md
@@ -91,29 +91,88 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.add
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.automatedsolution.add',
-            {
-                "fields": {
-                    "title": "HR",
-                    "typeIds": [
-                        1,
-                        2,
-                        3
-                    ]
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionAddResult = {
+          automatedSolution: {
+            id: number
+            title: string
+            typeIds: number[]
+          }
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionAddResult>({
+            method: 'crm.automatedsolution.add',
+            params: {
+              fields: {
+                title: 'HR',
+                typeIds: [1, 2, 3],
+              },
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolution)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function addAutomatedSolution() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.add',
+                params: {
+                  fields: {
+                    title: 'HR',
+                    typeIds: [1, 2, 3],
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolution)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', addAutomatedSolution)
+        </script>
         ```
 
     - PHP
@@ -194,24 +253,86 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.add
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.automatedsolution.add',
-            {
-                "fields": {
-                    "title": "HR"
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionAddResult = {
+          automatedSolution: {
+            id: number
+            title: string
+            typeIds: number[]
+          }
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionAddResult>({
+            method: 'crm.automatedsolution.add',
+            params: {
+              fields: {
+                title: 'HR',
+              },
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolution)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function addAutomatedSolution() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.add',
+                params: {
+                  fields: {
+                    title: 'HR',
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolution)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', addAutomatedSolution)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/automated-solution/crm-automated-solution-delete.md
+++ b/api-reference/crm/automated-solution/crm-automated-solution-delete.md
@@ -56,26 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.automatedsolution.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.automatedsolution.delete',
-    		{
-    			"id": 5
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.automatedsolution.delete',
+        params: {
+          id: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Automated solution deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteAutomatedSolution() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.automatedsolution.delete',
+            params: {
+              id: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Automated solution deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteAutomatedSolution)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/automated-solution/crm-automated-solution-fields.md
+++ b/api-reference/crm/automated-solution/crm-automated-solution-fields.md
@@ -41,24 +41,83 @@
     https://**put_your_bitrix24_address**/rest/crm.automatedsolution.fields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.automatedsolution.fields",
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      upperName: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AutomatedSolutionFieldsResult = Record<string, FieldItem>
+
+    try {
+      const response = await $b24.actions.v2.call.make<AutomatedSolutionFieldsResult>({
+        method: 'crm.automatedsolution.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result), result['title'])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAutomatedSolutionFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.automatedsolution.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result), result['title'])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAutomatedSolutionFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/automated-solution/crm-automated-solution-get.md
+++ b/api-reference/crm/automated-solution/crm-automated-solution-get.md
@@ -50,26 +50,82 @@
     https://**put_your_bitrix24_address**/rest/crm.automatedsolution.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.automatedsolution.get',
-    		{
-    			'id': 393
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AutomatedSolutionGetResult = {
+      automatedSolution: {
+        id: number
+        title: string
+        typeIds: number[]
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AutomatedSolutionGetResult>({
+        method: 'crm.automatedsolution.get',
+        params: {
+          id: 393,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.automatedSolution)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAutomatedSolution() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.automatedsolution.get',
+            params: {
+              id: 393,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.automatedSolution)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAutomatedSolution)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/automated-solution/crm-automated-solution-list.md
+++ b/api-reference/crm/automated-solution/crm-automated-solution-list.md
@@ -97,24 +97,96 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.automatedsolution.list",
-            {
-                "order": {
-                    "id": "DESC",
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type AutomatedSolutionItem = {
+          id: number
+          title: string
+          typeIds: number[]
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionListResult = {
+          automatedSolutions: AutomatedSolutionItem[]
+        }
+
+        // crm.automatedsolution.list returns a single page (max 50 records). For the whole result set
+        // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+        // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+        // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+        // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionListResult>({
+            method: 'crm.automatedsolution.list',
+            params: {
+              order: { id: 'DESC' },
+              start: 0,
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolutions.length, result.automatedSolutions)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function listAutomatedSolutions() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.automatedsolution.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.list',
+                params: {
+                  order: { id: 'DESC' },
+                  start: 0,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolutions.length, result.automatedSolutions)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', listAutomatedSolutions)
+        </script>
         ```
 
     - PHP
@@ -247,24 +319,96 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.automatedsolution.list",
-            {
-                "filter": {
-                    "%=title": "HR%"
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type AutomatedSolutionItem = {
+          id: number
+          title: string
+          typeIds: number[]
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionListResult = {
+          automatedSolutions: AutomatedSolutionItem[]
+        }
+
+        // crm.automatedsolution.list returns a single page (max 50 records). For the whole result set
+        // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+        // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+        // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+        // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionListResult>({
+            method: 'crm.automatedsolution.list',
+            params: {
+              filter: { '%=title': 'HR%' },
+              start: 0,
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolutions.length, result.automatedSolutions)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function listAutomatedSolutionsByTitle() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.automatedsolution.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.list',
+                params: {
+                  filter: { '%=title': 'HR%' },
+                  start: 0,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolutions.length, result.automatedSolutions)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', listAutomatedSolutionsByTitle)
+        </script>
         ```
 
     - PHP
@@ -342,36 +486,112 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.automatedsolution.list",
-            {
-                "order": {
-                    "title": "ASC"
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type AutomatedSolutionItem = {
+          id: number
+          title: string
+          typeIds: number[]
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionListResult = {
+          automatedSolutions: AutomatedSolutionItem[]
+        }
+
+        // crm.automatedsolution.list returns a single page (max 50 records). For the whole result set
+        // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+        // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+        // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+        // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionListResult>({
+            method: 'crm.automatedsolution.list',
+            params: {
+              order: { title: 'ASC' },
+              filter: {
+                '>id': 100,
+                '0': {
+                  logic: 'OR',
+                  '0': { '%=title': 'HR%' },
+                  '1': { '%=title': 'Customer%' },
                 },
-                "filter": {
-                    ">id": 100,
-                    "0": {
-                        "logic": "OR",
-                        "0": {
-                            "%=title": "HR%"
-                        },
-                        "1": {
-                            "%=title": "Customer%"
-                        }
-                    }
-                }
+              },
+              start: 0,
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolutions.length, result.automatedSolutions)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function listFilteredAutomatedSolutions() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.automatedsolution.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.list',
+                params: {
+                  order: { title: 'ASC' },
+                  filter: {
+                    '>id': 100,
+                    '0': {
+                      logic: 'OR',
+                      '0': { '%=title': 'HR%' },
+                      '1': { '%=title': 'Customer%' },
+                    },
+                  },
+                  start: 0,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolutions.length, result.automatedSolutions)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', listFilteredAutomatedSolutions)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/automated-solution/crm-automated-solution-update.md
+++ b/api-reference/crm/automated-solution/crm-automated-solution-update.md
@@ -97,25 +97,88 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.automatedsolution.update',
-            {
-                "id": 238,
-                "fields": {
-                    "title": "HR & Customer Success"
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionUpdateResult = {
+          automatedSolution: {
+            id: number
+            title: string
+            typeIds: number[]
+          }
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionUpdateResult>({
+            method: 'crm.automatedsolution.update',
+            params: {
+              id: 238,
+              fields: {
+                title: 'HR & Customer Success',
+              },
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolution.id, result.automatedSolution.title, result.automatedSolution.typeIds)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateAutomatedSolution() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.update',
+                params: {
+                  id: 238,
+                  fields: {
+                    title: 'HR & Customer Success',
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolution.id, result.automatedSolution.title, result.automatedSolution.typeIds)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', updateAutomatedSolution)
+        </script>
         ```
 
     - PHP
@@ -198,27 +261,88 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.automatedsolution.update',
-            {
-                "id": 238,
-                "fields": {
-                    "typeIds": [
-                        14
-                    ]
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionUpdateResult = {
+          automatedSolution: {
+            id: number
+            title: string
+            typeIds: number[]
+          }
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionUpdateResult>({
+            method: 'crm.automatedsolution.update',
+            params: {
+              id: 238,
+              fields: {
+                typeIds: [14],
+              },
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolution.id, result.automatedSolution.title, result.automatedSolution.typeIds)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateAutomatedSolution() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.update',
+                params: {
+                  id: 238,
+                  fields: {
+                    typeIds: [14],
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolution.id, result.automatedSolution.title, result.automatedSolution.typeIds)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', updateAutomatedSolution)
+        </script>
         ```
 
     - PHP
@@ -301,25 +425,88 @@
         https://**put_your_bitrix24_address**/rest/crm.automatedsolution.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.automatedsolution.update',
-            {
-                "id": 238,
-                "fields": {
-                    "typeIds": []
-                }
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type AutomatedSolutionUpdateResult = {
+          automatedSolution: {
+            id: number
+            title: string
+            typeIds: number[]
+          }
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<AutomatedSolutionUpdateResult>({
+            method: 'crm.automatedsolution.update',
+            params: {
+              id: 238,
+              fields: {
+                typeIds: [],
+              },
             },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error());
-                } else {
-                    console.info(result.data());
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(result.automatedSolution.id, result.automatedSolution.title, result.automatedSolution.typeIds)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateAutomatedSolution() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.automatedsolution.update',
+                params: {
+                  id: 238,
+                  fields: {
+                    typeIds: [],
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(result.automatedSolution.id, result.automatedSolution.title, result.automatedSolution.typeIds)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', updateAutomatedSolution)
+        </script>
         ```
 
     - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.