### PR TITLE
docs(crm/requisites): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/requisites/addresses/crm-address-add.md
+++ b/api-reference/crm/requisites/addresses/crm-address-add.md
@@ -107,39 +107,95 @@
     https://**put_your_bitrix24_address**/rest/crm.address.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.address.add",
-    		{
-    			fields:
-    			{
-    				"TYPE_ID": 1,            // Тип адреса, см. crm.enum.addresstype
-    				"ENTITY_TYPE_ID": 8,     // Тип объекта (реквизит или лид)
-    				"ENTITY_ID": 1,          // Идентификатор реквизита
-    				"ADDRESS_1": "проспект Мира, 4",
-    				"ADDRESS_2": "Калининградский областной драматический театр",
-    				"CITY": "Калининград",
-    				"POSTAL_CODE": "236036",
-    				"REGION": "городской округ Калининград",
-    				"PROVINCE": "Калининградская область",
-    				"COUNTRY": "Россия",
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.address.add',
+        params: {
+          fields: {
+            TYPE_ID: 1,            // Address type, see crm.enum.addresstype
+            ENTITY_TYPE_ID: 8,     // Parent object type (requisite or lead)
+            ENTITY_ID: 1,          // Requisite identifier
+            ADDRESS_1: '4 Peace Avenue',
+            ADDRESS_2: 'Kaliningrad Regional Drama Theater',
+            CITY: 'Kaliningrad',
+            POSTAL_CODE: '236036',
+            REGION: 'Kaliningrad urban district',
+            PROVINCE: 'Kaliningrad Oblast',
+            COUNTRY: 'Russia',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Address added:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addAddress() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.address.add',
+            params: {
+              fields: {
+                TYPE_ID: 1,            // Address type, see crm.enum.addresstype
+                ENTITY_TYPE_ID: 8,     // Parent object type (requisite or lead)
+                ENTITY_ID: 1,          // Requisite identifier
+                ADDRESS_1: '4 Peace Avenue',
+                ADDRESS_2: 'Kaliningrad Regional Drama Theater',
+                CITY: 'Kaliningrad',
+                POSTAL_CODE: '236036',
+                REGION: 'Kaliningrad urban district',
+                PROVINCE: 'Kaliningrad Oblast',
+                COUNTRY: 'Russia',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Address added:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addAddress)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/addresses/crm-address-delete.md
+++ b/api-reference/crm/requisites/addresses/crm-address-delete.md
@@ -79,34 +79,81 @@
     https://**put_your_bitrix24_address**/rest/crm.address.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.address.delete",
-    		{
-    			fields:
-    			{
-    				"TYPE_ID": 1,
-    				"ENTITY_TYPE_ID": 3,
-    				"ENTITY_ID": 1
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.address.delete',
+        params: {
+          fields: {
+            TYPE_ID: 1,
+            ENTITY_TYPE_ID: 3,
+            ENTITY_ID: 1,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Address deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteAddress() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.address.delete',
+            params: {
+              fields: {
+                TYPE_ID: 1,
+                ENTITY_TYPE_ID: 3,
+                ENTITY_ID: 1,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Address deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteAddress)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/addresses/crm-address-fields.md
+++ b/api-reference/crm/requisites/addresses/crm-address-fields.md
@@ -43,31 +43,84 @@
     https://**put_your_bitrix24_address**/rest/crm.address.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.address.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddressFieldsResult = Record<string, FieldDescriptor>
+
+    type FieldDescriptor = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AddressFieldsResult>({
+        method: 'crm.address.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Address field names:', Object.keys(result))
+        console.info('TYPE_ID field:', result['TYPE_ID'])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAddressFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.address.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Address field names:', Object.keys(result))
+          console.info('TYPE_ID field:', result['TYPE_ID'])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAddressFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/addresses/crm-address-list.md
+++ b/api-reference/crm/requisites/addresses/crm-address-list.md
@@ -170,48 +170,105 @@
     https://**put_your_bitrix24_address**/rest/crm.address.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.address.list',
-        {
-          order: { "TYPE_ID": "asc"},
-          filter: { "ENTITY_TYPE_ID": 8, "ENTITY_ID": 7335},
-          limit: 10
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each AddressItem returned in result[]
+    type AddressItem = {
+      TYPE_ID: string
+      ENTITY_TYPE_ID: string
+      ENTITY_ID: string
+      ADDRESS_1: string
+      ADDRESS_2: string
+      CITY: string
+      POSTAL_CODE: string
+      REGION: string
+      PROVINCE: string
+      COUNTRY: string
+      COUNTRY_CODE: string | null
+      LOC_ADDR_ID: string
+      ANCHOR_TYPE_ID: string
+      ANCHOR_ID: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('crm.address.list', { order: { "TYPE_ID": "asc"}, filter: { "ENTITY_TYPE_ID": 8, "ENTITY_ID": 7335}, limit: 10 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // crm.address.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<AddressItem[]>({
+        method: 'crm.address.list',
+        params: {
+          order: { TYPE_ID: 'asc' },
+          filter: { ENTITY_TYPE_ID: 8, ENTITY_ID: 7335 },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Addresses found:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.address.list', { order: { "TYPE_ID": "asc"}, filter: { "ENTITY_TYPE_ID": 8, "ENTITY_ID": 7335}, limit: 10 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchAddressList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.address.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.address.list',
+            params: {
+              order: { TYPE_ID: 'asc' },
+              filter: { ENTITY_TYPE_ID: 8, ENTITY_ID: 7335 },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Addresses found:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchAddressList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/addresses/crm-address-update.md
+++ b/api-reference/crm/requisites/addresses/crm-address-update.md
@@ -108,36 +108,85 @@
     https://**put_your_bitrix24_address**/rest/crm.address.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.address.update",
-    		{
-    			fields:
-    			{
-    				"TYPE_ID": 1,           //
-    				"ENTITY_TYPE_ID": 3,    // - Идентифицирующие поля.
-    				"ENTITY_ID": 1,         //
-    				"ADDRESS_1": "Московский проспект, 261", // - Поля, значения которых меняются.
-    				"CITY": "Калининград"                    //
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.address.update',
+        params: {
+          fields: {
+            TYPE_ID: 1,           // identifies the address
+            ENTITY_TYPE_ID: 3,    // identifies the address
+            ENTITY_ID: 1,         // identifies the address
+            ADDRESS_1: 'Moskovskiy prospect, 261', // field to update
+            CITY: 'Kaliningrad',                   // field to update
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Address updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateAddress() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.address.update',
+            params: {
+              fields: {
+                TYPE_ID: 1,           // identifies the address
+                ENTITY_TYPE_ID: 3,    // identifies the address
+                ENTITY_ID: 1,         // identifies the address
+                ADDRESS_1: 'Moskovskiy prospect, 261', // field to update
+                CITY: 'Kaliningrad',                   // field to update
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Address updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateAddress)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-add.md
+++ b/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-add.md
@@ -126,40 +126,99 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.bankdetail.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.bankdetail.add",
-    		{
-    			fields:
-    			{
-    				"ENTITY_ID": 27,                 // Идентификатор реквизита
-    				"COUNTRY_ID": 1,                 // Код страны (Россия)
-    				"NAME": "Супербанк",              // Название банковского реквизита
-    				"RQ_BANK_NAME": "ПАО Супербанк",  // Наименование банка
-    				"RQ_BANK_ADDR": "117312, г. Москва, улица Вавилова, дом 19",
-    				"RQ_BIK": "044525225",
-    				"RQ_ACC_NUM": "40702810938000060473",
-    				"RQ_ACC_CURRENCY": "RUR",
-    				"RQ_COR_ACC_NUM": "30101810400000000225",
-    				"XML_ID":"1e4641fd-2dd9-31e6-b2f2-105056c00008",
-    				"ACTIVE":"Y",
-    				"SORT":600
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("Создан банковский реквизит с ID " + result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.requisite.bankdetail.add',
+        params: {
+          fields: {
+            ENTITY_ID: 27,           // Requisite ID
+            COUNTRY_ID: 1,           // Country code (Russia)
+            NAME: 'Superbank',       // Bank detail name
+            RQ_BANK_NAME: 'JSC Superbank',  // Bank name
+            RQ_BANK_ADDR: '117312, Moscow, Vavilova str., 19',
+            RQ_BIK: '044525225',
+            RQ_ACC_NUM: '40702810938000060473',
+            RQ_ACC_CURRENCY: 'RUR',
+            RQ_COR_ACC_NUM: '30101810400000000225',
+            XML_ID: '1e4641fd-2dd9-31e6-b2f2-105056c00008',
+            ACTIVE: 'Y',
+            SORT: 600,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created bank detail with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBankDetail() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.bankdetail.add',
+            params: {
+              fields: {
+                ENTITY_ID: 27,           // Requisite ID
+                COUNTRY_ID: 1,           // Country code (Russia)
+                NAME: 'Superbank',       // Bank detail name
+                RQ_BANK_NAME: 'JSC Superbank',  // Bank name
+                RQ_BANK_ADDR: '117312, Moscow, Vavilova str., 19',
+                RQ_BIK: '044525225',
+                RQ_ACC_NUM: '40702810938000060473',
+                RQ_ACC_CURRENCY: 'RUR',
+                RQ_COR_ACC_NUM: '30101810400000000225',
+                XML_ID: '1e4641fd-2dd9-31e6-b2f2-105056c00008',
+                ACTIVE: 'Y',
+                SORT: 600,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created bank detail with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBankDetail)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-delete.md
+++ b/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-delete.md
@@ -52,31 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.bankdetail.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.bankdetail.delete',
-    		{ id: 357 }
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.info(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.bankdetail.delete',
+        params: {
+          id: 357,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bank detail deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteBankDetail() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.bankdetail.delete',
+            params: {
+              id: 357,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bank detail deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteBankDetail)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-fields.md
+++ b/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-fields.md
@@ -43,24 +43,82 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.bankdetail.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.bankdetail.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type FieldAttributes = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BankDetailFieldsResult = Record<string, FieldAttributes>
+
+    try {
+      const response = await $b24.actions.v2.call.make<BankDetailFieldsResult>({
+        method: 'crm.requisite.bankdetail.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bank detail fields:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBankDetailFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.bankdetail.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bank detail fields:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBankDetailFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-get.md
+++ b/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-get.md
@@ -54,31 +54,110 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.bankdetail.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.bankdetail.get',
-    		{ id: 357 }
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BankDetailGetResult = {
+      ID: string
+      ENTITY_ID: string
+      COUNTRY_ID: string
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+      CREATED_BY_ID: string
+      MODIFY_BY_ID: string | null
+      NAME: string
+      CODE: string | null
+      XML_ID: string
+      ORIGINATOR_ID: string | null
+      ACTIVE: string
+      SORT: string
+      RQ_BANK_NAME: string | null
+      RQ_BANK_CODE: string | null
+      RQ_BANK_ADDR: string | null
+      RQ_BANK_ROUTE_NUM: string | null
+      RQ_BIK: string | null
+      RQ_MFO: string | null
+      RQ_ACC_NAME: string | null
+      RQ_ACC_NUM: string | null
+      RQ_ACC_TYPE: string | null
+      RQ_IIK: string | null
+      RQ_ACC_CURRENCY: string | null
+      RQ_COR_ACC_NUM: string | null
+      RQ_IBAN: string | null
+      RQ_SWIFT: string | null
+      RQ_BIC: string | null
+      RQ_CODEB: string | null
+      RQ_CODEG: string | null
+      RQ_RIB: string | null
+      RQ_AGENCY_NAME: string | null
+      COMMENTS: string | null
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BankDetailGetResult>({
+        method: 'crm.requisite.bankdetail.get',
+        params: {
+          id: 357,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bank detail:', result.ID, result.NAME, result.RQ_BIK)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBankDetail() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.bankdetail.get',
+            params: {
+              id: 357,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bank detail:', result.ID, result.NAME, result.RQ_BIK)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBankDetail)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-list.md
+++ b/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-list.md
@@ -184,56 +184,96 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.bankdetail.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.requisite.bankdetail.list',
-        {
-          order: { "DATE_CREATE": "ASC" },
-          filter: { "COUNTRY_ID": "1" },
-          select: [ "ENTITY_ID", "ID", "NAME" ]
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each bank detail item returned in result[]
+    type BankDetailItem = {
+      ID: string
+      ENTITY_ID: string
+      NAME: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('crm.requisite.bankdetail.list', {
-        order: { "DATE_CREATE": "ASC" },
-        filter: { "COUNTRY_ID": "1" },
-        select: [ "ENTITY_ID", "ID", "NAME" ]
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // crm.requisite.bankdetail.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<BankDetailItem[]>({
+        method: 'crm.requisite.bankdetail.list',
+        params: {
+          order: { DATE_CREATE: 'ASC' },
+          filter: { COUNTRY_ID: '1' },
+          select: ['ENTITY_ID', 'ID', 'NAME'],
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bank details count:', result.length, 'Items:', result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.requisite.bankdetail.list', {
-        order: { "DATE_CREATE": "ASC" },
-        filter: { "COUNTRY_ID": "1" },
-        select: [ "ENTITY_ID", "ID", "NAME" ]
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listBankDetails() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.requisite.bankdetail.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.bankdetail.list',
+            params: {
+              order: { DATE_CREATE: 'ASC' },
+              filter: { COUNTRY_ID: '1' },
+              select: ['ENTITY_ID', 'ID', 'NAME'],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bank details count:', result.length, 'Items:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listBankDetails)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-update.md
+++ b/api-reference/crm/requisites/bank-detail/crm-requisite-bank-detail-update.md
@@ -121,33 +121,85 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.bankdetail.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.bankdetail.update",
-    		{
-    			id: 357,
-    			fields:
-    			{
-    				"NAME": "ПАО Супербанк (не использовать)",
-    				"COMMENTS": "Устаревший",
-    				"SORT" : 10000,
-    				"ACTIVE": "N"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.bankdetail.update',
+        params: {
+          id: 357,
+          fields: {
+            NAME: 'PAO Superbank (do not use)',
+            COMMENTS: 'Deprecated',
+            SORT: 10000,
+            ACTIVE: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bank detail updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBankDetail() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.bankdetail.update',
+            params: {
+              id: 357,
+              fields: {
+                NAME: 'PAO Superbank (do not use)',
+                COMMENTS: 'Deprecated',
+                SORT: 10000,
+                ACTIVE: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bank detail updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBankDetail)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/links/crm-requisite-link-fields.md
+++ b/api-reference/crm/requisites/links/crm-requisite-link-fields.md
@@ -43,24 +43,82 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.link.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.link.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RequisiteLinkFieldsResult = Record<string, FieldItem>
+
+    try {
+      const response = await $b24.actions.v2.call.make<RequisiteLinkFieldsResult>({
+        method: 'crm.requisite.link.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result), result['ENTITY_TYPE_ID'])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRequisiteLinkFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.link.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result), result['ENTITY_TYPE_ID'])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRequisiteLinkFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/links/crm-requisite-link-get.md
+++ b/api-reference/crm/requisites/links/crm-requisite-link-get.md
@@ -67,26 +67,85 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.link.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.link.get", {
-    			entityTypeId: 31,        // Идентификатор типа (Счёт)
-    			entityId: 315,             // Идентификатор счёта
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RequisiteLinkGetResult = {
+      ENTITY_TYPE_ID: number
+      ENTITY_ID: number
+      REQUISITE_ID: string
+      BANK_DETAIL_ID: string
+      MC_REQUISITE_ID: string
+      MC_BANK_DETAIL_ID: string
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RequisiteLinkGetResult>({
+        method: 'crm.requisite.link.get',
+        params: {
+          entityTypeId: 31,
+          entityId: 315,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ENTITY_TYPE_ID, result.ENTITY_ID, result.REQUISITE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRequisiteLink() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.link.get',
+            params: {
+              entityTypeId: 31,
+              entityId: 315,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ENTITY_TYPE_ID, result.ENTITY_ID, result.REQUISITE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRequisiteLink)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/links/crm-requisite-link-list.md
+++ b/api-reference/crm/requisites/links/crm-requisite-link-list.md
@@ -139,53 +139,97 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.link.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.requisite.link.list',
-        {
-          order: { "ENTITY_ID": "ASC" },
-          filter: { "@ENTITY_TYPE_ID": [1, 2, 7, 31] }    // Лиды, сделки, предложения, счёта.
-        },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type RequisiteLinkItem = {
+      ENTITY_TYPE_ID: string
+      ENTITY_ID: string
+      REQUISITE_ID: string
+      BANK_DETAIL_ID: string
+      MC_REQUISITE_ID: string
+      MC_BANK_DETAIL_ID: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('crm.requisite.link.list', {
-        order: { "ENTITY_ID": "ASC" },
-        filter: { "@ENTITY_TYPE_ID": [1, 2, 7, 31] }    // Лиды, сделки, предложения, счёта.
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+      // crm.requisite.link.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<RequisiteLinkItem[]>({
+        method: 'crm.requisite.link.list',
+        params: {
+          order: { ENTITY_ID: 'ASC' },
+          filter: { '@ENTITY_TYPE_ID': [1, 2, 7, 31] }, // Leads, deals, quotes, invoices
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Requisite links count:', result.length, 'First item:', result[0])
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.requisite.link.list', {
-        order: { "ENTITY_ID": "ASC" },
-        filter: { "@ENTITY_TYPE_ID": [1, 2, 7, 31] }    // Лиды, сделки, предложения, счёта.
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listRequisiteLinks() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.requisite.link.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.link.list',
+            params: {
+              order: { ENTITY_ID: 'ASC' },
+              filter: { '@ENTITY_TYPE_ID': [1, 2, 7, 31] }, // Leads, deals, quotes, invoices
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Requisite links count:', result.length, 'First item:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listRequisiteLinks)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/links/crm-requisite-link-register.md
+++ b/api-reference/crm/requisites/links/crm-requisite-link-register.md
@@ -95,32 +95,87 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.link.register
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.link.register", {
-    			fields: {
-    				ENTITY_TYPE_ID: 31,
-    				ENTITY_ID: 315,
-    				REQUISITE_ID: 60,
-    				BANK_DETAIL_ID: 24,
-    				MC_REQUISITE_ID: 2,
-    				MC_BANK_DETAIL_ID: 2
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.link.register',
+        params: {
+          fields: {
+            ENTITY_TYPE_ID: 31,
+            ENTITY_ID: 315,
+            REQUISITE_ID: 60,
+            BANK_DETAIL_ID: 24,
+            MC_REQUISITE_ID: 2,
+            MC_BANK_DETAIL_ID: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Link registered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerRequisiteLink() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.link.register',
+            params: {
+              fields: {
+                ENTITY_TYPE_ID: 31,
+                ENTITY_ID: 315,
+                REQUISITE_ID: 60,
+                BANK_DETAIL_ID: 24,
+                MC_REQUISITE_ID: 2,
+                MC_BANK_DETAIL_ID: 2,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Link registered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerRequisiteLink)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/links/crm-requisite-link-unregister.md
+++ b/api-reference/crm/requisites/links/crm-requisite-link-unregister.md
@@ -66,33 +66,75 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.link.unregister
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.link.unregister", {
-    			entityTypeId: 31,
-    			entityId: 315
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.link.unregister',
+        params: {
+          entityTypeId: 31,
+          entityId: 315,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Link unregistered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unregisterRequisiteLink() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.link.unregister',
+            params: {
+              entityTypeId: 31,
+              entityId: 315,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Link unregistered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unregisterRequisiteLink)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-add.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-add.md
@@ -82,34 +82,87 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.add",
-    		{
-    			fields:
-    			{
-    				"ENTITY_TYPE_ID": 8,    // Для шаблона реквизитов всегда указывается "Реквизит" (идентификатор 8), см. crm.enum.ownertype
-    				"COUNTRY_ID": 1,        // Россия
-    				"NAME": "ИП",
-    				"XML_ID": "EXAMPLE_COMPANY__VALUE_1",    // Уникальный внешний идентификатор
-    				"ACTIVE": "Y",
-    				"SORT": 520    // Порядок в списке шаблонов
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("Создан шаблон с ID " + result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.requisite.preset.add',
+        params: {
+          fields: {
+            ENTITY_TYPE_ID: 8,    // For a requisite preset, always use "Requisite" (ID 8), see crm.enum.ownertype
+            COUNTRY_ID: 1,        // Russia
+            NAME: 'Sole Proprietor',
+            XML_ID: 'EXAMPLE_COMPANY__VALUE_1',    // Unique external identifier
+            ACTIVE: 'Y',
+            SORT: 520,            // Position in the preset list
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created preset with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRequisitePreset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.add',
+            params: {
+              fields: {
+                ENTITY_TYPE_ID: 8,    // For a requisite preset, always use "Requisite" (ID 8), see crm.enum.ownertype
+                COUNTRY_ID: 1,        // Russia
+                NAME: 'Sole Proprietor',
+                XML_ID: 'EXAMPLE_COMPANY__VALUE_1',    // Unique external identifier
+                ACTIVE: 'Y',
+                SORT: 520,            // Position in the preset list
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created preset with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRequisitePreset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-countries.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-countries.md
@@ -43,24 +43,76 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.countries
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.preset.countries',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of each country item returned in result[]
+    type CountryItem = {
+      ID: number,
+      CODE: string,
+      TITLE: string,
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CountryItem[]>({
+        method: 'crm.requisite.preset.countries',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Countries count:', result.length, 'First country:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCountries() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.countries',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Countries count:', result.length, 'First country:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCountries)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-delete.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-delete.md
@@ -54,33 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.delete",
-    		{
-    			id: 347    // Идентификатор удаляемого шаблона
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.preset.delete',
+        params: {
+          id: 347,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preset deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePreset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.delete',
+            params: {
+              id: 347,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Preset deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePreset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-fields.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-fields.md
@@ -45,31 +45,84 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.fields",
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    type FieldAttributeItem = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PresetFieldsResult = Record<string, FieldAttributeItem>
+
+    try {
+      const response = await $b24.actions.v2.call.make<PresetFieldsResult>({
+        method: 'crm.requisite.preset.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preset field names:', Object.keys(result))
+        console.info('First field details:', result[Object.keys(result)[0]])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPresetFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Preset field names:', Object.keys(result))
+          console.info('First field details:', result[Object.keys(result)[0]])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPresetFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-get.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-get.md
@@ -52,24 +52,88 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.get",
-    		{ id: 347 }    // Идентификатор шаблона реквизита.
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RequisitePresetResult = {
+      ID: string
+      ENTITY_TYPE_ID: string
+      COUNTRY_ID: string
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+      CREATED_BY_ID: string
+      MODIFY_BY_ID: string | null
+      NAME: string
+      XML_ID: string
+      ACTIVE: string
+      SORT: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RequisitePresetResult>({
+        method: 'crm.requisite.preset.get',
+        params: {
+          id: 347,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.ACTIVE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRequisitePreset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.get',
+            params: {
+              id: 347,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.ACTIVE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRequisitePreset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-list.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-list.md
@@ -140,59 +140,95 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each PresetItem returned in result[]
+    type PresetItem = {
+      ID: string
+      NAME: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.requisite.preset.list',
-        {
-          order: { "ID": "ASC" },
-          filter: { "COUNTRY_ID": "1"},
-          select: [ "ID", "NAME"]
+      // crm.requisite.preset.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PresetItem[]>({
+        method: 'crm.requisite.preset.list',
+        params: {
+          order: { ID: 'ASC' },
+          filter: { COUNTRY_ID: '1' },
+          select: ['ID', 'NAME'],
+          start: 0,
         },
-        (progress) => { 
-          if(progress.error())
-            console.error(progress.error());
-          else
-          {
-            console.dir(progress.data());
-            if(progress.more())
-              progress.next();
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preset count on this page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchRequisitePresets() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.requisite.preset.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.list',
+            params: {
+              order: { ID: 'ASC' },
+              filter: { COUNTRY_ID: '1' },
+              select: ['ID', 'NAME'],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-        }
-      )
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.requisite.preset.list', { order: { "ID": "ASC" }, filter: { "COUNTRY_ID": "1"}, select: [ "ID", "NAME"] }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { 
-          console.dir(entity);
+
+          const result = response.getData().result
+          console.info('Preset count on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
       }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.requisite.preset.list', { order: { "ID": "ASC" }, filter: { "COUNTRY_ID": "1"}, select: [ "ID", "NAME"] }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { 
-        console.dir(entity);
-      }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+
+      document.addEventListener('DOMContentLoaded', fetchRequisitePresets)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/crm-requisite-preset-update.md
+++ b/api-reference/crm/requisites/presets/crm-requisite-preset-update.md
@@ -77,31 +77,81 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.update",
-    		{
-    			id: 347,    // Идентификатор шаблона, который нужно изменить.
-    			fields:
-    			{
-    				"NAME": "ИП (архив)",
-    				"ACTIVE": "N"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.preset.update',
+        params: {
+          id: 347,
+          fields: {
+            NAME: 'IP (archive)',
+            ACTIVE: 'N',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preset updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateRequisitePreset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.update',
+            params: {
+              id: 347,
+              fields: {
+                NAME: 'IP (archive)',
+                ACTIVE: 'N',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Preset updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateRequisitePreset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-add.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-add.md
@@ -78,36 +78,89 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.field.add",
-    		{
-    			preset:
-    			{
-    				"ID": 27    // Идентификатор шаблона
-    			},
-    			fields:        // Объект с описанием настраиваемого поля
-    			{
-    				"FIELD_NAME": "RQ_NAME",
-    				"FIELD_TITLE": "TEST",
-    				"IN_SHORT_LIST": "N",
-    				"SORT": 580
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("В шаблон добавлено настраиваемое поле с ID " + result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.requisite.preset.field.add',
+        params: {
+          preset: {
+            ID: 27, // Template ID
+          },
+          fields: {
+            FIELD_NAME: 'RQ_NAME',
+            FIELD_TITLE: 'TEST',
+            IN_SHORT_LIST: 'N',
+            SORT: 580,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added field ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPresetField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.add',
+            params: {
+              preset: {
+                ID: 27, // Template ID
+              },
+              fields: {
+                FIELD_NAME: 'RQ_NAME',
+                FIELD_TITLE: 'TEST',
+                IN_SHORT_LIST: 'N',
+                SORT: 580,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added field ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPresetField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-available-to-add.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-available-to-add.md
@@ -56,36 +56,77 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.availabletoadd
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.field.availabletoadd",
-    		{
-    			preset:
-    			{
-    				"ID": 27
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'crm.requisite.preset.field.availabletoadd',
+        params: {
+          preset: {
+            ID: 27,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available fields:', result, 'Count:', result.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAvailablePresetFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.availabletoadd',
+            params: {
+              preset: {
+                ID: 27,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available fields:', result, 'Count:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAvailablePresetFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-delete.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-delete.md
@@ -58,37 +58,79 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.field.delete",
-    		{
-    			ID: 27,
-    			preset:
-    			{
-    				"ID": 1
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.preset.field.delete',
+        params: {
+          ID: 27,
+          preset: {
+            ID: 1,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePresetField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.delete',
+            params: {
+              ID: 27,
+              preset: {
+                ID: 1,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePresetField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-fields.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-fields.md
@@ -43,24 +43,82 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.preset.field.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type FieldDescriptor = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PresetFieldFieldsResult = Record<string, FieldDescriptor>
+
+    try {
+      const response = await $b24.actions.v2.call.make<PresetFieldFieldsResult>({
+        method: 'crm.requisite.preset.field.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preset field descriptors:', Object.keys(result), result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPresetFieldFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Preset field descriptors:', Object.keys(result), result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPresetFieldFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-get.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-get.md
@@ -58,37 +58,88 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.field.get",
-    		{
-    			ID: 1,          // Идентификатор настраиваемого поля
-    			preset:
-    			{
-    				"ID": 27    // Идентификатор шаблона реквизитов
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PresetFieldResult = {
+      ID: number
+      FIELD_NAME: string
+      FIELD_TITLE: string
+      IN_SHORT_LIST: string
+      SORT: number
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PresetFieldResult>({
+        method: 'crm.requisite.preset.field.get',
+        params: {
+          ID: 1,
+          preset: {
+            ID: 27,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.FIELD_NAME, result.FIELD_TITLE, result.SORT)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPresetField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.get',
+            params: {
+              ID: 1,
+              preset: {
+                ID: 27,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.FIELD_NAME, result.FIELD_TITLE, result.SORT)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPresetField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-list.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-list.md
@@ -52,55 +52,98 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.requisite.preset.field.list',
-        {
-          preset: {
-            "ID": 27
-          }
-        }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type PresetFieldItem = {
+      ID: number
+      FIELD_NAME: string
+      FIELD_TITLE: string
+      IN_SHORT_LIST: string
+      SORT: number
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('crm.requisite.preset.field.list', {
-        preset: {
-          "ID": 27
-        }
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // crm.requisite.preset.field.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PresetFieldItem[]>({
+        method: 'crm.requisite.preset.field.list',
+        params: {
+          preset: {
+            ID: 27,
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preset fields:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.requisite.preset.field.list', {
-        preset: {
-          "ID": 27
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listPresetFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.requisite.preset.field.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.list',
+            params: {
+              preset: {
+                ID: 27,
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Preset fields:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listPresetFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-update.md
+++ b/api-reference/crm/requisites/presets/fields/crm-requisite-preset-field-update.md
@@ -84,36 +84,89 @@ API требует указать значение в этом поле. Есл�
     https://**put_your_bitrix24_address**/rest/crm.requisite.preset.field.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.preset.field.update",
-    		{
-    			ID: 1,
-    			preset:
-    			{
-    				"ID": 27
-    			},
-    			fields:
-    			{
-    				"FIELD_NAME": "RQ_NAME",
-    				"FIELD_TITLE": "Имя",
-    				"IN_SHORT_LIST": "Y",
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.preset.field.update',
+        params: {
+          ID: 1,
+          preset: {
+            ID: 27,
+          },
+          fields: {
+            FIELD_NAME: 'RQ_NAME',
+            FIELD_TITLE: 'Name',
+            IN_SHORT_LIST: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePresetField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.preset.field.update',
+            params: {
+              ID: 1,
+              preset: {
+                ID: 27,
+              },
+              fields: {
+                FIELD_NAME: 'RQ_NAME',
+                FIELD_TITLE: 'Name',
+                IN_SHORT_LIST: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePresetField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/universal/crm-requisite-add.md
+++ b/api-reference/crm/requisites/universal/crm-requisite-add.md
@@ -239,45 +239,109 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.add",
-    		{
-    			fields:
-    			{
-    				"ENTITY_TYPE_ID": 4,
-    				"ENTITY_ID": 1,
-    				"PRESET_ID": 1,
-    				"NAME": "Организация",
-    				"ACTIVE": "Y",
-    				"ADDRESS_ONLY": "N",
-    				"SORT": 500,
-    				"RQ_COMPANY_NAME": "ООО \"1С-БИТРИКС\"",
-    				"RQ_COMPANY_FULL_NAME": "ОБЩЕСТВО С ОГРАНИЧЕННОЙ ОТВЕТСТВЕННОСТЬЮ \"1С-БИТРИКС\"",
-    				"RQ_COMPANY_REG_DATE": "06.04.2007",
-    				"RQ_DIRECTOR": "РЫЖИКОВ СЕРГЕЙ ВЛАДИМИРОВИЧ",
-    				"RQ_INN": "7717586110",
-    				"RQ_KPP": "770501001",
-    				"RQ_OGRN": "5077746476209",
-    				"UF_CRM_1707997209": "56",
-    				"UF_CRM_1708012333": "Категория 1",
-    				"XML_ID": "5e4641fd-1dd9-11e6-b2f2-005056c00008"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("Создан реквизит с ID " + result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.requisite.add',
+        params: {
+          fields: {
+            ENTITY_TYPE_ID: 4,
+            ENTITY_ID: 1,
+            PRESET_ID: 1,
+            NAME: 'Organization',
+            ACTIVE: 'Y',
+            ADDRESS_ONLY: 'N',
+            SORT: 500,
+            RQ_COMPANY_NAME: 'LLC "1C-BITRIX"',
+            RQ_COMPANY_FULL_NAME: 'LIMITED LIABILITY COMPANY "1C-BITRIX"',
+            RQ_COMPANY_REG_DATE: '06.04.2007',
+            RQ_DIRECTOR: 'RYZHIKOV SERGEY VLADIMIROVICH',
+            RQ_INN: '7717586110',
+            RQ_KPP: '770501001',
+            RQ_OGRN: '5077746476209',
+            UF_CRM_1707997209: '56',
+            UF_CRM_1708012333: 'Category 1',
+            XML_ID: '5e4641fd-1dd9-11e6-b2f2-005056c00008',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created requisite with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRequisite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.add',
+            params: {
+              fields: {
+                ENTITY_TYPE_ID: 4,
+                ENTITY_ID: 1,
+                PRESET_ID: 1,
+                NAME: 'Organization',
+                ACTIVE: 'Y',
+                ADDRESS_ONLY: 'N',
+                SORT: 500,
+                RQ_COMPANY_NAME: 'LLC "1C-BITRIX"',
+                RQ_COMPANY_FULL_NAME: 'LIMITED LIABILITY COMPANY "1C-BITRIX"',
+                RQ_COMPANY_REG_DATE: '06.04.2007',
+                RQ_DIRECTOR: 'RYZHIKOV SERGEY VLADIMIROVICH',
+                RQ_INN: '7717586110',
+                RQ_KPP: '770501001',
+                RQ_OGRN: '5077746476209',
+                UF_CRM_1707997209: '56',
+                UF_CRM_1708012333: 'Category 1',
+                XML_ID: '5e4641fd-1dd9-11e6-b2f2-005056c00008',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created requisite with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRequisite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/universal/crm-requisite-delete.md
+++ b/api-reference/crm/requisites/universal/crm-requisite-delete.md
@@ -54,33 +54,73 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.delete',
-    		{
-    			id: 27
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.info(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.delete',
+        params: {
+          id: 27,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Requisite deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteRequisite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.delete',
+            params: {
+              id: 27,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Requisite deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteRequisite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/universal/crm-requisite-fields.md
+++ b/api-reference/crm/requisites/universal/crm-requisite-fields.md
@@ -43,31 +43,87 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    type FieldInfo = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      statusType?: string[]
+      listLabel?: string
+      formLabel?: string
+      filterLabel?: string
+      settings?: Record<string, unknown>
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RequisiteFieldsResult = Record<string, FieldInfo>
+
+    try {
+      const response = await $b24.actions.v2.call.make<RequisiteFieldsResult>({
+        method: 'crm.requisite.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result).length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRequisiteFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result).length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRequisiteFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/universal/crm-requisite-get.md
+++ b/api-reference/crm/requisites/universal/crm-requisite-get.md
@@ -54,33 +54,100 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.get",
-    		{
-    			id: 27
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RequisiteGetResult = {
+      ID: string
+      ENTITY_TYPE_ID: string
+      ENTITY_ID: string
+      PRESET_ID: string
+      DATE_CREATE: ISODate | null
+      DATE_MODIFY: ISODate | null
+      CREATED_BY_ID: string
+      MODIFY_BY_ID: string | null
+      NAME: string
+      CODE: string | null
+      XML_ID: string | null
+      ORIGINATOR_ID: string | null
+      ACTIVE: string
+      ADDRESS_ONLY: string
+      SORT: string
+      RQ_COMPANY_NAME: string | null
+      RQ_COMPANY_FULL_NAME: string | null
+      RQ_COMPANY_REG_DATE: string | null
+      RQ_DIRECTOR: string | null
+      RQ_INN: string | null
+      RQ_KPP: string | null
+      RQ_OGRN: string | null
+      RQ_VAT_PAYER: string | null
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RequisiteGetResult>({
+        method: 'crm.requisite.get',
+        params: {
+          id: 27,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.ENTITY_TYPE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRequisite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.get',
+            params: {
+              id: 27,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.ENTITY_TYPE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRequisite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/universal/crm-requisite-list.md
+++ b/api-reference/crm/requisites/universal/crm-requisite-list.md
@@ -108,28 +108,97 @@
         https://**put_your_bitrix24_address**/rest/crm.requisite.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.requisite.list",
-            {
-                order: { "DATE_CREATE": "ASC" },
-                filter: { "PRESET_ID": "1"},
-                select: [ "ENTITY_TYPE_ID", "ENTITY_ID", "ID", "NAME" ]
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of each RequisiteResult returned in result[]
+        type RequisiteResult = {
+          ENTITY_TYPE_ID: string
+          ENTITY_ID: string
+          ID: string
+          NAME: string
+        }
+
+        try {
+          // crm.requisite.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make<RequisiteResult[]>({
+            method: 'crm.requisite.list',
+            params: {
+              order: { DATE_CREATE: 'ASC' },
+              filter: { PRESET_ID: '1' },
+              select: ['ENTITY_TYPE_ID', 'ENTITY_ID', 'ID', 'NAME'],
+              start: 0,
             },
-            function(result)
-            {
-                if(result.error())
-                    console.error(result.error());
-                else
-                {
-                    console.dir(result.data());
-                    if(result.more())
-                        result.next();
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Requisites:', result.length, result)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getRequisiteList() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.requisite.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.requisite.list',
+                params: {
+                  order: { DATE_CREATE: 'ASC' },
+                  filter: { PRESET_ID: '1' },
+                  select: ['ENTITY_TYPE_ID', 'ENTITY_ID', 'ID', 'NAME'],
+                  start: 0,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Requisites:', result.length, result)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', getRequisiteList)
+        </script>
         ```
 
     - PHP
@@ -177,28 +246,94 @@
         https://**put_your_bitrix24_address**/rest/crm.requisite.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            "crm.requisite.list",
-            {
-                order: {},
-                filter: { "ID": "51"}, // Идентификатор реквизита
-                select: [ "UF_CRM_1707997209"] // Идентификатор пользовательского поля
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of each RequisiteUserField returned in result[]
+        type RequisiteUserField = {
+          UF_CRM_1707997209: string
+        }
+
+        try {
+          // crm.requisite.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make<RequisiteUserField[]>({
+            method: 'crm.requisite.list',
+            params: {
+              order: {},
+              filter: { ID: '51' }, // Requisite ID
+              select: ['UF_CRM_1707997209'], // User-defined field ID
+              start: 0,
             },
-            function(result)
-            {
-                if(result.error())
-                    console.error(result.error());
-                else
-                {
-                    console.dir(result.data());    
-                    if(result.more())
-                        result.next();        
-                }
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('User field value:', result[0]?.UF_CRM_1707997209)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getRequisiteUserField() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.requisite.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.requisite.list',
+                params: {
+                  order: {},
+                  filter: { ID: '51' }, // Requisite ID
+                  select: ['UF_CRM_1707997209'], // User-defined field ID
+                  start: 0,
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('User field value:', result[0]?.UF_CRM_1707997209)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', getRequisiteUserField)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/requisites/universal/crm-requisite-update.md
+++ b/api-reference/crm/requisites/universal/crm-requisite-update.md
@@ -218,33 +218,85 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.update",
-    		{
-    			id: 27,
-    			fields:
-    			{
-    				"RQ_OKPO": "80715150",
-    				"RQ_OKTMO": "45381000000",
-    				"UF_CRM_1707997209": "78",
-    				"UF_CRM_1708012333": "Категория 3"
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.update',
+        params: {
+          id: 27,
+          fields: {
+            RQ_OKPO: '80715150',
+            RQ_OKTMO: '45381000000',
+            UF_CRM_1707997209: '78',
+            UF_CRM_1708012333: 'Category 3',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Requisite updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateRequisite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.update',
+            params: {
+              id: 27,
+              fields: {
+                RQ_OKPO: '80715150',
+                RQ_OKTMO: '45381000000',
+                UF_CRM_1707997209: '78',
+                UF_CRM_1708012333: 'Category 3',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Requisite updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateRequisite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/user-fields/crm-requisite-userfield-add.md
+++ b/api-reference/crm/requisites/user-fields/crm-requisite-userfield-add.md
@@ -137,39 +137,97 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.userfield.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.userfield.add",
-    		{
-    			fields:
-    			{
-    				"USER_TYPE_ID": "string",
-    				"ENTITY_ID": "CRM_REQUISITE",
-    				"SORT": 100,
-    				"MULTIPLE": "N",
-    				"MANDATORY": "N",
-    				"SHOW_FILTER": "E",
-    				"SHOW_IN_LIST": "Y",
-    				"EDIT_FORM_LABEL": "ПП - Строка",
-    				"LIST_COLUMN_LABEL": "ПП - Строка",
-    				"LIST_FILTER_LABEL": "ПП - Строка",
-    				"FIELD_NAME": "NEWTECH_v1_STRING"
-    			}
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.requisite.userfield.add',
+        params: {
+          fields: {
+            USER_TYPE_ID: 'string',
+            ENTITY_ID: 'CRM_REQUISITE',
+            SORT: 100,
+            MULTIPLE: 'N',
+            MANDATORY: 'N',
+            SHOW_FILTER: 'E',
+            SHOW_IN_LIST: 'Y',
+            EDIT_FORM_LABEL: 'PP - String',
+            LIST_COLUMN_LABEL: 'PP - String',
+            LIST_FILTER_LABEL: 'PP - String',
+            FIELD_NAME: 'NEWTECH_v1_STRING',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created user field ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addRequisiteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.userfield.add',
+            params: {
+              fields: {
+                USER_TYPE_ID: 'string',
+                ENTITY_ID: 'CRM_REQUISITE',
+                SORT: 100,
+                MULTIPLE: 'N',
+                MANDATORY: 'N',
+                SHOW_FILTER: 'E',
+                SHOW_IN_LIST: 'Y',
+                EDIT_FORM_LABEL: 'PP - String',
+                LIST_COLUMN_LABEL: 'PP - String',
+                LIST_FILTER_LABEL: 'PP - String',
+                FIELD_NAME: 'NEWTECH_v1_STRING',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created user field ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addRequisiteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/user-fields/crm-requisite-userfield-delete.md
+++ b/api-reference/crm/requisites/user-fields/crm-requisite-userfield-delete.md
@@ -52,33 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.userfield.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.userfield.delete',
-    		{
-    			id: 235
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.info(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.userfield.delete',
+        params: {
+          id: 235,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteRequisiteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.userfield.delete',
+            params: {
+              id: 235,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteRequisiteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/user-fields/crm-requisite-userfield-get.md
+++ b/api-reference/crm/requisites/user-fields/crm-requisite-userfield-get.md
@@ -52,33 +52,95 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.userfield.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.requisite.userfield.get',
-    		{
-    			id: 235
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RequisiteUserFieldGetResult = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+      EDIT_FORM_LABEL: Record<string, string>
+      LIST_COLUMN_LABEL: Record<string, string>
+      LIST_FILTER_LABEL: Record<string, string>
+      ERROR_MESSAGE: Record<string, string>
+      HELP_MESSAGE: Record<string, string>
+      SETTINGS: Record<string, unknown>
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RequisiteUserFieldGetResult>({
+        method: 'crm.requisite.userfield.get',
+        params: {
+          id: 235,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.FIELD_NAME, result.USER_TYPE_ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRequisiteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.userfield.get',
+            params: {
+              id: 235,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.FIELD_NAME, result.USER_TYPE_ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRequisiteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/user-fields/crm-requisite-userfield-list.md
+++ b/api-reference/crm/requisites/user-fields/crm-requisite-userfield-list.md
@@ -154,47 +154,109 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.userfield.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.requisite.userfield.list',
-        {
-          order: { "SORT": "ASC" },
-          filter: { "MANDATORY": "N", "LANG": "ru" }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each UserFieldItem returned in result[]
+    type UserFieldItem = {
+      ID: string
+      ENTITY_ID: string
+      FIELD_NAME: string
+      USER_TYPE_ID: string
+      XML_ID: string | null
+      SORT: string
+      MULTIPLE: string
+      MANDATORY: string
+      SHOW_FILTER: string
+      SHOW_IN_LIST: string
+      EDIT_IN_LIST: string
+      IS_SEARCHABLE: string
+      SETTINGS: Record<string, unknown>
+      EDIT_FORM_LABEL: string | null
+      LIST_COLUMN_LABEL: string | null
+      LIST_FILTER_LABEL: string | null
+      ERROR_MESSAGE: string | null
+      HELP_MESSAGE: string | null
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('crm.requisite.userfield.list', { order: { "SORT": "ASC" }, filter: { "MANDATORY": "N", "LANG": "ru" } }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // crm.requisite.userfield.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<UserFieldItem[]>({
+        method: 'crm.requisite.userfield.list',
+        params: {
+          order: { SORT: 'ASC' },
+          filter: { MANDATORY: 'N', LANG: 'ru' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User fields count:', result.length, 'First field:', result[0]?.FIELD_NAME)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.requisite.userfield.list', { order: { "SORT": "ASC" }, filter: { "MANDATORY": "N", "LANG": "ru" } }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listRequisiteUserFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.requisite.userfield.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.userfield.list',
+            params: {
+              order: { SORT: 'ASC' },
+              filter: { MANDATORY: 'N', LANG: 'ru' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User fields count:', result.length, 'First field:', result[0]?.FIELD_NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listRequisiteUserFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/requisites/user-fields/crm-requisite-userfield-update.md
+++ b/api-reference/crm/requisites/user-fields/crm-requisite-userfield-update.md
@@ -113,32 +113,83 @@
     https://**put_your_bitrix24_address**/rest/crm.requisite.userfield.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.requisite.userfield.update",
-    		{
-    			id: 235,
-    			fields:
-    			{
-    				"EDIT_FORM_LABEL": title,
-    				"LIST_COLUMN_LABEL": title,
-    				"LIST_FILTER_LABEL": title
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.requisite.userfield.update',
+        params: {
+          id: 235,
+          fields: {
+            EDIT_FORM_LABEL: 'Category',
+            LIST_COLUMN_LABEL: 'Category',
+            LIST_FILTER_LABEL: 'Category',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User field updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateRequisiteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.requisite.userfield.update',
+            params: {
+              id: 235,
+              fields: {
+                EDIT_FORM_LABEL: 'Category',
+                LIST_COLUMN_LABEL: 'Category',
+                LIST_FILTER_LABEL: 'Category',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User field updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateRequisiteUserField)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.