### PR TITLE
docs(crm/quote): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/quote/crm-quote-add.md
+++ b/api-reference/crm/quote/crm-quote-add.md
@@ -174,40 +174,103 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.add',
-    		{
-    			fields: {
-    				TITLE: 'КП на поставку мебели',
-    				STATUS_ID: 'DRAFT',
-    				OPENED: 'Y',
-    				ASSIGNED_BY_ID: 1,
-    				CURRENCY_ID: 'RUB',
-    				OPPORTUNITY: 150000,
-    				COMPANY_ID: 1,
-    				MYCOMPANY_ID: 3,
-    				COMMENTS: 'Подготовлено по запросу клиента',
-    				BEGINDATE: '2026-03-13T10:00:00+03:00',
-    				CLOSEDATE: '2026-03-20T18:00:00+03:00',
-    			},
-    			params: {
-    				IMPORT: 'N',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.quote.add',
+        params: {
+          fields: {
+            TITLE: 'Furniture supply quote',
+            STATUS_ID: 'DRAFT',
+            OPENED: 'Y',
+            ASSIGNED_BY_ID: 1,
+            CURRENCY_ID: 'RUB',
+            OPPORTUNITY: 150000,
+            COMPANY_ID: 1,
+            MYCOMPANY_ID: 3,
+            COMMENTS: 'Prepared at client request',
+            BEGINDATE: '2026-03-13T10:00:00+03:00',
+            CLOSEDATE: '2026-03-20T18:00:00+03:00',
+          },
+          params: {
+            IMPORT: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created quote ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createQuote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.add',
+            params: {
+              fields: {
+                TITLE: 'Furniture supply quote',
+                STATUS_ID: 'DRAFT',
+                OPENED: 'Y',
+                ASSIGNED_BY_ID: 1,
+                CURRENCY_ID: 'RUB',
+                OPPORTUNITY: 150000,
+                COMPANY_ID: 1,
+                MYCOMPANY_ID: 3,
+                COMMENTS: 'Prepared at client request',
+                BEGINDATE: '2026-03-13T10:00:00+03:00',
+                CLOSEDATE: '2026-03-20T18:00:00+03:00',
+              },
+              params: {
+                IMPORT: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created quote ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createQuote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-delete.md
+++ b/api-reference/crm/quote/crm-quote-delete.md
@@ -62,25 +62,73 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.delete',
-    		{
-    			id: 43,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.quote.delete',
+        params: {
+          id: 43,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteQuote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.delete',
+            params: {
+              id: 43,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteQuote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-fields.md
+++ b/api-reference/crm/quote/crm-quote-fields.md
@@ -51,24 +51,88 @@
          https://**put_your_bitrix24_address**/rest/crm.quote.fields  
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.quote.fields",
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      statusType?: string
+      isDeprecated?: boolean
+      listLabel?: string
+      formLabel?: string
+      filterLabel?: string
+      settings?: Record<string, unknown>
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type QuoteFieldsResult = Record<string, FieldDescription>
+
+    try {
+      const response = await $b24.actions.v2.call.make<QuoteFieldsResult>({
+        method: 'crm.quote.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Quote fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getQuoteFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Quote fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getQuoteFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-get.md
+++ b/api-reference/crm/quote/crm-quote-get.md
@@ -62,25 +62,100 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.get',
-    		{
-    			id: 43,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type QuoteData = {
+      ID: string
+      TITLE: string
+      STATUS_ID: string
+      CURRENCY_ID: string
+      OPPORTUNITY: string
+      TAX_VALUE: string
+      COMPANY_ID: string | null
+      CONTACT_ID: string | null
+      MYCOMPANY_ID: string | null
+      BEGINDATE: ISODate | null
+      CLOSEDATE: ISODate | null
+      ACTUAL_DATE: ISODate | null
+      ASSIGNED_BY_ID: string
+      CREATED_BY_ID: string
+      MODIFY_BY_ID: string
+      DATE_CREATE: ISODate
+      DATE_MODIFY: ISODate
+      OPENED: string
+      CLOSED: string
+      COMMENTS: string | null
+      LEAD_ID: string | null
+      DEAL_ID: string | null
+      QUOTE_NUMBER: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<QuoteData>({
+        method: 'crm.quote.get',
+        params: {
+          id: 43,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.TITLE, result.STATUS_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getQuote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.get',
+            params: {
+              id: 43,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.TITLE, result.STATUS_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getQuote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-list.md
+++ b/api-reference/crm/quote/crm-quote-list.md
@@ -139,64 +139,99 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      await $b24.callListMethod(
-        'crm.quote.list',
-        {
-          order: { STATUS_ID: 'ASC', ID: 'ASC' },
-          filter: { '=COMPANY_ID': 1, '=STATUS_ID': 'SENT' },
-          select: ['ID', 'TITLE', 'STATUS_ID', 'OPPORTUNITY', 'CURRENCY_ID', 'ASSIGNED_BY_ID'],
-        },
-        (progress) => {
-          progress.error()
-            ? console.error(progress.error())
-            : console.info(progress.data())
-          ;
-        },
-      );
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    try {
-      const generator = $b24.fetchListMethod(
-        'crm.quote.list',
-        {
-          order: { STATUS_ID: 'ASC', ID: 'ASC' },
-          filter: { '=COMPANY_ID': 1, '=STATUS_ID': 'SENT' },
-          select: ['ID', 'TITLE', 'STATUS_ID', 'OPPORTUNITY', 'CURRENCY_ID', 'ASSIGNED_BY_ID'],
-        },
-        'ID',
-      );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-      for await (const page of generator) {
-        for (const entity of page) {
-          console.info(entity);
-        }
-      }
-    } catch (error) {
-      console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of each QuoteItem returned in result[]
+    type QuoteItem = {
+      ID: string
+      TITLE: string
+      STATUS_ID: string
+      OPPORTUNITY: string
+      CURRENCY_ID: string
+      ASSIGNED_BY_ID: string
     }
 
     try {
-      const response = await $b24.callMethod(
-        'crm.quote.list',
-        {
+      // crm.quote.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<QuoteItem[]>({
+        method: 'crm.quote.list',
+        params: {
           order: { STATUS_ID: 'ASC', ID: 'ASC' },
           filter: { '=COMPANY_ID': 1, '=STATUS_ID': 'SENT' },
           select: ['ID', 'TITLE', 'STATUS_ID', 'OPPORTUNITY', 'CURRENCY_ID', 'ASSIGNED_BY_ID'],
           start: 0,
         },
-      );
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const result = response.getData().result || [];
-      console.info(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Quotes on this page:', result.length, result)
+      }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchQuoteList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.quote.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.list',
+            params: {
+              order: { STATUS_ID: 'ASC', ID: 'ASC' },
+              filter: { '=COMPANY_ID': 1, '=STATUS_ID': 'SENT' },
+              select: ['ID', 'TITLE', 'STATUS_ID', 'OPPORTUNITY', 'CURRENCY_ID', 'ASSIGNED_BY_ID'],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Quotes on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchQuoteList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-product-rows-get.md
+++ b/api-reference/crm/quote/crm-quote-product-rows-get.md
@@ -62,25 +62,105 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.productrows.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.productrows.get',
-    		{
-    			id: 1,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each ProductRow returned in result[]
+    type ProductRow = {
+      ID: string
+      OWNER_ID: string
+      OWNER_TYPE: string
+      PRODUCT_ID: number
+      PRODUCT_NAME: string
+      ORIGINAL_PRODUCT_NAME: string
+      PRODUCT_DESCRIPTION: string
+      PRICE: number
+      PRICE_EXCLUSIVE: number
+      PRICE_NETTO: number
+      PRICE_BRUTTO: number
+      PRICE_ACCOUNT: string
+      QUANTITY: number
+      DISCOUNT_TYPE_ID: number
+      DISCOUNT_RATE: number
+      DISCOUNT_SUM: number
+      TAX_RATE: number
+      TAX_INCLUDED: string
+      CUSTOMIZED: string
+      MEASURE_CODE: number
+      MEASURE_NAME: string
+      SORT: number
+      XML_ID: string | null
+      TYPE: number
+      STORE_ID: number | null
+      RESERVE_ID: number | null
+      DATE_RESERVE_END: ISODate | null
+      RESERVE_QUANTITY: number | null
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductRow[]>({
+        method: 'crm.quote.productrows.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product rows count:', result.length, result.map(r => r.PRODUCT_NAME))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getQuoteProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.productrows.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product rows count:', result.length, result.map(r => r.PRODUCT_NAME))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getQuoteProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-product-rows-set.md
+++ b/api-reference/crm/quote/crm-quote-product-rows-set.md
@@ -124,51 +124,125 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.productrows.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.productrows.set',
-    		{
-    			id: 1,
-    			rows: [
-    				{
-    					PRODUCT_ID: 459,
-    					PRICE: 3000,
-    					QUANTITY: 1,
-    					DISCOUNT_TYPE_ID: 2,
-    					DISCOUNT_RATE: 0,
-    					TAX_RATE: 0,
-    					TAX_INCLUDED: 'Y',
-    					MEASURE_CODE: 796,
-    					MEASURE_NAME: 'шт',
-    					SORT: 10,
-    				},
-    				{
-    					PRODUCT_NAME: 'Услуга сопровождения',
-    					PRICE: 1500,
-    					QUANTITY: 2,
-    					DISCOUNT_TYPE_ID: 2,
-    					DISCOUNT_RATE: 0,
-    					TAX_RATE: 0,
-    					TAX_INCLUDED: 'Y',
-    					MEASURE_CODE: 796,
-    					MEASURE_NAME: 'шт',
-    					SORT: 20,
-    				},
-    			],
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.quote.productrows.set',
+        params: {
+          id: 1,
+          rows: [
+            {
+              PRODUCT_ID: 459,
+              PRICE: 3000,
+              QUANTITY: 1,
+              DISCOUNT_TYPE_ID: 2,
+              DISCOUNT_RATE: 0,
+              TAX_RATE: 0,
+              TAX_INCLUDED: 'Y',
+              MEASURE_CODE: 796,
+              MEASURE_NAME: 'pcs',
+              SORT: 10,
+            },
+            {
+              PRODUCT_NAME: 'Support service',
+              PRICE: 1500,
+              QUANTITY: 2,
+              DISCOUNT_TYPE_ID: 2,
+              DISCOUNT_RATE: 0,
+              TAX_RATE: 0,
+              TAX_INCLUDED: 'Y',
+              MEASURE_CODE: 796,
+              MEASURE_NAME: 'pcs',
+              SORT: 20,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product rows saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setQuoteProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.productrows.set',
+            params: {
+              id: 1,
+              rows: [
+                {
+                  PRODUCT_ID: 459,
+                  PRICE: 3000,
+                  QUANTITY: 1,
+                  DISCOUNT_TYPE_ID: 2,
+                  DISCOUNT_RATE: 0,
+                  TAX_RATE: 0,
+                  TAX_INCLUDED: 'Y',
+                  MEASURE_CODE: 796,
+                  MEASURE_NAME: 'pcs',
+                  SORT: 10,
+                },
+                {
+                  PRODUCT_NAME: 'Support service',
+                  PRICE: 1500,
+                  QUANTITY: 2,
+                  DISCOUNT_TYPE_ID: 2,
+                  DISCOUNT_RATE: 0,
+                  TAX_RATE: 0,
+                  TAX_INCLUDED: 'Y',
+                  MEASURE_CODE: 796,
+                  MEASURE_NAME: 'pcs',
+                  SORT: 20,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product rows saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setQuoteProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/crm-quote-update.md
+++ b/api-reference/crm/quote/crm-quote-update.md
@@ -163,32 +163,87 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.update',
-    		{
-    			id: 43,
-    			fields: {
-    				STATUS_ID: 'SENT',
-    				COMMENTS: 'Уточнены условия и сроки',
-    			},
-    			params: {
-    				REGISTER_HISTORY_EVENT: 'Y',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.quote.update',
+        params: {
+          id: 43,
+          fields: {
+            STATUS_ID: 'SENT',
+            COMMENTS: 'Clarified terms and deadlines',
+          },
+          params: {
+            REGISTER_HISTORY_EVENT: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Quote updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateQuote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.update',
+            params: {
+              id: 43,
+              fields: {
+                STATUS_ID: 'SENT',
+                COMMENTS: 'Clarified terms and deadlines',
+              },
+              params: {
+                REGISTER_HISTORY_EVENT: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Quote updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateQuote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/user-field/crm-quote-user-field-add.md
+++ b/api-reference/crm/quote/user-field/crm-quote-user-field-add.md
@@ -420,58 +420,141 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.userfield.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.quote.userfield.add',
-            {
-                fields: {
-                    LABEL: 'Поле Привет, мир!',
-                    USER_TYPE_ID: 'string',
-                    FIELD_NAME: 'HELLO_WORLD',
-                    MULTIPLE: 'Y',
-                    MANDATORY: 'Y',
-                    SHOW_FILTER: 'Y',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Привет, мир! Значение по умолчанию',
-                        ROWS: 3,
-                    },
-                    SORT: 1000,
-                    EDIT_IN_LIST: 'Y',
-                    LIST_FILTER_LABEL: 'Привет, мир! Фильтр',
-                    LIST_COLUMN_LABEL: {
-                        en: 'Hello, World! Column',
-                        ru: 'Привет, мир! Колонка',
-                        de: 'Hallo, Welt! Spalte',
-                    },
-                    EDIT_FORM_LABEL: {
-                        en: 'Hello, World! Edit',
-                        ru: 'Привет, мир! Редактировать',
-                        de: 'Hallo, Welt! Bearbeiten',
-                    },
-                    ERROR_MESSAGE: {
-                        en: 'Hello, World! Error',
-                        ru: 'Привет, мир! Ошибка',
-                        de: 'Hallo, Welt! Fehler',
-                    },
-                    HELP_MESSAGE: {
-                        en: 'Hello, World! Help',
-                        ru: 'Привет, мир! Помощь',
-                        de: 'Hallo, Welt! Hilfe',
-                    },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.quote.userfield.add',
+        params: {
+          fields: {
+            LABEL: 'Hello, World! Field',
+            USER_TYPE_ID: 'string',
+            FIELD_NAME: 'HELLO_WORLD',
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            SHOW_FILTER: 'Y',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Hello, World! Default value',
+              ROWS: 3,
+            },
+            SORT: 1000,
+            EDIT_IN_LIST: 'Y',
+            LIST_FILTER_LABEL: 'Hello, World! Filter',
+            LIST_COLUMN_LABEL: {
+              en: 'Hello, World! Column',
+              ru: 'Привет, мир! Колонка',
+              de: 'Hallo, Welt! Spalte',
+            },
+            EDIT_FORM_LABEL: {
+              en: 'Hello, World! Edit',
+              ru: 'Привет, мир! Редактировать',
+              de: 'Hallo, Welt! Bearbeiten',
+            },
+            ERROR_MESSAGE: {
+              en: 'Hello, World! Error',
+              ru: 'Привет, мир! Ошибка',
+              de: 'Hallo, Welt! Fehler',
+            },
+            HELP_MESSAGE: {
+              en: 'Hello, World! Help',
+              ru: 'Привет, мир! Помощь',
+              de: 'Hallo, Welt! Hilfe',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created userfield ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addStringQuoteUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.userfield.add',
+            params: {
+              fields: {
+                LABEL: 'Hello, World! Field',
+                USER_TYPE_ID: 'string',
+                FIELD_NAME: 'HELLO_WORLD',
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                SHOW_FILTER: 'Y',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Hello, World! Default value',
+                  ROWS: 3,
                 },
-            }
-        );
+                SORT: 1000,
+                EDIT_IN_LIST: 'Y',
+                LIST_FILTER_LABEL: 'Hello, World! Filter',
+                LIST_COLUMN_LABEL: {
+                  en: 'Hello, World! Column',
+                  ru: 'Привет, мир! Колонка',
+                  de: 'Hallo, Welt! Spalte',
+                },
+                EDIT_FORM_LABEL: {
+                  en: 'Hello, World! Edit',
+                  ru: 'Привет, мир! Редактировать',
+                  de: 'Hallo, Welt! Bearbeiten',
+                },
+                ERROR_MESSAGE: {
+                  en: 'Hello, World! Error',
+                  ru: 'Привет, мир! Ошибка',
+                  de: 'Hallo, Welt! Fehler',
+                },
+                HELP_MESSAGE: {
+                  en: 'Hello, World! Help',
+                  ru: 'Привет, мир! Помощь',
+                  de: 'Hallo, Welt! Hilfe',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created userfield ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addStringQuoteUserfield)
+    </script>
     ```
 
 - PHP
@@ -609,42 +692,109 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.userfield.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.quote.userfield.add',
-            {
-                fields: {
-                    LABEL: 'Пользовательское поле (список)',
-                    USER_TYPE_ID: 'enumeration',
-                    FIELD_NAME: 'ENUMERATION_EXAMPLE',
-                    MULTIPLE: 'N',
-                    MANDATORY: 'N',
-                    SHOW_FILTER: 'Y',
-                    LIST: [
-                        { VALUE: 'Элемент списка #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
-                        { VALUE: 'Элемент списка #2', XML_ID: 'XML_ID_2', SORT: 200 },
-                        { VALUE: 'Элемент списка #3', XML_ID: 'XML_ID_3', SORT: 300 },
-                        { VALUE: 'Элемент списка #4', XML_ID: 'XML_ID_4', SORT: 400 },
-                    ],
-                    SETTINGS: {
-                        DISPLAY: 'UI',
-                        LIST_HEIGHT: 2,
-                    },
-                    SORT: 2000,
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.quote.userfield.add',
+        params: {
+          fields: {
+            LABEL: 'Custom field (enumeration)',
+            USER_TYPE_ID: 'enumeration',
+            FIELD_NAME: 'ENUMERATION_EXAMPLE',
+            MULTIPLE: 'N',
+            MANDATORY: 'N',
+            SHOW_FILTER: 'Y',
+            LIST: [
+              { VALUE: 'List item #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
+              { VALUE: 'List item #2', XML_ID: 'XML_ID_2', SORT: 200 },
+              { VALUE: 'List item #3', XML_ID: 'XML_ID_3', SORT: 300 },
+              { VALUE: 'List item #4', XML_ID: 'XML_ID_4', SORT: 400 },
+            ],
+            SETTINGS: {
+              DISPLAY: 'UI',
+              LIST_HEIGHT: 2,
+            },
+            SORT: 2000,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created userfield ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addEnumerationQuoteUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.userfield.add',
+            params: {
+              fields: {
+                LABEL: 'Custom field (enumeration)',
+                USER_TYPE_ID: 'enumeration',
+                FIELD_NAME: 'ENUMERATION_EXAMPLE',
+                MULTIPLE: 'N',
+                MANDATORY: 'N',
+                SHOW_FILTER: 'Y',
+                LIST: [
+                  { VALUE: 'List item #1', DEF: 'Y', XML_ID: 'XML_ID_1', SORT: 100 },
+                  { VALUE: 'List item #2', XML_ID: 'XML_ID_2', SORT: 200 },
+                  { VALUE: 'List item #3', XML_ID: 'XML_ID_3', SORT: 300 },
+                  { VALUE: 'List item #4', XML_ID: 'XML_ID_4', SORT: 400 },
+                ],
+                SETTINGS: {
+                  DISPLAY: 'UI',
+                  LIST_HEIGHT: 2,
                 },
-            }
-        );
+                SORT: 2000,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created userfield ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addEnumerationQuoteUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/user-field/crm-quote-user-field-delete.md
+++ b/api-reference/crm/quote/user-field/crm-quote-user-field-delete.md
@@ -54,28 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.userfield.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.userfield.delete',
-    		{
-    			id: 432,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.quote.userfield.delete',
+        params: {
+          id: 432,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Userfield deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteQuoteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.userfield.delete',
+            params: {
+              id: 432,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Userfield deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteQuoteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/user-field/crm-quote-user-field-get.md
+++ b/api-reference/crm/quote/user-field/crm-quote-user-field-get.md
@@ -54,28 +54,102 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.userfield.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.quote.userfield.get',
-    		{
-    			id: 399,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result)
-    	;
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type QuoteUserFieldGetResult = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+      SETTINGS: {
+        SIZE: number
+        ROWS: number
+        REGEXP: string
+        MIN_LENGTH: number
+        MAX_LENGTH: number
+        DEFAULT_VALUE: string
+      }
+      EDIT_FORM_LABEL: Record<string, string>
+      LIST_COLUMN_LABEL: Record<string, string>
+      LIST_FILTER_LABEL: Record<string, string>
+      ERROR_MESSAGE: Record<string, string>
+      HELP_MESSAGE: Record<string, string>
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<QuoteUserFieldGetResult>({
+        method: 'crm.quote.userfield.get',
+        params: {
+          id: 399,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.FIELD_NAME, result.USER_TYPE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getQuoteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.userfield.get',
+            params: {
+              id: 399,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.FIELD_NAME, result.USER_TYPE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getQuoteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/user-field/crm-quote-user-field-list.md
+++ b/api-reference/crm/quote/user-field/crm-quote-user-field-list.md
@@ -170,74 +170,123 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.userfield.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-    const response = await $b24.callListMethod(
-        'crm.quote.userfield.list',
-        {
-         filter: {
-            MULTIPLE: "Y",
-            MANDATORY: "Y",
-            LANG: "ru",
-         },
-         order: {
-            USER_TYPE_ID: "ASC",
-            SORT: "ASC",
-         },
-        },
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-    const generator = $b24.fetchListMethod('crm.quote.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    
-    try {
-    const response = await $b24.callMethod('crm.quote.userfield.list', {
-        filter: {
-         MULTIPLE: "Y",
-         MANDATORY: "Y",
-         LANG: "ru",
-        },
-        order: {
-         USER_TYPE_ID: "ASC",
-         SORT: "ASC",
-        },
-    }, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type QuoteUserFieldItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+      SETTINGS: Record<string, unknown>
+      EDIT_FORM_LABEL: string | null
+      LIST_COLUMN_LABEL: string | null
+      LIST_FILTER_LABEL: string | null
+      ERROR_MESSAGE: string | null
+      HELP_MESSAGE: string | null
     }
+
+    try {
+      // crm.quote.userfield.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<QuoteUserFieldItem[]>({
+        method: 'crm.quote.userfield.list',
+        params: {
+          filter: {
+            MULTIPLE: 'Y',
+            MANDATORY: 'Y',
+            LANG: 'ru',
+          },
+          order: {
+            USER_TYPE_ID: 'ASC',
+            SORT: 'ASC',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User fields count:', result.length, 'fields:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchQuoteUserFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.quote.userfield.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.userfield.list',
+            params: {
+              filter: {
+                MULTIPLE: 'Y',
+                MANDATORY: 'Y',
+                LANG: 'ru',
+              },
+              order: {
+                USER_TYPE_ID: 'ASC',
+                SORT: 'ASC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User fields count:', result.length, 'fields:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchQuoteUserFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/quote/user-field/crm-quote-user-field-update.md
+++ b/api-reference/crm/quote/user-field/crm-quote-user-field-update.md
@@ -326,55 +326,135 @@
     https://**put_your_bitrix24_address**/rest/crm.quote.userfield.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.quote.userfield.update',
-            {
-                id: 536,
-                fields: {
-                    MANDATORY: 'N',
-                    SHOW_FILTER: 'N',
-                    SETTINGS: {
-                        DEFAULT_VALUE: 'Привет, мир! Значение по умолчанию (изменено)',
-                        ROWS: 10,
-                    },
-                    SORT: 2000,
-                    EDIT_IN_LIST: 'N',
-                    LIST_FILTER_LABEL: 'Привет, мир! Фильтр (изменено)',
-                    LIST_COLUMN_LABEL: {
-                        en: 'Hello, World! Column (changed)',
-                        ru: 'Привет, мир! Колонка (изменено)',
-                        de: 'Hallo, Welt! Spalte (geändert)',
-                    },
-                    EDIT_FORM_LABEL: {
-                        en: 'Hello, World! Edit (changed)',
-                        ru: 'Привет, мир! Редактировать (изменено)',
-                        de: 'Hallo, Welt! Bearbeiten (geändert)',
-                    },
-                    ERROR_MESSAGE: {
-                        en: 'Hello, World! Error (changed)',
-                        ru: 'Привет, мир! Ошибка (изменено)',
-                        de: 'Hallo, Welt! Fehler (geändert)',
-                    },
-                    HELP_MESSAGE: {
-                        en: 'Hello, World! Help (changed)',
-                        ru: 'Привет, мир! Помощь (изменено)',
-                        de: 'Hallo, Welt! Hilfe (geändert)',
-                    },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.quote.userfield.update',
+        params: {
+          id: 536,
+          fields: {
+            MANDATORY: 'N',
+            SHOW_FILTER: 'N',
+            SETTINGS: {
+              DEFAULT_VALUE: 'Hello, World! Default value (changed)',
+              ROWS: 10,
+            },
+            SORT: 2000,
+            EDIT_IN_LIST: 'N',
+            LIST_FILTER_LABEL: 'Hello, World! Filter (changed)',
+            LIST_COLUMN_LABEL: {
+              en: 'Hello, World! Column (changed)',
+              ru: 'Hello, World! Column (changed)',
+              de: 'Hello, World! Column (changed)',
+            },
+            EDIT_FORM_LABEL: {
+              en: 'Hello, World! Edit (changed)',
+              ru: 'Hello, World! Edit (changed)',
+              de: 'Hello, World! Edit (changed)',
+            },
+            ERROR_MESSAGE: {
+              en: 'Hello, World! Error (changed)',
+              ru: 'Hello, World! Error (changed)',
+              de: 'Hello, World! Error (changed)',
+            },
+            HELP_MESSAGE: {
+              en: 'Hello, World! Help (changed)',
+              ru: 'Hello, World! Help (changed)',
+              de: 'Hello, World! Help (changed)',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateQuoteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.quote.userfield.update',
+            params: {
+              id: 536,
+              fields: {
+                MANDATORY: 'N',
+                SHOW_FILTER: 'N',
+                SETTINGS: {
+                  DEFAULT_VALUE: 'Hello, World! Default value (changed)',
+                  ROWS: 10,
                 },
-            }
-        );
+                SORT: 2000,
+                EDIT_IN_LIST: 'N',
+                LIST_FILTER_LABEL: 'Hello, World! Filter (changed)',
+                LIST_COLUMN_LABEL: {
+                  en: 'Hello, World! Column (changed)',
+                  ru: 'Hello, World! Column (changed)',
+                  de: 'Hello, World! Column (changed)',
+                },
+                EDIT_FORM_LABEL: {
+                  en: 'Hello, World! Edit (changed)',
+                  ru: 'Hello, World! Edit (changed)',
+                  de: 'Hello, World! Edit (changed)',
+                },
+                ERROR_MESSAGE: {
+                  en: 'Hello, World! Error (changed)',
+                  ru: 'Hello, World! Error (changed)',
+                  de: 'Hello, World! Error (changed)',
+                },
+                HELP_MESSAGE: {
+                  en: 'Hello, World! Help (changed)',
+                  ru: 'Hello, World! Help (changed)',
+                  de: 'Hello, World! Help (changed)',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        console.info(response.getData().result);
-    }
-    catch (error)
-    {
-        console.error(error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateQuoteUserField)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.