### PR TITLE
docs(crm/document-generator): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-add.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-add.md
@@ -135,41 +135,143 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    		const response = await $b24.callMethod(
-    			'crm.documentgenerator.document.add',
-    			{
-    				templateId: 39,
-    				entityTypeId: 2,
-    				entityId: 101,
-    				values: {
-    					DocumentNumber: '2026-001',
-    				},
-    				fields: {
-    					DocumentTitle: {
-    						title: 'Название документа',
-    						value: 'Демонстрационная реализация товара 1',
-    						required: 'Y',
-    						default: 'Демонстрационная реализация товара 1',
-    						chain: [{}, 'getTitle'],
-    						VALUE: 'Тест через fields',
-    					},
-    				},
-    				stampsEnabled: 1,
-    			}
-    		);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentAddResult = {
+      document: {
+        id: number
+        title: string
+        number: string
+        createTime: ISODate
+        updateTime: ISODate
+        createdBy: number
+        updatedBy: number | null
+        changeStampsEnabled: boolean
+        changeStampsDisabledReason: string
+        changeQrCodeEnabled: boolean
+        qrCodeEnabled: boolean
+        changeQrCodeDisabledReason: string
+        products: {
+          currencyId: string
+          totalSum: string
+          totalRows: number
+        }
+        stampsEnabled: boolean
+        downloadUrl: string
+        downloadUrlMachine: string
+        publicUrl: string | null
+        isTransformationError: boolean
+        transformationErrorMessage: string
+        transformationErrorCode: string
+        templateId: string
+        pullTag: string
+        emailDiskFile: number
+        entityTypeId: string
+        entityId: string
+        values: Record<string, unknown>
+        imageUrl: string
+        pdfUrl: string
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentAddResult>({
+        method: 'crm.documentgenerator.document.add',
+        params: {
+          templateId: 39,
+          entityTypeId: 2,
+          entityId: 101,
+          values: {
+            DocumentNumber: '2026-001',
+          },
+          fields: {
+            DocumentTitle: {
+              title: 'Document title',
+              value: 'Demo product delivery 1',
+              required: 'Y',
+              default: 'Demo product delivery 1',
+              chain: [{}, 'getTitle'],
+              VALUE: 'Test via fields',
+            },
+          },
+          stampsEnabled: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document.id, result.document.title, result.document.downloadUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.add',
+            params: {
+              templateId: 39,
+              entityTypeId: 2,
+              entityId: 101,
+              values: {
+                DocumentNumber: '2026-001',
+              },
+              fields: {
+                DocumentTitle: {
+                  title: 'Document title',
+                  value: 'Demo product delivery 1',
+                  required: 'Y',
+                  default: 'Demo product delivery 1',
+                  chain: [{}, 'getTitle'],
+                  VALUE: 'Test via fields',
+                },
+              },
+              stampsEnabled: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.document.id, result.document.title, result.document.downloadUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-delete.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-delete.md
@@ -54,25 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.document.delete',
-    		{
-    			id: 61,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'crm.documentgenerator.document.delete',
+        params: {
+          id: 61,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document deleted, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.delete',
+            params: {
+              id: 61,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document deleted, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-enable-public-url.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-enable-public-url.md
@@ -61,26 +61,80 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.enablepublicurl
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.document.enablepublicurl',
-    		{
-    			id: 61,
-    			status: 1,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EnablePublicUrlResult = {
+      publicUrl: string | null
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<EnablePublicUrlResult>({
+        method: 'crm.documentgenerator.document.enablepublicurl',
+        params: {
+          id: 61,
+          status: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.publicUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function enablePublicUrl() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.enablepublicurl',
+            params: {
+              id: 61,
+              status: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.publicUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', enablePublicUrl)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-get-fields.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-get-fields.md
@@ -102,28 +102,97 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.getfields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.document.getfields',
-    		{
-    			id: 101,
-    			values: {
-    				DocumentNumber: '2026-001',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type DocumentField = {
+      title: string
+      value: string | unknown[] | null
+      default?: string | null
+      required?: string
+      type?: string
+      group?: string[]
+      chain?: string | string[]
+      format?: Record<string, unknown>
+      options?: Record<string, unknown>
+      hideRow?: string
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentFieldsResult = {
+      documentFields: Record<string, DocumentField>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentFieldsResult>({
+        method: 'crm.documentgenerator.document.getfields',
+        params: {
+          id: 101,
+          values: {
+            DocumentNumber: '2026-001',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.documentFields), result.documentFields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocumentFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.getfields',
+            params: {
+              id: 101,
+              values: {
+                DocumentNumber: '2026-001',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.documentFields), result.documentFields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocumentFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-get.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-get.md
@@ -60,25 +60,111 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.document.get',
-    		{
-    			id: 61,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentGetResult = {
+      document: {
+        id: string
+        title: string
+        number: string
+        createTime: ISODate
+        updateTime: ISODate
+        createdBy: string
+        updatedBy: string | null
+        changeStampsEnabled: boolean
+        changeStampsDisabledReason: string
+        changeQrCodeEnabled: boolean
+        qrCodeEnabled: boolean
+        changeQrCodeDisabledReason: string
+        products: {
+          currencyId: string
+          totalSum: string
+          totalRows: number
+        }
+        stampsEnabled: boolean
+        downloadUrl: string
+        downloadUrlMachine: string
+        imageUrl: string
+        imageUrlMachine: string
+        pdfUrl: string
+        pdfUrlMachine: string
+        publicUrl: string | null
+        isTransformationError: boolean
+        templateId: string
+        pullTag: string
+        emailDiskFile: number
+        entityTypeId: string
+        entityId: string
+        values: Record<string, unknown>
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentGetResult>({
+        method: 'crm.documentgenerator.document.get',
+        params: {
+          id: 61,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document.id, result.document.title, result.document.downloadUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.get',
+            params: {
+              id: 61,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.document.id, result.document.title, result.document.downloadUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-list.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-list.md
@@ -121,28 +121,118 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.document.list',
-    		{
-    			select: ['id', 'title', 'number', 'entityId', 'createTime'],
-    			order: { id: 'desc' },
-    			filter: { entityTypeId: 2, entityId: 101 },
-    			start: 0,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type DocumentItem = {
+      id: string
+      title: string
+      number: string
+      templateId: string
+      entityTypeId: string
+      entityId: string
+      fileId: string
+      imageId: string
+      pdfId: string
+      createTime: ISODate
+      updateTime: ISODate
+      createdBy: string | null
+      updatedBy: string | null
+      values: Record<string, unknown> | null
+      downloadUrl: string
+      imageUrl: string
+      pdfUrl: string
+      stampsEnabled: boolean
+      downloadUrlMachine: string
+      pdfUrlMachine: string
+      imageUrlMachine: string
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentListResult = {
+      documents: DocumentItem[]
     }
+
+    try {
+      // crm.documentgenerator.document.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DocumentListResult>({
+        method: 'crm.documentgenerator.document.list',
+        params: {
+          select: ['id', 'title', 'number', 'entityId', 'createTime'],
+          order: { id: 'desc' },
+          filter: { entityTypeId: 2, entityId: 101 },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Documents on this page:', result.documents.length, result.documents)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchDocumentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.documentgenerator.document.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.list',
+            params: {
+              select: ['id', 'title', 'number', 'entityId', 'createTime'],
+              order: { id: 'desc' },
+              filter: { entityTypeId: 2, entityId: 101 },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Documents on this page:', result.documents.length, result.documents)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchDocumentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-update.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-update.md
@@ -88,29 +88,117 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.document.update',
-    		{
-    			id: 61,
-    			values: {
-    				DocumentNumber: '2026-002',
-    			},
-    			stampsEnabled: 1,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentUpdateResult = {
+      document: {
+        id: string
+        title: string
+        number: string
+        createTime: ISODate
+        updateTime: ISODate
+        createdBy: string | null
+        updatedBy: number | null
+        changeStampsEnabled: boolean
+        changeStampsDisabledReason: string
+        changeQrCodeEnabled: boolean
+        qrCodeEnabled: boolean
+        changeQrCodeDisabledReason: string
+        products: {
+          currencyId: string
+          totalSum: string
+          totalRows: number
+        }
+        stampsEnabled: boolean
+        downloadUrl: string
+        downloadUrlMachine: string
+        publicUrl: string | null
+        isTransformationError: boolean
+        templateId: string
+        pullTag: string
+        emailDiskFile: number
+        entityTypeId: string
+        entityId: string
+        values: Record<string, unknown>
+        imageUrl: string
+        pdfUrl: string
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentUpdateResult>({
+        method: 'crm.documentgenerator.document.update',
+        params: {
+          id: 61,
+          values: {
+            DocumentNumber: '2026-002',
+          },
+          stampsEnabled: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document.id, result.document.number, result.document.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.update',
+            params: {
+              id: 61,
+              values: {
+                DocumentNumber: '2026-002',
+              },
+              stampsEnabled: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.document.id, result.document.number, result.document.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/documents/crm-document-generator-document-upload.md
+++ b/api-reference/crm/document-generator/documents/crm-document-generator-document-upload.md
@@ -105,34 +105,125 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.document.upload
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    		const response = await $b24.callMethod(
-    			'crm.documentgenerator.document.upload',
-    			{
-    				fields: {
-    					entityTypeId: 2,
-    					entityId: 101,
-    					fileContent: '**base64_docx_content**',
-    					region: 'ru',
-    					title: 'Демонстрационная реализация товара',
-    					number: '2026-001',
-    					pdfContent: '**base64_pdf_content**',
-    					imageContent: '**base64_image_content**',
-    				},
-    			}
-    		);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentUploadResult = {
+      document: {
+        id: string
+        title: string
+        number: string
+        createTime: ISODate
+        updateTime: ISODate
+        createdBy: string
+        updatedBy: string | null
+        changeStampsEnabled: boolean
+        changeStampsDisabledReason: string
+        changeQrCodeEnabled: boolean
+        qrCodeEnabled: boolean
+        changeQrCodeDisabledReason: string
+        products: {
+          currencyId: string
+          totalSum: string
+          totalRows: number
+        }
+        stampsEnabled: boolean
+        isTransformationError: boolean
+        downloadUrl: string
+        downloadUrlMachine: string
+        publicUrl: string | null
+        templateId: string
+        pullTag: string
+        emailDiskFile: number
+        entityTypeId: string
+        entityId: string
+        values: Record<string, unknown> | null
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentUploadResult>({
+        method: 'crm.documentgenerator.document.upload',
+        params: {
+          fields: {
+            entityTypeId: 2,
+            entityId: 101,
+            fileContent: '**base64_docx_content**',
+            region: 'ru',
+            title: 'Demo Sales Document',
+            number: '2026-001',
+            pdfContent: '**base64_pdf_content**',
+            imageContent: '**base64_image_content**',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.document.id, result.document.title, result.document.downloadUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function uploadDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.document.upload',
+            params: {
+              fields: {
+                entityTypeId: 2,
+                entityId: 101,
+                fileContent: '**base64_docx_content**',
+                region: 'ru',
+                title: 'Demo Sales Document',
+                number: '2026-001',
+                pdfContent: '**base64_pdf_content**',
+                imageContent: '**base64_image_content**',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.document.id, result.document.title, result.document.downloadUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', uploadDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-add.md
+++ b/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-add.md
@@ -120,39 +120,122 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.numerator.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.numerator.add',
-    		{
-    			fields: {
-    				name: 'Нумератор из REST',
-    				template: '{NUMBER}',
-    				settings: {
-    					Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
-    						start: 1,
-    						step: 1,
-    						length: 6,
-    						padString: '0',
-    						periodicBy: '',
-    						timezone: '',
-    						isDirectNumeration: false,
-    					},
-    				},
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorAddResult = {
+      numerator: {
+        id: number
+        name: string
+        template: string
+        code: string | null
+        settings: {
+          Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+            start: number
+            step: number
+            length: number
+            padString: string
+            periodicBy: string | null
+            timezone: string | null
+            isDirectNumeration: boolean
+          }
+        }
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<NumeratorAddResult>({
+        method: 'crm.documentgenerator.numerator.add',
+        params: {
+          fields: {
+            name: 'Numerator from REST',
+            template: '{NUMBER}',
+            settings: {
+              Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                start: 1,
+                step: 1,
+                length: 6,
+                padString: '0',
+                periodicBy: '',
+                timezone: '',
+                isDirectNumeration: false,
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New numerator created:', result.numerator.id, result.numerator.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.numerator.add',
+            params: {
+              fields: {
+                name: 'Numerator from REST',
+                template: '{NUMBER}',
+                settings: {
+                  Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                    start: 1,
+                    step: 1,
+                    length: 6,
+                    padString: '0',
+                    periodicBy: '',
+                    timezone: '',
+                    isDirectNumeration: false,
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New numerator created:', result.numerator.id, result.numerator.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addNumerator)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-delete.md
+++ b/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-delete.md
@@ -56,25 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.numerator.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.numerator.delete',
-    		{
-    			id: 47,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'crm.documentgenerator.numerator.delete',
+        params: {
+          id: 47,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Numerator deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.numerator.delete',
+            params: {
+              id: 47,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Numerator deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteNumerator)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-get.md
+++ b/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-get.md
@@ -54,25 +54,92 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.numerator.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.numerator.get',
-    		{
-    			id: 45,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorGetResult = {
+      numerator: {
+        id: string
+        name: string
+        template: string
+        code: string | null
+        settings: Record<string, {
+          start: number
+          step: number
+          length: number
+          padString: string
+          periodicBy: string | null
+          timezone: string | null
+          isDirectNumeration: boolean
+        }>
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<NumeratorGetResult>({
+        method: 'crm.documentgenerator.numerator.get',
+        params: {
+          id: 45,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.numerator.id, result.numerator.name, result.numerator.template)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.numerator.get',
+            params: {
+              id: 45,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.numerator.id, result.numerator.name, result.numerator.template)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNumerator)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-list.md
+++ b/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-list.md
@@ -50,25 +50,101 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.numerator.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.numerator.list',
-    		{
-    			start: 0,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorResult = {
+      numerators: {
+        id: string
+        name: string
+        template: string
+        settings: Record<string, {
+          start: number
+          step: number
+          length?: number
+          padString?: string
+          periodicBy: string | null
+          timezone: string | null
+          isDirectNumeration: boolean
+        }>
+      }[]
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      // crm.documentgenerator.numerator.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<NumeratorResult>({
+        method: 'crm.documentgenerator.numerator.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Numerators count:', result.numerators.length, result.numerators)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listNumerators() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.documentgenerator.numerator.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.numerator.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Numerators count:', result.numerators.length, result.numerators)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listNumerators)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-update.md
+++ b/api-reference/crm/document-generator/numerator/crm-document-generator-numerator-update.md
@@ -122,40 +122,122 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.numerator.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.numerator.update',
-    		{
-    			id: 45,
-    			fields: {
-    				name: 'Нумератор из REST (обновлен)',
-    				template: 'INV-{NUMBER}',
-    				settings: {
-    					Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
-    						start: 100,
-    						step: 1,
-    						length: 6,
-    						padString: '0',
-    						periodicBy: '',
-    						timezone: '',
-    						isDirectNumeration: false,
-    					},
-    				},
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NumeratorUpdateResult = {
+      id: string
+      name: string
+      template: string
+      code: string | null
+      settings: {
+        Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+          start: number
+          step: number
+          length: number
+          padString: string
+          periodicBy: string | null
+          timezone: string | null
+          isDirectNumeration: boolean
+        }
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<NumeratorUpdateResult>({
+        method: 'crm.documentgenerator.numerator.update',
+        params: {
+          id: 45,
+          fields: {
+            name: 'Numerator from REST (updated)',
+            template: 'INV-{NUMBER}',
+            settings: {
+              Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                start: 100,
+                step: 1,
+                length: 6,
+                padString: '0',
+                periodicBy: '',
+                timezone: '',
+                isDirectNumeration: false,
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.template)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateNumerator() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.numerator.update',
+            params: {
+              id: 45,
+              fields: {
+                name: 'Numerator from REST (updated)',
+                template: 'INV-{NUMBER}',
+                settings: {
+                  Bitrix_Main_Numerator_Generator_SequentNumberGenerator: {
+                    start: 100,
+                    step: 1,
+                    length: 6,
+                    padString: '0',
+                    periodicBy: '',
+                    timezone: '',
+                    isDirectNumeration: false,
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.template)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateNumerator)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/templates/crm-document-generator-template-add.md
+++ b/api-reference/crm/document-generator/templates/crm-document-generator-template-add.md
@@ -118,35 +118,115 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.template.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.template.add',
-    		{
-    			fields: {
-    				name: 'Шаблон КП из REST',
-    				file: ['template.docx', '**base64_encoded_content**'],
-    				numeratorId: 49,
-    				region: 'ru',
-    				entityTypeId: ['2', '2_category_0'],
-    				users: ['UA'],
-    				active: 'Y',
-    				withStamps: 'N',
-    				sort: 500,
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateAddResult = {
+      template: {
+        id: string,
+        name: string,
+        region: string,
+        code: string | null,
+        download: string,
+        downloadMachine: string,
+        active: string,
+        moduleId: string,
+        numeratorId: string,
+        withStamps: string,
+        users: Record<string, string>,
+        isDeleted: string,
+        sort: string,
+        entityTypeId: string[],
+        createTime: ISODate,
+        updateTime: ISODate,
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateAddResult>({
+        method: 'crm.documentgenerator.template.add',
+        params: {
+          fields: {
+            name: 'Template KP from REST',
+            file: ['template.docx', '**base64_encoded_content**'],
+            numeratorId: 49,
+            region: 'ru',
+            entityTypeId: ['2', '2_category_0'],
+            users: ['UA'],
+            active: 'Y',
+            withStamps: 'N',
+            sort: 500,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.template.id, result.template.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.template.add',
+            params: {
+              fields: {
+                name: 'Template KP from REST',
+                file: ['template.docx', '**base64_encoded_content**'],
+                numeratorId: 49,
+                region: 'ru',
+                entityTypeId: ['2', '2_category_0'],
+                users: ['UA'],
+                active: 'Y',
+                withStamps: 'N',
+                sort: 500,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.template.id, result.template.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/templates/crm-document-generator-template-delete.md
+++ b/api-reference/crm/document-generator/templates/crm-document-generator-template-delete.md
@@ -55,25 +55,73 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.template.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.template.delete',
-    		{
-    			id: 41,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'crm.documentgenerator.template.delete',
+        params: {
+          id: 41,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Template deleted, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.template.delete',
+            params: {
+              id: 41,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Template deleted, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/templates/crm-document-generator-template-get-fields.md
+++ b/api-reference/crm/document-generator/templates/crm-document-generator-template-get-fields.md
@@ -153,30 +153,98 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.template.getfields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.template.getfields',
-    		{
-    			id: 1,
-    			entityTypeId: 2,
-    			entityId: 123,
-    			values: {
-    				DocumentNumber: '2026-001',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = {
+      templateFields: Record<string, TemplateField>
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    type TemplateField = {
+      title: string
+      value: string | string[] | null
+      default?: string | null
+      required?: string
+      type?: string
+      group: string[]
+      chain?: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'crm.documentgenerator.template.getfields',
+        params: {
+          id: 1,
+          entityTypeId: 2,
+          entityId: 123,
+          values: {
+            DocumentNumber: '2026-001',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Template fields:', Object.keys(result.templateFields))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTemplateFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.template.getfields',
+            params: {
+              id: 1,
+              entityTypeId: 2,
+              entityId: 123,
+              values: {
+                DocumentNumber: '2026-001',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Template fields:', Object.keys(result.templateFields))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTemplateFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/templates/crm-document-generator-template-get.md
+++ b/api-reference/crm/document-generator/templates/crm-document-generator-template-get.md
@@ -55,25 +55,95 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.template.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.template.get',
-    		{
-    			id: 41,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplateGetResult = {
+      template: {
+        id: string
+        name: string
+        region: string
+        code: string | null
+        download: string
+        downloadMachine: string
+        active: string
+        moduleId: string
+        numeratorId: string
+        withStamps: string
+        users: Record<string, string>
+        isDeleted: string
+        sort: string
+        entityTypeId: string[]
+        createTime: ISODate
+        updateTime: ISODate
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TemplateGetResult>({
+        method: 'crm.documentgenerator.template.get',
+        params: {
+          id: 41,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.template.id, result.template.name, result.template.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.template.get',
+            params: {
+              id: 41,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.template.id, result.template.name, result.template.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/templates/crm-document-generator-template-list.md
+++ b/api-reference/crm/document-generator/templates/crm-document-generator-template-list.md
@@ -130,28 +130,106 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.template.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.template.list',
-    		{
-    			select: ['id', 'name', 'region', 'entityTypeId', 'users'],
-    			order: { id: 'desc' },
-    			filter: { region: 'ru', active: 'Y' },
-    			start: 0,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type Template = {
+      id: string
+      name: string
+      region: string
+      download: string
+      users: string[]
+      entityTypeId: string[]
+      downloadMachine: string
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TemplatesResult = {
+      templates: Record<string, Template>
     }
+
+    try {
+      // crm.documentgenerator.template.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TemplatesResult>({
+        method: 'crm.documentgenerator.template.list',
+        params: {
+          select: ['id', 'name', 'region', 'entityTypeId', 'users'],
+          order: { id: 'desc' },
+          filter: { region: 'ru', active: 'Y' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Templates on this page:', Object.keys(result.templates).length)
+        console.info(result.templates)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTemplateList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.documentgenerator.template.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.template.list',
+            params: {
+              select: ['id', 'name', 'region', 'entityTypeId', 'users'],
+              order: { id: 'desc' },
+              filter: { region: 'ru', active: 'Y' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Templates on this page:', Object.keys(result.templates).length)
+          console.info(result.templates)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTemplateList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/document-generator/templates/crm-document-generator-template-update.md
+++ b/api-reference/crm/document-generator/templates/crm-document-generator-template-update.md
@@ -117,36 +117,117 @@
     https://**put_your_bitrix24_address**/rest/crm.documentgenerator.template.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.documentgenerator.template.update',
-    		{
-    			id: 41,
-    			fields: {
-    				name: 'Шаблон из файла (обновлен)',
-    				file: ['template-updated.docx', '**base64_encoded_content**'],
-    				numeratorId: 49,
-    				region: 'ru',
-    				entityTypeId: ['2'],
-    				users: ['UA'],
-    				active: 'Y',
-    				withStamps: 'N',
-    				sort: 500,
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UpdateTemplateResult = {
+      template: {
+        id: string
+        name: string
+        region: string
+        code: string | null
+        download: string
+        downloadMachine: string
+        active: 'Y' | 'N'
+        moduleId: string
+        numeratorId: string
+        withStamps: 'Y' | 'N'
+        users: Record<string, string>
+        isDeleted: 'Y' | 'N'
+        sort: string
+        entityTypeId: string[]
+        createTime: ISODate
+        updateTime: ISODate
+      }
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UpdateTemplateResult>({
+        method: 'crm.documentgenerator.template.update',
+        params: {
+          id: 41,
+          fields: {
+            name: 'Template from file (updated)',
+            file: ['template-updated.docx', '**base64_encoded_content**'],
+            numeratorId: 49,
+            region: 'ru',
+            entityTypeId: ['2'],
+            users: ['UA'],
+            active: 'Y',
+            withStamps: 'N',
+            sort: 500,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.template.id, result.template.name, result.template.updateTime)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.documentgenerator.template.update',
+            params: {
+              id: 41,
+              fields: {
+                name: 'Template from file (updated)',
+                file: ['template-updated.docx', '**base64_encoded_content**'],
+                numeratorId: 49,
+                region: 'ru',
+                entityTypeId: ['2'],
+                users: ['UA'],
+                active: 'Y',
+                withStamps: 'N',
+                sort: 500,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.template.id, result.template.name, result.template.updateTime)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTemplate)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.