### PR TITLE
docs(crm/call-list): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/call-list/crm-calllist-add.md
+++ b/api-reference/crm/call-list/crm-calllist-add.md
@@ -57,32 +57,77 @@
          https://**your_bitrix24**/rest/crm.calllist.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.calllist.add',
-    		{
-    			ENTITY_TYPE: 'CONTACT',
-    			ENTITIES: [9, 17, 19],
-    			WEBFORM_ID: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error()) {
-    		console.error(result.error());
-    	} else {
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.calllist.add',
+        params: {
+          ENTITY_TYPE: 'CONTACT',
+          ENTITIES: [9, 17, 19],
+          WEBFORM_ID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created call list ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCallList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.calllist.add',
+            params: {
+              ENTITY_TYPE: 'CONTACT',
+              ENTITIES: [9, 17, 19],
+              WEBFORM_ID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created call list ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCallList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/call-list/crm-calllist-get.md
+++ b/api-reference/crm/call-list/crm-calllist-get.md
@@ -50,31 +50,83 @@
          https://**your_bitrix24**/rest/crm.calllist.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.calllist.get',
-    		{ ID: 123 }
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CallListGetResult = {
+      ID: string
+      DATE_CREATE: ISODate | null
+      CREATED_BY_ID: string
+      WEBFORM_ID: string
+      ENTITY_TYPE_ID: string
+      ENTITY_TYPE: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CallListGetResult>({
+        method: 'crm.calllist.get',
+        params: {
+          ID: 123,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.ENTITY_TYPE, result.DATE_CREATE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCallList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.calllist.get',
+            params: {
+              ID: 123,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.ENTITY_TYPE, result.DATE_CREATE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCallList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/call-list/crm-calllist-items-get.md
+++ b/api-reference/crm/call-list/crm-calllist-items-get.md
@@ -53,29 +53,86 @@
          https://**your_bitrix24**/rest/crm.calllist.items.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.calllist.items.get",
-    		{
-    			LIST_ID: 13,
-    			FILTER: {
-    				STATUS: "IN_WORK"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type CallListItem = {
+      ID: number,
+      STATUS: string,
+      ENTITY_TYPE: number,
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CallListItem[]>({
+        method: 'crm.calllist.items.get',
+        params: {
+          LIST_ID: 13,
+          FILTER: {
+            STATUS: 'IN_WORK',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call list items count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCallListItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.calllist.items.get',
+            params: {
+              LIST_ID: 13,
+              FILTER: {
+                STATUS: 'IN_WORK',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call list items count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCallListItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/call-list/crm-calllist-list.md
+++ b/api-reference/crm/call-list/crm-calllist-list.md
@@ -97,48 +97,95 @@
     curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -d '{"SELECT":["ID","CREATED_BY_ID"],"FILTER":{"ENTITY_TYPE_ID":3},"ORDER":{"ID":"DESC"},"auth":"**put_access_token_here**"}' https://**put_your_bitrix24_address**/rest/crm.calllist.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.calllist.list',
-        {
-          SELECT: ["ID", "CREATED_BY_ID"],
-          FILTER: { "ENTITY_TYPE_ID": 3 },
-          ORDER: { "ID": "DESC" }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type CallListItem = {
+      ID: string
+      CREATED_BY_ID: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
+    // crm.calllist.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
     try {
-      const generator = $b24.fetchListMethod('crm.calllist.list', { SELECT: ["ID", "CREATED_BY_ID"], FILTER: { "ENTITY_TYPE_ID": 3 }, ORDER: { "ID": "DESC" } }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      const response = await $b24.actions.v2.call.make<CallListItem[]>({
+        method: 'crm.calllist.list',
+        params: {
+          SELECT: ['ID', 'CREATED_BY_ID'],
+          FILTER: { ENTITY_TYPE_ID: 3 },
+          ORDER: { ID: 'DESC' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call lists fetched:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.calllist.list', { SELECT: ["ID", "CREATED_BY_ID"], FILTER: { "ENTITY_TYPE_ID": 3 }, ORDER: { "ID": "DESC" } }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCallLists() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.calllist.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.calllist.list',
+            params: {
+              SELECT: ['ID', 'CREATED_BY_ID'],
+              FILTER: { ENTITY_TYPE_ID: 3 },
+              ORDER: { ID: 'DESC' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call lists fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCallLists)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/call-list/crm-calllist-statuslist.md
+++ b/api-reference/crm/call-list/crm-calllist-statuslist.md
@@ -45,24 +45,77 @@
          https://**your_bitrix24**/rest/crm.calllist.statuslist
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.calllist.statuslist",
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of each CallListStatus returned in result[]
+    type CallListStatusItem = {
+      ID: number
+      NAME: string
+      SORT: number
+      STATUS_ID: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CallListStatusItem[]>({
+        method: 'crm.calllist.statuslist',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call list statuses:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCallListStatuses() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.calllist.statuslist',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call list statuses:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCallListStatuses)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/call-list/crm-calllist-update.md
+++ b/api-reference/crm/call-list/crm-calllist-update.md
@@ -75,33 +75,79 @@
          https://**your_bitrix24**/rest/crm.calllist.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.calllist.update',
-    		{
-    			LIST_ID: 123,
-    			ENTITY_TYPE: 'CONTACT',
-    			ENTITIES: [1, 2, 3],
-    			WEBFORM_ID: 5
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error()) {
-    		console.error(result.error());
-    	} else {
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.calllist.update',
+        params: {
+          LIST_ID: 123,
+          ENTITY_TYPE: 'CONTACT',
+          ENTITIES: [1, 2, 3],
+          WEBFORM_ID: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Call list updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCallList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.calllist.update',
+            params: {
+              LIST_ID: 123,
+              ENTITY_TYPE: 'CONTACT',
+              ENTITIES: [1, 2, 3],
+              WEBFORM_ID: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Call list updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCallList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/call-list/index.md
+++ b/api-reference/crm/call-list/index.md
@@ -42,101 +42,138 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each activity item returned in result[]
+    type ActivityItem = {
+      ID: string,
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.activity.list',
-        {
+      // crm.activity.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const listResponse = await $b24.actions.v2.call.make<ActivityItem[]>({
+        method: 'crm.activity.list',
+        params: {
           filter: {
-            "SUBJECT": "Обзвон #13",
+            SUBJECT: 'Call list #13',
           },
-          select: ["ID"]
-        }
-      )
-      const deals = response.getData() || []
-    
-      if (deals.length === 0) {
-        console.log("Дел с названием 'Обзвон #13' не найдено.");
-        return;
-      }
-    
-      let dealId = deals[0].ID;
-    
-      await $b24.callMethod(
-        'crm.activity.delete',
-        {
-          id: dealId,
-        }
-      )
-      console.log("Дело ID " + dealId + " успешно удалено.");
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.activity.list', {
-        filter: {
-          "SUBJECT": "Обзвон #13",
+          select: ['ID'],
+          start: 0,
         },
-        select: ["ID"]
-      }, 'ID')
-    
-      for await (const page of generator) {
-        if (page.length === 0) {
-          console.log("Дел с названием 'Обзвон #13' не найдено.");
-          return;
-        }
-    
-        let dealId = page[0].ID;
-    
-        await $b24.callMethod(
-          'crm.activity.delete',
-          {
-            id: dealId,
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!listResponse.isSuccess) {
+        console.error(listResponse.getErrorMessages().join('; '))
+      } else {
+        const activities = listResponse.getData()!.result
+        if (activities.length === 0) {
+          console.info('No activities named "Call list #13" found.')
+        } else {
+          const activityId = activities[0].ID
+
+          const deleteResponse = await $b24.actions.v2.call.make<boolean>({
+            method: 'crm.activity.delete',
+            params: {
+              id: activityId,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!deleteResponse.isSuccess) {
+            console.error(deleteResponse.getErrorMessages().join('; '))
+          } else {
+            const deleted = deleteResponse.getData()!.result
+            console.info('Activity ID', activityId, 'deleted:', deleted)
           }
-        )
-        console.log("Дело ID " + dealId + " успешно удалено.");
-      }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.activity.list', {
-        filter: {
-          "SUBJECT": "Обзвон #13",
-        },
-        select: ["ID"]
-      }, 0)
-    
-      const deals = response.getData().result || []
-    
-      if (deals.length === 0) {
-        console.log("Дел с названием 'Обзвон #13' не найдено.");
-        return;
-      }
-    
-      let dealId = deals[0].ID;
-    
-      await $b24.callMethod(
-        'crm.activity.delete',
-        {
-          id: dealId,
         }
-      )
-      console.log("Дело ID " + dealId + " успешно удалено.");
+      }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function findAndDeleteActivity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.activity.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const listResponse = await $b24.actions.v2.call.make({
+            method: 'crm.activity.list',
+            params: {
+              filter: {
+                SUBJECT: 'Call list #13',
+              },
+              select: ['ID'],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!listResponse.isSuccess) {
+            console.error(listResponse.getErrorMessages().join('; '))
+            return
+          }
+
+          const activities = listResponse.getData().result
+          if (activities.length === 0) {
+            console.info('No activities named "Call list #13" found.')
+            return
+          }
+
+          const activityId = activities[0].ID
+
+          const deleteResponse = await $b24.actions.v2.call.make({
+            method: 'crm.activity.delete',
+            params: {
+              id: activityId,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!deleteResponse.isSuccess) {
+            console.error(deleteResponse.getErrorMessages().join('; '))
+            return
+          }
+
+          const deleted = deleteResponse.getData().result
+          console.info('Activity ID', activityId, 'deleted:', deleted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', findAndDeleteActivity)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.