### PR TITLE
docs(crm/universal): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/crm/universal/category/crm-category-add.md
+++ b/api-reference/crm/universal/category/crm-category-add.md
@@ -105,31 +105,94 @@ fields: {
     https://**put_your_bitrix24_address**/rest/crm.category.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.category.add',
-    		{
-    			entityTypeId: 1152,
-    			fields: {
-    				name: 'Новая воронка по умолчанию',
-    				sort: 50,
-    				isDefault: 'Y',
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CategoryAddResult = {
+      category: {
+        id: number
+        name: string
+        sort: number
+        entityTypeId: number
+        isDefault: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CategoryAddResult>({
+        method: 'crm.category.add',
+        params: {
+          entityTypeId: 1152,
+          fields: {
+            name: 'New default pipeline',
+            sort: 50,
+            isDefault: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.category.id, result.category.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCategory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.category.add',
+            params: {
+              entityTypeId: 1152,
+              fields: {
+                name: 'New default pipeline',
+                sort: 50,
+                isDefault: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.category.id, result.category.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCategory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/category/crm-category-delete.md
+++ b/api-reference/crm/universal/category/crm-category-delete.md
@@ -63,27 +63,75 @@
     https://**put_your_bitrix24_address**/rest/crm.category.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.category.delete',
-    		{
-    			entityTypeId: 2,
-    			id: 5,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'crm.category.delete',
+        params: {
+          entityTypeId: 2,
+          id: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Category deleted successfully', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteCategory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.category.delete',
+            params: {
+              entityTypeId: 2,
+              id: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Category deleted successfully', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteCategory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/category/crm-category-fields.md
+++ b/api-reference/crm/universal/category/crm-category-fields.md
@@ -52,26 +52,89 @@
     https://**put_your_bitrix24_address**/rest/crm.category.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.category.fields",
-    		{
-    			entityTypeId: 2,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      upperName: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CategoryFieldsResult = {
+      fields: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CategoryFieldsResult>({
+        method: 'crm.category.fields',
+        params: {
+          entityTypeId: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available category fields:', Object.keys(result.fields))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCategoryFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.category.fields',
+            params: {
+              entityTypeId: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available category fields:', Object.keys(result.fields))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCategoryFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/category/crm-category-get.md
+++ b/api-reference/crm/universal/category/crm-category-get.md
@@ -56,27 +56,88 @@
     https://**put_your_bitrix24_address**/rest/crm.category.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.category.get',
-    		{
-    			entityTypeId: 2,
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CategoryGetResult = {
+      category: {
+        id: number
+        name: string
+        sort: number
+        entityTypeId: number
+        isDefault: string
+        originId: string
+        originatorId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CategoryGetResult>({
+        method: 'crm.category.get',
+        params: {
+          entityTypeId: 2,
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.category)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCategoryById() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.category.get',
+            params: {
+              entityTypeId: 2,
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.category)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCategoryById)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/category/crm-category-list.md
+++ b/api-reference/crm/universal/category/crm-category-list.md
@@ -60,46 +60,98 @@
     https://**put_your_bitrix24_address**/rest/crm.category.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'crm.category.list',
-        {
-          entityTypeId: 2,
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CategoryListResult = {
+      categories: Array<{
+        id: number
+        name: string
+        sort: number
+        entityTypeId: number
+        isDefault: 'Y' | 'N'
+        originId?: string
+        originatorId?: string
+      }>
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('crm.category.list', { entityTypeId: 2 }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // crm.category.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CategoryListResult>({
+        method: 'crm.category.list',
+        params: {
+          entityTypeId: 2,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Categories:', result.categories, 'Count:', result.categories.length)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.category.list', { entityTypeId: 2 }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function loadCategoryList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.category.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.category.list',
+            params: {
+              entityTypeId: 2,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Categories:', result.categories, 'Count:', result.categories.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', loadCategoryList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/category/crm-category-update.md
+++ b/api-reference/crm/universal/category/crm-category-update.md
@@ -99,32 +99,96 @@ fields: {
     https://**put_your_bitrix24_address**/rest/crm.category.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.category.update",
-    		{
-    			entityTypeId: 1152,
-    			id: 4,
-    			fields: {
-    				name: "Новое название воронки",
-    				sort: 1000,
-    				isDefault: "Y",
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CategoryUpdateResult = {
+      category: {
+        id: number
+        name: string
+        sort: number
+        entityTypeId: number
+        isDefault: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CategoryUpdateResult>({
+        method: 'crm.category.update',
+        params: {
+          entityTypeId: 1152,
+          id: 4,
+          fields: {
+            name: 'New funnel name',
+            sort: 1000,
+            isDefault: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.category.id, result.category.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCategory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.category.update',
+            params: {
+              entityTypeId: 1152,
+              id: 4,
+              fields: {
+                name: 'New funnel name',
+                sort: 1000,
+                isDefault: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.category.id, result.category.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCategory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/crm-item-add.md
+++ b/api-reference/crm/universal/crm-item-add.md
@@ -1299,55 +1299,146 @@
         https://**put_your_bitrix24_address**/rest/crm.item.add
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        const formatDate = (date) => {
-            return date.toISOString().slice(0, 10);
-        };
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const day = 60 * 60 * 24 * 1000;
+        declare const $b24: B24Frame
 
-        const now = new Date();
-        const twelveDaysInAdvance = new Date(now.getTime() + 12 * day);
-        const monthAgo = new Date(now.getTime() - 30 * day);
+        type CrmItem = {
+          id: number
+          title: string
+        }
 
-        const commentsExample = `
-        Пример комментария внутри сделки
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type ItemAddResult = {
+          item: CrmItem
+        }
 
-        [B]Жирный текст[/B]
-        [I]Курсив[/I]
-        [U]Подчеркнутый[/U]
-        [S]Зачеркнутый[/S]
-        [B][I][U][S]Микс[/S][/U][/I][/B]
+        const formatDate = (date: Date): string => date.toISOString().slice(0, 10)
+        const day = 60 * 60 * 24 * 1000
+        const now = new Date()
+        const twelveDaysInAdvance = new Date(now.getTime() + 12 * day)
+        const monthAgo = new Date(now.getTime() - 30 * day)
 
-        [LIST]
-        [*]Элемент списка #1
-        [*]Элемент списка #2
-        [*]Элемент списка #3
-        [/LIST]
+        const commentsExample = [
+          'Example comment inside a deal',
+          '',
+          '[B]Bold text[/B]',
+          '[I]Italic[/I]',
+          '[U]Underlined[/U]',
+          '[S]Strikethrough[/S]',
+          '[B][I][U][S]Mix[/S][/U][/I][/B]',
+          '',
+          '[LIST]',
+          '[*]List item #1',
+          '[*]List item #2',
+          '[*]List item #3',
+          '[/LIST]',
+        ].join('\n')
 
-        [LIST=1]
-        [*]Нумерованный элемент списка #1
-        [*]Нумерованный элемент списка #2
-        [*]Нумерованный элемент списка #3
-        [/LIST]
-        `;
+        try {
+          const response = await $b24.actions.v2.call.make<ItemAddResult>({
+            method: 'crm.item.add',
+            params: {
+              entityTypeId: 2,
+              fields: {
+                title: 'New deal (specifically for the REST methods example)',
+                typeId: 'SERVICE',
+                categoryId: 9,
+                stageId: 'C9:UC_KN8KFI',
+                isReccurring: 'Y',
+                probability: 50,
+                currencyId: 'RUB',
+                isManualOpportunity: 'Y',
+                opportunity: 999.99,
+                taxValue: 99.9,
+                companyId: 5,
+                contactId: 4,
+                contactIds: [4, 5],
+                quoteId: 7,
+                begindate: formatDate(monthAgo),
+                closedate: formatDate(twelveDaysInAdvance),
+                opened: 'N',
+                comments: commentsExample,
+                assignedById: 6,
+                sourceId: 'WEB',
+                sourceDescription: 'Additional description about the source goes here',
+                leadId: 102,
+                additionalInfo: 'Additional information goes here',
+                observers: [2, 3],
+                utmSource: 'google',
+                utmMedium: 'CPC',
+                ufCrm_1721244707107: 1111.1,
+                parentId1220: 2,
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
 
-        BX24.callMethod(
-            'crm.item.add', 
-            {
-                entityTypeId: 2,
-                fields: 
-                {
-                    title: "Новая сделка (специально для примера REST методов)",
-                    typeId: "SERVICE",
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(`Created item #${result.item.id} (${result.item.title})`)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function addCrmItem() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const formatDate = (date) => date.toISOString().slice(0, 10)
+              const day = 60 * 60 * 24 * 1000
+              const now = new Date()
+              const twelveDaysInAdvance = new Date(now.getTime() + 12 * day)
+              const monthAgo = new Date(now.getTime() - 30 * day)
+
+              const commentsExample = [
+                'Example comment inside a deal',
+                '',
+                '[B]Bold text[/B]',
+                '[I]Italic[/I]',
+                '[U]Underlined[/U]',
+                '[S]Strikethrough[/S]',
+                '[B][I][U][S]Mix[/S][/U][/I][/B]',
+                '',
+                '[LIST]',
+                '[*]List item #1',
+                '[*]List item #2',
+                '[*]List item #3',
+                '[/LIST]',
+              ].join('\n')
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.item.add',
+                params: {
+                  entityTypeId: 2,
+                  fields: {
+                    title: 'New deal (specifically for the REST methods example)',
+                    typeId: 'SERVICE',
                     categoryId: 9,
-                    stageId: "C9:UC_KN8KFI",
-                    isReccurring: "Y",
+                    stageId: 'C9:UC_KN8KFI',
+                    isReccurring: 'Y',
                     probability: 50,
-                    currencyId: "RUB",
-                    isManualOpportunity: "Y",
+                    currencyId: 'RUB',
+                    isManualOpportunity: 'Y',
                     opportunity: 999.99,
                     taxValue: 99.9,
                     companyId: 5,
@@ -1356,28 +1447,39 @@
                     quoteId: 7,
                     begindate: formatDate(monthAgo),
                     closedate: formatDate(twelveDaysInAdvance),
-                    opened: "N",
+                    opened: 'N',
                     comments: commentsExample,
                     assignedById: 6,
-                    sourceId: "WEB",
-                    sourceDescription: "Тут должно быть дополнительное описание об источнике",
+                    sourceId: 'WEB',
+                    sourceDescription: 'Additional description about the source goes here',
                     leadId: 102,
-                    additionalInfo: "Тут должна быть дополнительная информация",
+                    additionalInfo: 'Additional information goes here',
                     observers: [2, 3],
-                    utmSource: "google",
-                    utmMedium: "CPC",
+                    utmSource: 'google',
+                    utmMedium: 'CPC',
                     ufCrm_1721244707107: 1111.1,
                     parentId1220: 2,
+                  },
                 },
-            },
-            (result) => 
-            {
-                result.error() 
-                    ? console.error(result.error()) 
-                    : console.info(result.data())
-                ;
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(`Created item #${result.item.id} (${result.item.title})`)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', addCrmItem)
+        </script>
         ```
 
     - PHP
@@ -1725,40 +1827,119 @@
         https://**put_your_bitrix24_address**/rest/crm.item.add
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        const greenPixelInBase64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAAAMCAYAAACqTLVoAAAALklEQVR42u3SAQEAAAQDsEsuOj3YMqwy6fBWCSCAAAIgAAIgAAIgAAIgAAJw3QLOrRH1U/gU4gAAAABJRU5ErkJggg==";
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        BX24.callMethod(
-            'crm.item.add', 
-            {
-                entityTypeId: 1302,
-                fields: {
-                    ufCrm44_1721812760630: "Строка для пользовательского поля типа Строка",
+        declare const $b24: B24Frame
+
+        type CrmItem = {
+          id: number
+          title: string
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type ItemAddResult = {
+          item: CrmItem
+        }
+
+        const greenPixelInBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAIAAAAAMCAYAAACqTLVoAAAALklEQVR42u3SAQEAAAQDsEsuOj3YMqwy6fBWCSCAAAIgAAIgAAIgAAIgAAJw3QLOrRH1U/gU4gAAAABJRU5ErkJggg=='
+
+        try {
+          const response = await $b24.actions.v2.call.make<ItemAddResult>({
+            method: 'crm.item.add',
+            params: {
+              entityTypeId: 1302,
+              fields: {
+                ufCrm44_1721812760630: 'Value for a String-type custom field',
+                ufCrm44_1721812814433: 81,
+                ufCrm44_1721812853419: new Date().toISOString().slice(0, 10),
+                ufCrm44_1721812885588: [
+                  'example.com',
+                  'second-example.com',
+                ],
+                ufCrm44_1721812898903: [
+                  'green_pixel.png',
+                  greenPixelInBase64,
+                ],
+                ufCrm44_1721812915476: '300|RUB',
+                ufCrm44_1721812935209: 'Y',
+                ufCrm44_1721812948498: 9999.9,
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(`Created item #${result.item.id} (${result.item.title})`)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function addCrmItemWithCustomFields() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const greenPixelInBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAIAAAAAMCAYAAACqTLVoAAAALklEQVR42u3SAQEAAAQDsEsuOj3YMqwy6fBWCSCAAAIgAAIgAAIgAAIgAAJw3QLOrRH1U/gU4gAAAABJRU5ErkJggg=='
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.item.add',
+                params: {
+                  entityTypeId: 1302,
+                  fields: {
+                    ufCrm44_1721812760630: 'Value for a String-type custom field',
                     ufCrm44_1721812814433: 81,
-                    ufCrm44_1721812853419: (new Date()).toISOString().slice(0, 10),
+                    ufCrm44_1721812853419: new Date().toISOString().slice(0, 10),
                     ufCrm44_1721812885588: [
-                        "example.com",
-                        "second-example.com",
+                      'example.com',
+                      'second-example.com',
                     ],
                     ufCrm44_1721812898903: [
-                        "green_pixel.png",
-                        greenpixelBase64,
+                      'green_pixel.png',
+                      greenPixelInBase64,
                     ],
-                    ufCrm44_1721812915476: "300|RUB",
-                    ufCrm44_1721812935209: "Y",
+                    ufCrm44_1721812915476: '300|RUB',
+                    ufCrm44_1721812935209: 'Y',
                     ufCrm44_1721812948498: 9999.9,
+                  },
                 },
-            },
-            (result) => 
-            {
-                result.error() 
-                    ? console.error(result.error()) 
-                    : console.info(result.data())
-                ;
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(`Created item #${result.item.id} (${result.item.title})`)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', addCrmItemWithCustomFields)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/universal/crm-item-delete.md
+++ b/api-reference/crm/universal/crm-item-delete.md
@@ -61,27 +61,75 @@
     https://**put_your_bitrix24_address**/rest/crm.item.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.delete',
-    		{
-    			entityTypeId: 1268,
-    			id: 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<never[]>({
+        method: 'crm.item.delete',
+        params: {
+          entityTypeId: 1268,
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Item deleted successfully', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.delete',
+            params: {
+              entityTypeId: 1268,
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Item deleted successfully', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/crm-item-fields.md
+++ b/api-reference/crm/universal/crm-item-fields.md
@@ -70,27 +70,96 @@
     https://**put_your_bitrix24_address**/rest/crm.item.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.fields',
-    		{
-    			entityTypeId: 1268,
-    			useOriginalUfNames: 'N',
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      upperName: string
+      settings?: Record<string, unknown>
+      statusType?: string
+      isDeprecated?: boolean
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmItemFieldsResult = {
+      fields: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmItemFieldsResult>({
+        method: 'crm.item.fields',
+        params: {
+          entityTypeId: 1268,
+          useOriginalUfNames: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field count:', Object.keys(result.fields).length)
+        console.info('Fields:', result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCrmItemFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.fields',
+            params: {
+              entityTypeId: 1268,
+              useOriginalUfNames: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field count:', Object.keys(result.fields).length)
+          console.info('Fields:', result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCrmItemFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/crm-item-get.md
+++ b/api-reference/crm/universal/crm-item-get.md
@@ -68,28 +68,113 @@
     https://**put_your_bitrix24_address**/rest/crm.item.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.get',
-    		{
-    			entityTypeId: 1,
-    			id: 250,
-    			useOriginalUfNames: 'N',
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmItemGetResult = {
+      item: {
+        id: number
+        createdTime: ISODate
+        updatedTime: ISODate
+        createdBy: number
+        updatedBy: number
+        assignedById: number
+        opened: string
+        stageId: string
+        stageSemanticId: string
+        opportunity: number
+        currencyId: string
+        sourceId: string
+        title: string
+        name: string
+        lastName: string
+        movedBy: number
+        movedTime: ISODate
+        lastActivityBy: number
+        lastActivityTime: ISODate
+        email: string
+        phone: string
+        fm: Array<{
+          id: number
+          valueType: string
+          value: string
+          typeId: string
+        }>
+        observers: number[]
+        contactIds: number[]
+        entityTypeId: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmItemGetResult>({
+        method: 'crm.item.get',
+        params: {
+          entityTypeId: 1,
+          id: 250,
+          useOriginalUfNames: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Item:', result.item.id, result.item.title, result.item.entityTypeId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCrmItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.get',
+            params: {
+              entityTypeId: 1,
+              id: 250,
+              useOriginalUfNames: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Item:', result.item.id, result.item.title, result.item.entityTypeId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCrmItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/crm-item-list.md
+++ b/api-reference/crm/universal/crm-item-list.md
@@ -167,146 +167,166 @@
     https://**put_your_bitrix24_address**/rest/crm.item.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    type CrmItem = {
+      id: number
+      assignedById: number
+      stageId: string
+      opportunity: number
+      sourceId: string
+      title: string
+      name: string
+      lastName: string | null
+      isManualOpportunity: string
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmItemListResult = {
+      items: CrmItem[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.item.list',
-        {
+      // crm.item.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmItemListResult>({
+        method: 'crm.item.list',
+        params: {
           entityTypeId: 1,
           select: [
-            "id",
-            "title",
-            "lastName",
-            "name",
-            "stageId",
-            "sourceId",
-            "assignedById",
-            "opportunity",
-            "isManualOpportunity",
+            'id',
+            'title',
+            'lastName',
+            'name',
+            'stageId',
+            'sourceId',
+            'assignedById',
+            'opportunity',
+            'isManualOpportunity',
           ],
           filter: {
-            "0": {
-              logic: "OR",
-              "0": {
-                "!=name": "",
+            '0': {
+              logic: 'OR',
+              '0': {
+                '!=name': '',
               },
-              "1": {
-                "!=lastName": "",
+              '1': {
+                '!=lastName': '',
               },
             },
-            "@stageId": ["NEW", "IN_PROCESS"],
-            "@sourceId": ['WEB', "ADVERTISING"],
-            "@assignedById": [1, 6],
-            ">=opportunity": 5000,
-            "<=opportunity": 20000,
-            "isManualOpportunity": "Y",
+            '@stageId': ['NEW', 'IN_PROCESS'],
+            '@sourceId': ['WEB', 'ADVERTISING'],
+            '@assignedById': [1, 6],
+            '>=opportunity': 5000,
+            '<=opportunity': 20000,
+            isManualOpportunity: 'Y',
           },
           order: {
             lastName: 'ASC',
             name: 'ASC',
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.item.list', {
-        entityTypeId: 1,
-        select: [
-          "id",
-          "title",
-          "lastName",
-          "name",
-          "stageId",
-          "sourceId",
-          "assignedById",
-          "opportunity",
-          "isManualOpportunity",
-        ],
-        filter: {
-          "0": {
-            logic: "OR",
-            "0": {
-              "!=name": "",
-            },
-            "1": {
-              "!=lastName": "",
-            },
-          },
-          "@stageId": ["NEW", "IN_PROCESS"],
-          "@sourceId": ['WEB', "ADVERTISING"],
-          "@assignedById": [1, 6],
-          ">=opportunity": 5000,
-          "<=opportunity": 20000,
-          "isManualOpportunity": "Y",
-        },
-        order: {
-          lastName: 'ASC',
-          name: 'ASC',
-        },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fetched items:', result.items.length, result.items)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.item.list', {
-        entityTypeId: 1,
-        select: [
-          "id",
-          "title",
-          "lastName",
-          "name",
-          "stageId",
-          "sourceId",
-          "assignedById",
-          "opportunity",
-          "isManualOpportunity",
-        ],
-        filter: {
-          "0": {
-            logic: "OR",
-            "0": {
-              "!=name": "",
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCrmItemList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.list',
+            params: {
+              entityTypeId: 1,
+              select: [
+                'id',
+                'title',
+                'lastName',
+                'name',
+                'stageId',
+                'sourceId',
+                'assignedById',
+                'opportunity',
+                'isManualOpportunity',
+              ],
+              filter: {
+                '0': {
+                  logic: 'OR',
+                  '0': {
+                    '!=name': '',
+                  },
+                  '1': {
+                    '!=lastName': '',
+                  },
+                },
+                '@stageId': ['NEW', 'IN_PROCESS'],
+                '@sourceId': ['WEB', 'ADVERTISING'],
+                '@assignedById': [1, 6],
+                '>=opportunity': 5000,
+                '<=opportunity': 20000,
+                isManualOpportunity: 'Y',
+              },
+              order: {
+                lastName: 'ASC',
+                name: 'ASC',
+              },
+              start: 0,
             },
-            "1": {
-              "!=lastName": "",
-            },
-          },
-          "@stageId": ["NEW", "IN_PROCESS"],
-          "@sourceId": ['WEB', "ADVERTISING"],
-          "@assignedById": [1, 6],
-          ">=opportunity": 5000,
-          "<=opportunity": 20000,
-          "isManualOpportunity": "Y",
-        },
-        order: {
-          lastName: 'ASC',
-          name: 'ASC',
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fetched items:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCrmItemList)
+    </script>
     ```
 
 - PHP
@@ -472,38 +492,124 @@
     https://**put_your_bitrix24_address**/rest/crm.item.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'crm.item.list',
-            {
-                entityTypeId: 2,
-                select: ['id', 'title', 'createdTime'],
-                filter: {
-                    '0': {
-                        logic: 'OR',
-                        '0': {
-                            '>=createdTime': '2025-10-31T00:00:00+02:00',
-                            '<createdTime': '2025-11-01T00:00:00+02:00',
-                        },
-                        '1': {
-                            '>=createdTime': '2025-02-28T00:00:00+02:00',
-                            '<createdTime': '2025-03-01T00:00:00+02:00',
-                        },
-                    },
-                },
-            },
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const items = response.getData().items || [];
-        items.forEach((item) => {
-            console.info(`Deal #${item.id}: ${item.title} (${item.createdTime})`);
-        });
-    } catch (error) {
-        console.error('crm.item.list error', error);
+    declare const $b24: B24Frame
+
+    type CrmItem = {
+      id: number
+      title: string
+      createdTime: ISODate | null
     }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmItemListResult = {
+      items: CrmItem[]
+    }
+
+    try {
+      // crm.item.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmItemListResult>({
+        method: 'crm.item.list',
+        params: {
+          entityTypeId: 2,
+          select: ['id', 'title', 'createdTime'],
+          filter: {
+            '0': {
+              logic: 'OR',
+              '0': {
+                '>=createdTime': '2025-10-31T00:00:00+02:00',
+                '<createdTime': '2025-11-01T00:00:00+02:00',
+              },
+              '1': {
+                '>=createdTime': '2025-02-28T00:00:00+02:00',
+                '<createdTime': '2025-03-01T00:00:00+02:00',
+              },
+            },
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fetched items:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCrmItemListByDate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.list',
+            params: {
+              entityTypeId: 2,
+              select: ['id', 'title', 'createdTime'],
+              filter: {
+                '0': {
+                  logic: 'OR',
+                  '0': {
+                    '>=createdTime': '2025-10-31T00:00:00+02:00',
+                    '<createdTime': '2025-11-01T00:00:00+02:00',
+                  },
+                  '1': {
+                    '>=createdTime': '2025-02-28T00:00:00+02:00',
+                    '<createdTime': '2025-03-01T00:00:00+02:00',
+                  },
+                },
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fetched items:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCrmItemListByDate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/crm-item-update.md
+++ b/api-reference/crm/universal/crm-item-update.md
@@ -1025,41 +1025,115 @@
     https://**put_your_bitrix24_address**/rest/crm.item.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-        BX24.callMethod(
-            'crm.item.update',
-            {
-                entityTypeId: 2,
-                id: 351,
-                fields: {
-                    title: "REST Сделка #1",
-                    stageId: "C9:UC_NYL06U",
-                    assignedById: 6,
-                    observers: [1, 2, 3],
-                    opened: "N",
-                    typeId: "SERVICE",
-                    opportunity: 10000,
-                    currencyId: "USD",
-                    additionalInfo: "Изменение сделки через REST",
-                    isManualOpportunity: "N",
-                    utmSource: "google",
-                    ufCrm_1721244707107: 200.05,
-                    parentId1220: 2,
-                },
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    type CrmItem = {
+      id: number
+      title: string
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ItemUpdateResult = {
+      item: CrmItem
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ItemUpdateResult>({
+        method: 'crm.item.update',
+        params: {
+          entityTypeId: 2,
+          id: 351,
+          fields: {
+            title: 'REST Deal #1',
+            stageId: 'C9:UC_NYL06U',
+            assignedById: 6,
+            observers: [1, 2, 3],
+            opened: 'N',
+            typeId: 'SERVICE',
+            opportunity: 10000,
+            currencyId: 'USD',
+            additionalInfo: 'Update a deal via REST',
+            isManualOpportunity: 'N',
+            utmSource: 'google',
+            ufCrm_1721244707107: 200.05,
+            parentId1220: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(`Updated item #${result.item.id} (${result.item.title})`)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateCrmItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.update',
+            params: {
+              entityTypeId: 2,
+              id: 351,
+              fields: {
+                title: 'REST Deal #1',
+                stageId: 'C9:UC_NYL06U',
+                assignedById: 6,
+                observers: [1, 2, 3],
+                opened: 'N',
+                typeId: 'SERVICE',
+                opportunity: 10000,
+                currencyId: 'USD',
+                additionalInfo: 'Update a deal via REST',
+                isManualOpportunity: 'N',
+                utmSource: 'google',
+                ufCrm_1721244707107: 200.05,
+                parentId1220: 2,
+              },
             },
-            (result) => {
-                if (result.error())
-                {
-                    console.error(result.error());
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-                    return;
-                }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
 
-                console.info(result.data());
-            },
-        );
+          const result = response.getData().result
+          console.info(`Updated item #${result.item.id} (${result.item.title})`)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateCrmItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/delivery/crm-item-delivery-get.md
+++ b/api-reference/crm/universal/delivery/crm-item-delivery-get.md
@@ -52,25 +52,85 @@
     https://**put_your_bitrix24_address**/rest/crm.item.delivery.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.delivery.get', {
-    			id: 4077,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeliveryGetResult = {
+      id: number
+      accountNumber: string
+      priceDelivery: number
+      currency: string
+      deducted: string
+      dateDeducted: ISODate | null
+      deliveryId: number
+      deliveryName: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DeliveryGetResult>({
+        method: 'crm.item.delivery.get',
+        params: {
+          id: 4077,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.deliveryName, result.priceDelivery, result.currency)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDelivery() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.delivery.get',
+            params: {
+              id: 4077,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.deliveryName, result.priceDelivery, result.currency)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDelivery)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/delivery/crm-item-delivery-list.md
+++ b/api-reference/crm/universal/delivery/crm-item-delivery-list.md
@@ -60,62 +60,105 @@
     https://**put_your_bitrix24_address**/rest/crm.item.delivery.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each DeliveryItem returned in result[]
+    type DeliveryItem = {
+      id: number
+      accountNumber: string
+      deducted: string
+      dateDeducted: ISODate | null
+      deliveryId: number
+      priceDelivery: number
+      currency: string
+      deliveryName: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.item.delivery.list',
-        {
+      // crm.item.delivery.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DeliveryItem[]>({
+        method: 'crm.item.delivery.list',
+        params: {
           entityId: 13127,
           entityTypeId: 2,
           filter: {
-            "@id": [4077, 4078]
-          }
+            '@id': [4077, 4078],
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.item.delivery.list', {
-        entityId: 13127,
-        entityTypeId: 2,
-        filter: {
-          "@id": [4077, 4078]
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deliveries fetched:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.item.delivery.list', {
-        entityId: 13127,
-        entityTypeId: 2,
-        filter: {
-          "@id": [4077, 4078]
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listDeliveries() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.delivery.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.delivery.list',
+            params: {
+              entityId: 13127,
+              entityTypeId: 2,
+              filter: {
+                '@id': [4077, 4078],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deliveries fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listDeliveries)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/import/crm-item-batch-import.md
+++ b/api-reference/crm/universal/import/crm-item-batch-import.md
@@ -372,58 +372,153 @@
         https://**put_your_bitrix24_address**/rest/crm.item.batchImport
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        const greenPixelInBase64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAAAMCAYAAACqTLVoAAAALklEQVR42u3SAQEAAAQDsEsuOj3YMqwy6fBWCSCAAAIgAAIgAAIgAAIgAAJw3QLOrRH1U/gU4gAAAABJRU5ErkJggg==";
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        BX24.callMethod(
-            'crm.item.batchImport', 
-            {
-                entityTypeId: 1302,
-                data: [
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type BatchImportResult = {
+          items: Array<
+            | { item: { id: number } }
+            | { error: string; error_description: string }
+          >
+        }
+
+        const greenPixelInBase64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAAAMCAYAAACqTLVoAAAALklEQVR42u3SAQEAAAQDsEsuOj3YMqwy6fBWCSCAAAIgAAIgAAIgAAIgAAJw3QLOrRH1U/gU4gAAAABJRU5ErkJggg=="
+
+        try {
+          const response = await $b24.actions.v2.call.make<BatchImportResult>({
+            method: 'crm.item.batchImport',
+            params: {
+              entityTypeId: 1302,
+              data: [
+                {
+                  ufCrm44_1721812760630: "String for custom field of type String",
+                  ufCrm44_1721812814433: 81,
+                  ufCrm44_1721812853419: new Date().toISOString().slice(0, 10),
+                  ufCrm44_1721812885588: [
+                    "example.com",
+                    "second-example.com",
+                  ],
+                  ufCrm44_1721812898903: [
+                    "green_pixel.png",
+                    greenPixelInBase64,
+                  ],
+                  ufCrm44_1721812915476: "300|RUB",
+                  ufCrm44_1721812935209: "Y",
+                  ufCrm44_1721812948498: 9999.9,
+                },
+                {
+                  ufCrm44_1721812760630: "String for custom field of type String",
+                  ufCrm44_1721812814433: 45,
+                  ufCrm44_1721812853419: new Date().toISOString().slice(0, 10),
+                  ufCrm44_1721812885588: [
+                    "example.com",
+                    "second-example.com",
+                  ],
+                  ufCrm44_1721812898903: [
+                    "green_pixel2.png",
+                    greenPixelInBase64,
+                  ],
+                  ufCrm44_1721812915476: "600|RUB",
+                  ufCrm44_1721812935209: "N",
+                  ufCrm44_1721812948498: 9999.9,
+                },
+              ],
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Imported items:', result.items)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function batchImportItems() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const greenPixelInBase64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAAAMCAYAAACqTLVoAAAALklEQVR42u3SAQEAAAQDsEsuOj3YMqwy6fBWCSCAAAIgAAIgAAIgAAIgAAJw3QLOrRH1U/gU4gAAAABJRU5ErkJggg=="
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.item.batchImport',
+                params: {
+                  entityTypeId: 1302,
+                  data: [
                     {
-                        ufCrm44_1721812760630: "Строка для пользовательского поля типа Строка",
-                        ufCrm44_1721812814433: 81,
-                        ufCrm44_1721812853419: (new Date()).toISOString().slice(0, 10),
-                        ufCrm44_1721812885588: [
-                            "example.com",
-                            "second-example.com",
-                        ],
-                        ufCrm44_1721812898903: [
-                            "green_pixel.png",
-                            greenpixelBase64,
-                        ],
-                        ufCrm44_1721812915476: "300|RUB",
-                        ufCrm44_1721812935209: "Y",
-                        ufCrm44_1721812948498: 9999.9,
+                      ufCrm44_1721812760630: "String for custom field of type String",
+                      ufCrm44_1721812814433: 81,
+                      ufCrm44_1721812853419: new Date().toISOString().slice(0, 10),
+                      ufCrm44_1721812885588: [
+                        "example.com",
+                        "second-example.com",
+                      ],
+                      ufCrm44_1721812898903: [
+                        "green_pixel.png",
+                        greenPixelInBase64,
+                      ],
+                      ufCrm44_1721812915476: "300|RUB",
+                      ufCrm44_1721812935209: "Y",
+                      ufCrm44_1721812948498: 9999.9,
                     },
                     {
-                        ufCrm44_1721812760630: "Строка для пользовательского поля типа Строка",
-                        ufCrm44_1721812814433: 45,
-                        ufCrm44_1721812853419: (new Date()).toISOString().slice(0, 10),
-                        ufCrm44_1721812885588: [
-                            "example.com",
-                            "second-example.com",
-                        ],
-                        ufCrm44_1721812898903: [
-                            "green_pixel2.png",
-                            greenpixelBase64,
-                        ],
-                        ufCrm44_1721812915476: "600|RUB",
-                        ufCrm44_1721812935209: "N",
-                        ufCrm44_1721812948498: 9999.9,
-                    }
-                ],
-            },
-            (result) => 
-            {
-                result.error() 
-                    ? console.error(result.error()) 
-                    : console.info(result.data())
-                ;
+                      ufCrm44_1721812760630: "String for custom field of type String",
+                      ufCrm44_1721812814433: 45,
+                      ufCrm44_1721812853419: new Date().toISOString().slice(0, 10),
+                      ufCrm44_1721812885588: [
+                        "example.com",
+                        "second-example.com",
+                      ],
+                      ufCrm44_1721812898903: [
+                        "green_pixel2.png",
+                        greenPixelInBase64,
+                      ],
+                      ufCrm44_1721812915476: "600|RUB",
+                      ufCrm44_1721812935209: "N",
+                      ufCrm44_1721812948498: 9999.9,
+                    },
+                  ],
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info('Imported items:', result.items)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
             }
-        );
+          }
+
+          document.addEventListener('DOMContentLoaded', batchImportItems)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-forceCommonScopeForAll.md
+++ b/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-forceCommonScopeForAll.md
@@ -78,29 +78,79 @@
     https://**put_your_bitrix24_address**/rest/crm.item.details.configuration.forceCommonScopeForAll
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.details.configuration.forceCommonScopeForAll',
-    		{
-    			entityTypeId: 2,
-    			extras: {
-    				dealCategoryId: 9,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.details.configuration.forceCommonScopeForAll',
+        params: {
+          entityTypeId: 2,
+          extras: {
+            dealCategoryId: 9,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Force common scope result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function forceCommonScopeForAll() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.details.configuration.forceCommonScopeForAll',
+            params: {
+              entityTypeId: 2,
+              extras: {
+                dealCategoryId: 9,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Force common scope result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', forceCommonScopeForAll)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-get.md
+++ b/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-get.md
@@ -95,30 +95,97 @@
         https://**put_your_bitrix24_address**/rest/crm.item.details.configuration.get
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-            BX24.callMethod(
-                'crm.item.details.configuration.get',
-                {
-                    entityTypeId: 2,
-                    userId: 1,
-                    scope: "C",
-                    extras: {
-                        dealCategoryId: 9,
-                    },
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type SectionElement = {
+          name: string
+          optionFlags: string
+          options?: Record<string, string>
+        }
+
+        type Section = {
+          name: string
+          title: string
+          type: string
+          elements: SectionElement[]
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<Section[] | null>({
+            method: 'crm.item.details.configuration.get',
+            params: {
+              entityTypeId: 2,
+              userId: 1,
+              scope: 'C',
+              extras: {
+                dealCategoryId: 9,
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Sections count:', result?.length ?? 0, 'first section:', result?.[0]?.name)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getDetailsConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.item.details.configuration.get',
+                params: {
+                  entityTypeId: 2,
+                  userId: 1,
+                  scope: 'C',
+                  extras: {
+                    dealCategoryId: 9,
+                  },
                 },
-                (result) => {
-                    if (result.error())
-                    {
-                        console.error(result.error());
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
 
-                        return;
-                    }
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
 
-                    console.info(result.data());
-                },
-            );
+              const result = response.getData().result
+              console.info('Sections count:', result?.length ?? 0, 'first section:', result?.[0]?.name)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getDetailsConfiguration)
+        </script>
         ```
 
     - PHP
@@ -169,28 +236,93 @@
         https://**put_your_bitrix24_address**/rest/crm.item.details.configuration.get
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-            BX24.callMethod(
-                'crm.item.details.configuration.get',
-                {
-                    entityTypeId: 1032,
-                    extras: {
-                        categoryId: 5,
-                    },
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type SectionElement = {
+          name: string
+          optionFlags: string
+          options?: Record<string, string>
+        }
+
+        type Section = {
+          name: string
+          title: string
+          type: string
+          elements: SectionElement[]
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<Section[] | null>({
+            method: 'crm.item.details.configuration.get',
+            params: {
+              entityTypeId: 1032,
+              extras: {
+                categoryId: 5,
+              },
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Sections count:', result?.length ?? 0, 'first section:', result?.[0]?.name)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function getDetailsConfiguration() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.item.details.configuration.get',
+                params: {
+                  entityTypeId: 1032,
+                  extras: {
+                    categoryId: 5,
+                  },
                 },
-                (result) => {
-                    if (result.error())
-                    {
-                        console.error(result.error());
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
 
-                        return;
-                    }
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
 
-                    console.info(result.data());
-                },
-            );
+              const result = response.getData().result
+              console.info('Sections count:', result?.length ?? 0, 'first section:', result?.[0]?.name)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', getDetailsConfiguration)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-reset.md
+++ b/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-reset.md
@@ -93,31 +93,83 @@
     https://**put_your_bitrix24_address**/rest/crm.item.details.configuration.reset
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.details.configuration.reset',
-    		{
-    			entityTypeId: 2,
-    			userId: 1,
-    			scope: "C",
-    			extras: {
-    				dealCategoryId: 9,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.details.configuration.reset',
+        params: {
+          entityTypeId: 2,
+          userId: 1,
+          scope: 'C',
+          extras: {
+            dealCategoryId: 9,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Configuration reset successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function resetDetailsConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.details.configuration.reset',
+            params: {
+              entityTypeId: 2,
+              userId: 1,
+              scope: 'C',
+              extras: {
+                dealCategoryId: 9,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Configuration reset successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', resetDetailsConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-set.md
+++ b/api-reference/crm/universal/item-details-configuration/crm-item-details-configuration-set.md
@@ -191,84 +191,189 @@
     https://**put_your_bitrix24_address**/rest/crm.item.details.configuration.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.details.configuration.set',
-    		{
-    			entityTypeId: 3,
-    			userId: 1,
-    			data: [
-    				{
-    					name: "section_1",
-    					title: "Личные данные",
-    					type: "section",
-    					elements: [
-    						{
-    							name: "NAME",
-    							optionFlags: 1,
-    						},
-    						{
-    							name: "LAST_NAME",
-    							optionFlags: 1,
-    						},
-    						{
-    							name: "SECOND_NAME",
-    						},
-    						{
-    							name: "BIRTHDATE",
-    						},
-    						{
-    							name: "PHONE",
-    							optionFlags: 1,
-    							options: {
-    								defaultCountry: "GB",
-    							},
-    						},
-    						{
-    							name: "ADDRESS",
-    							optionFlags: 1,
-    							options: {
-    								defaultAddressType: 4,
-    							},
-    						},
-    					],
-    				},
-    				{
-    					name: "section_2",
-    					title: "Основная информация",
-    					type: "section",
-    					elements: [
-    						{ name: "TYPE_ID" },
-    						{ name: "SOURCE_ID" },
-    						{ name: "POST" },
-    					],
-    				},
-    				{
-    					name: "section_3",
-    					title: "Дополнительная информация",
-    					type: "section",
-    					elements: [
-    						{ name: "PHOTO" },
-    						{ name: "COMMENTS" },
-    						{ name: "UF_CRM_1720697698689" },
-    					],
-    				},
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.details.configuration.set',
+        params: {
+          entityTypeId: 3,
+          userId: 1,
+          data: [
+            {
+              name: 'section_1',
+              title: 'Personal data',
+              type: 'section',
+              elements: [
+                {
+                  name: 'NAME',
+                  optionFlags: 1,
+                },
+                {
+                  name: 'LAST_NAME',
+                  optionFlags: 1,
+                },
+                {
+                  name: 'SECOND_NAME',
+                },
+                {
+                  name: 'BIRTHDATE',
+                },
+                {
+                  name: 'PHONE',
+                  optionFlags: 1,
+                  options: {
+                    defaultCountry: 'GB',
+                  },
+                },
+                {
+                  name: 'ADDRESS',
+                  optionFlags: 1,
+                  options: {
+                    defaultAddressType: 4,
+                  },
+                },
+              ],
+            },
+            {
+              name: 'section_2',
+              title: 'Main information',
+              type: 'section',
+              elements: [
+                { name: 'TYPE_ID' },
+                { name: 'SOURCE_ID' },
+                { name: 'POST' },
+              ],
+            },
+            {
+              name: 'section_3',
+              title: 'Additional information',
+              type: 'section',
+              elements: [
+                { name: 'PHOTO' },
+                { name: 'COMMENTS' },
+                { name: 'UF_CRM_1720697698689' },
+              ],
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Configuration saved successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setDetailsConfiguration() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.details.configuration.set',
+            params: {
+              entityTypeId: 3,
+              userId: 1,
+              data: [
+                {
+                  name: 'section_1',
+                  title: 'Personal data',
+                  type: 'section',
+                  elements: [
+                    {
+                      name: 'NAME',
+                      optionFlags: 1,
+                    },
+                    {
+                      name: 'LAST_NAME',
+                      optionFlags: 1,
+                    },
+                    {
+                      name: 'SECOND_NAME',
+                    },
+                    {
+                      name: 'BIRTHDATE',
+                    },
+                    {
+                      name: 'PHONE',
+                      optionFlags: 1,
+                      options: {
+                        defaultCountry: 'GB',
+                      },
+                    },
+                    {
+                      name: 'ADDRESS',
+                      optionFlags: 1,
+                      options: {
+                        defaultAddressType: 4,
+                      },
+                    },
+                  ],
+                },
+                {
+                  name: 'section_2',
+                  title: 'Main information',
+                  type: 'section',
+                  elements: [
+                    { name: 'TYPE_ID' },
+                    { name: 'SOURCE_ID' },
+                    { name: 'POST' },
+                  ],
+                },
+                {
+                  name: 'section_3',
+                  title: 'Additional information',
+                  type: 'section',
+                  elements: [
+                    { name: 'PHOTO' },
+                    { name: 'COMMENTS' },
+                    { name: 'UF_CRM_1720697698689' },
+                  ],
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Configuration saved successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setDetailsConfiguration)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/order-entity/crm-order-entity-add.md
+++ b/api-reference/crm/universal/order-entity/crm-order-entity-add.md
@@ -77,30 +77,90 @@
     https://**put_your_bitrix24_address**/rest/crm.orderentity.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.orderentity.add",
-    		{
-    			fields: {
-    				orderId: 5125,
-    				ownerId: 6933,
-    				ownerTypeId: 2
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OrderEntityAddResult = {
+      dealOrder: {
+        orderId: number
+        ownerId: number
+        ownerTypeId: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<OrderEntityAddResult>({
+        method: 'crm.orderentity.add',
+        params: {
+          fields: {
+            orderId: 5125,
+            ownerId: 6933,
+            ownerTypeId: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.dealOrder)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addOrderEntity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.orderentity.add',
+            params: {
+              fields: {
+                orderId: 5125,
+                ownerId: 6933,
+                ownerTypeId: 2,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.dealOrder)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addOrderEntity)
+    </script>
     ```
 
 - BX24.js

--- a/api-reference/crm/universal/order-entity/crm-order-entity-delete-by-filter.md
+++ b/api-reference/crm/universal/order-entity/crm-order-entity-delete-by-filter.md
@@ -77,30 +77,81 @@
     https://**put_your_bitrix24_address**/rest/crm.orderentity.deletebyfilter
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.orderentity.deletebyfilter",
-    		{
-    			fields: {
-    				orderId: 5125,
-    				ownerId: 6933,
-    				ownerTypeId: 2
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.orderentity.deletebyfilter',
+        params: {
+          fields: {
+            orderId: 5125,
+            ownerId: 6933,
+            ownerTypeId: 2,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Order entity deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteOrderEntityByFilter() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.orderentity.deletebyfilter',
+            params: {
+              fields: {
+                orderId: 5125,
+                ownerId: 6933,
+                ownerTypeId: 2,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Order entity deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteOrderEntityByFilter)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/order-entity/crm-order-entity-get-fields.md
+++ b/api-reference/crm/universal/order-entity/crm-order-entity-get-fields.md
@@ -43,24 +43,81 @@
     https://**put_your_bitrix24_address**/rest/crm.orderentity.getFields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.orderentity.getFields",
-    		{}
-    	);
-    
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      isImmutable: boolean
+      isReadOnly: boolean
+      isRequired: boolean
+      type: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetFieldsResult = {
+      orderEntity: Record<string, FieldDescription>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetFieldsResult>({
+        method: 'crm.orderentity.getFields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.orderEntity), result.orderEntity)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOrderEntityFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.orderentity.getFields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.orderEntity), result.orderEntity)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOrderEntityFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/order-entity/crm-order-entity-list.md
+++ b/api-reference/crm/universal/order-entity/crm-order-entity-list.md
@@ -105,16 +105,33 @@
     https://**put_your_bitrix24_address**/rest/crm.orderentity.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OrderEntityListResult = {
+      orderEntity: {
+        orderId: number
+        ownerId: number
+      }[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.orderentity.list',
-        {
+      // crm.orderentity.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<OrderEntityListResult>({
+        method: 'crm.orderentity.list',
+        params: {
           select: [
             'orderId',
             'ownerId',
@@ -124,61 +141,77 @@
             '@ownerId': [6938, 6937, 6933],
           },
           order: {
-            orderId: 'asc'
+            orderId: 'asc',
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.orderentity.list', {
-        select: [
-          'orderId',
-          'ownerId',
-        ],
-        filter: {
-          '=ownerTypeId': 2,
-          '@ownerId': [6938, 6937, 6933],
-        },
-        order: {
-          orderId: 'asc'
-        },
-      }, 'orderId');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Order entities:', result.orderEntity.length, result.orderEntity)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.orderentity.list', {
-        select: [
-          'orderId',
-          'ownerId',
-        ],
-        filter: {
-          '=ownerTypeId': 2,
-          '@ownerId': [6938, 6937, 6933],
-        },
-        order: {
-          orderId: 'asc'
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listOrderEntities() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.orderentity.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.orderentity.list',
+            params: {
+              select: [
+                'orderId',
+                'ownerId',
+              ],
+              filter: {
+                '=ownerTypeId': 2,
+                '@ownerId': [6938, 6937, 6933],
+              },
+              order: {
+                orderId: 'asc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Order entities:', result.orderEntity.length, result.orderEntity)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listOrderEntities)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-add.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-add.md
@@ -54,26 +54,75 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.add', {
-    			entityId: 13123,
-    			entityTypeId: 2
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.item.payment.add',
+        params: {
+          entityId: 13123,
+          entityTypeId: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created payment ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.add',
+            params: {
+              entityId: 13123,
+              entityTypeId: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created payment ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-delete.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-delete.md
@@ -52,25 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.delete', {
-    			id: 1035,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.delete',
+        params: {
+          id: 1035,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.delete',
+            params: {
+              id: 1035,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-get.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-get.md
@@ -52,25 +52,86 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.get', {
-    			id: 1036,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PaymentGetResult = {
+      id: number
+      accountNumber: string
+      paid: 'Y' | 'N'
+      datePaid: ISODate | null
+      empPaidId: number
+      paySystemId: number
+      sum: number
+      currency: string
+      paySystemName: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PaymentGetResult>({
+        method: 'crm.item.payment.get',
+        params: {
+          id: 1036,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.accountNumber, result.paid, result.sum, result.currency)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.get',
+            params: {
+              id: 1036,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.accountNumber, result.paid, result.sum, result.currency)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-list.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-list.md
@@ -59,62 +59,106 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each payment item returned in result[]
+    type PaymentItem = {
+      id: number
+      accountNumber: string
+      paid: 'Y' | 'N'
+      datePaid: ISODate | null
+      empPaidId: number | null
+      paySystemId: number
+      sum: number
+      currency: string
+      paySystemName: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.item.payment.list',
-        {
+      // crm.item.payment.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PaymentItem[]>({
+        method: 'crm.item.payment.list',
+        params: {
           entityId: 13123,
           entityTypeId: 2,
           filter: {
-            "@id": [1036, 1037]
-          }
+            '@id': [1036, 1037],
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.item.payment.list', {
-        entityId: 13123,
-        entityTypeId: 2,
-        filter: {
-          "@id": [1036, 1037]
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payments:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.item.payment.list', {
-        entityId: 13123,
-        entityTypeId: 2,
-        filter: {
-          "@id": [1036, 1037]
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function loadPaymentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.payment.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.list',
+            params: {
+              entityId: 13123,
+              entityTypeId: 2,
+              filter: {
+                '@id': [1036, 1037],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payments:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', loadPaymentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-pay.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-pay.md
@@ -52,25 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.pay
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.pay', {
-    			id: 1038
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.pay',
+        params: {
+          id: 1038,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment marked as paid:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function payItemPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.pay',
+            params: {
+              id: 1038,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment marked as paid:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', payItemPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-unpay.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-unpay.md
@@ -52,25 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.unpay
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.unpay', {
-    			id: 1038
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.unpay',
+        params: {
+          id: 1038,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unpay result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unpayPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.unpay',
+            params: {
+              id: 1038,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unpay result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unpayPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/crm-item-payment-update.md
+++ b/api-reference/crm/universal/payment/crm-item-payment-update.md
@@ -70,29 +70,81 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.update', {
-    			id: 1036,
-    			fields: {
-    				paid: "Y",
-    				paySystemId: 110,
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.update',
+        params: {
+          id: 1036,
+          fields: {
+            paid: 'Y',
+            paySystemId: 110,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.update',
+            params: {
+              id: 1036,
+              fields: {
+                paid: 'Y',
+                paySystemId: 110,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-add.md
+++ b/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-add.md
@@ -56,26 +56,75 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.delivery.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.delivery.add', {
-    			paymentId: 1039,
-    			deliveryId: 4072
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.item.payment.delivery.add',
+        params: {
+          paymentId: 1039,
+          deliveryId: 4072,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Delivery item ID in payment:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDeliveryToPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.delivery.add',
+            params: {
+              paymentId: 1039,
+              deliveryId: 4072,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Delivery item ID in payment:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDeliveryToPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-delete.md
+++ b/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-delete.md
@@ -53,25 +53,73 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.delivery.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.delivery.delete', {
-    			id: 1199,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.delivery.delete',
+        params: {
+          id: 1199,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePaymentDelivery() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.delivery.delete',
+            params: {
+              id: 1199,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePaymentDelivery)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-list.md
+++ b/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-list.md
@@ -95,62 +95,101 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.delivery.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type CrmItemPaymentDelivery = {
+      id: number
+      paymentId: number
+      quantity: number
+      deliveryId: number
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.item.payment.delivery.list',
-        {
+      // crm.item.payment.delivery.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<CrmItemPaymentDelivery[]>({
+        method: 'crm.item.payment.delivery.list',
+        params: {
           paymentId: 1040,
           filter: {
-            ">=quantity": 1,
-            "@id": [1201],
+            '>=quantity': 1,
+            '@id': [1201],
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.item.payment.delivery.list', {
-        paymentId: 1040,
-        filter: {
-          ">=quantity": 1,
-          "@id": [1201],
-        },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Delivery items count:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.item.payment.delivery.list', {
-        paymentId: 1040,
-        filter: {
-          ">=quantity": 1,
-          "@id": [1201],
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listPaymentDeliveries() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.payment.delivery.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.delivery.list',
+            params: {
+              paymentId: 1040,
+              filter: {
+                '>=quantity': 1,
+                '@id': [1201],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Delivery items count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listPaymentDeliveries)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-set-delivery.md
+++ b/api-reference/crm/universal/payment/delivery-in-payment/crm-item-payment-delivery-set-delivery.md
@@ -57,26 +57,75 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.delivery.setDelivery
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.delivery.setDelivery', {
-    			id: 1201,
-    			deliveryId: 4073,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.delivery.setDelivery',
+        params: {
+          id: 1201,
+          deliveryId: 4073,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Delivery reassigned:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setDelivery() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.delivery.setDelivery',
+            params: {
+              id: 1201,
+              deliveryId: 4073,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Delivery reassigned:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setDelivery)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-add.md
+++ b/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-add.md
@@ -61,27 +61,77 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.product.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.product.add', {
-    			paymentId: 1039,
-    			rowId: 17587,
-    			quantity: 2
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'crm.item.payment.product.add',
+        params: {
+          paymentId: 1039,
+          rowId: 17587,
+          quantity: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added product row id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPaymentProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.product.add',
+            params: {
+              paymentId: 1039,
+              rowId: 17587,
+              quantity: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added product row id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPaymentProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-delete.md
+++ b/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-delete.md
@@ -55,25 +55,73 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.product.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.product.delete', {
-    			id: 1194,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.product.delete',
+        params: {
+          id: 1194,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePaymentProduct() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.product.delete',
+            params: {
+              id: 1194,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePaymentProduct)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-list.md
+++ b/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-list.md
@@ -95,62 +95,101 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.product.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type PaymentProductItem = {
+      id: number,
+      paymentId: number,
+      quantity: number,
+      rowId: number,
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.item.payment.product.list',
-        {
+      // crm.item.payment.product.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PaymentProductItem[]>({
+        method: 'crm.item.payment.product.list',
+        params: {
           paymentId: 1039,
           filter: {
-            ">=quantity": 2,
-            "@id": [1195, 1196],
+            '>=quantity': 2,
+            '@id': [1195, 1196],
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.item.payment.product.list', {
-        paymentId: 1039,
-        filter: {
-          ">=quantity": 2,
-          "@id": [1195, 1196],
-        },
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment products:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.item.payment.product.list', {
-        paymentId: 1039,
-        filter: {
-          ">=quantity": 2,
-          "@id": [1195, 1196],
-        },
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchPaymentProductList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.payment.product.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.product.list',
+            params: {
+              paymentId: 1039,
+              filter: {
+                '>=quantity': 2,
+                '@id': [1195, 1196],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment products:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchPaymentProductList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-set-quantity.md
+++ b/api-reference/crm/universal/payment/products-in-payment/crm-item-payment-product-set-quantity.md
@@ -54,26 +54,75 @@
     https://**put_your_bitrix24_address**/rest/crm.item.payment.product.setQuantity
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.payment.product.setQuantity', {
-    			id: 1195,
-    			quantity: 3
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.item.payment.product.setQuantity',
+        params: {
+          id: 1195,
+          quantity: 3,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Quantity updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setProductQuantity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.payment.product.setQuantity',
+            params: {
+              id: 1195,
+              quantity: 3,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Quantity updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setProductQuantity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/payment/salescenter-payment-get-public-url.md
+++ b/api-reference/crm/universal/payment/salescenter-payment-get-public-url.md
@@ -52,25 +52,84 @@
     https://**put_your_bitrix24_address**/rest/salescenter.payment.getPublicUrl
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'salescenter.payment.getPublicUrl', {
-    			id: 1063,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SalesCenterPaymentGetPublicUrlResult = {
+      payment: {
+        url: string
+        shortUrl: string
+        qr: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SalesCenterPaymentGetPublicUrlResult>({
+        method: 'salescenter.payment.getPublicUrl',
+        params: {
+          id: 1063,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment URL:', result.payment.url)
+        console.info('Short URL:', result.payment.shortUrl)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPaymentPublicUrl() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'salescenter.payment.getPublicUrl',
+            params: {
+              id: 1063,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment URL:', result.payment.url)
+          console.info('Short URL:', result.payment.shortUrl)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPaymentPublicUrl)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-add.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-add.md
@@ -96,37 +96,125 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.add', {
-    			fields: {
-    				ownerId: 13142,
-    				ownerType: 'D',
-    				productId: 9621,
-    				price: 80000.000000,
-    				quantity: 2,
-    				discountTypeId: 2,
-    				discountRate: 20,
-    				taxRate: 20,
-    				taxIncluded: 'Y',
-    				measureCode: 796,
-    				sort: 10,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductRowAddResult = {
+      productRow: {
+        id: number
+        ownerId: number
+        ownerType: string
+        productId: number
+        price: number
+        quantity: number
+        discountTypeId: number
+        discountRate: number
+        taxRate: number
+        taxIncluded: string
+        measureCode: number
+        sort: number
+        type: number
+        productName: string
+        priceAccount: number
+        priceExclusive: number
+        priceNetto: number
+        priceBrutto: number
+        discountSum: number
+        customized: string
+        measureName: string
+        xmlId: string
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductRowAddResult>({
+        method: 'crm.item.productrow.add',
+        params: {
+          fields: {
+            ownerId: 13142,
+            ownerType: 'D',
+            productId: 9621,
+            price: 80000,
+            quantity: 2,
+            discountTypeId: 2,
+            discountRate: 20,
+            taxRate: 20,
+            taxIncluded: 'Y',
+            measureCode: 796,
+            sort: 10,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productRow.id, result.productRow.productName, result.productRow.price)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addProductRow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.add',
+            params: {
+              fields: {
+                ownerId: 13142,
+                ownerType: 'D',
+                productId: 9621,
+                price: 80000,
+                quantity: 2,
+                discountTypeId: 2,
+                discountRate: 20,
+                taxRate: 20,
+                taxIncluded: 'Y',
+                measureCode: 796,
+                sort: 10,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productRow.id, result.productRow.productName, result.productRow.price)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addProductRow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-delete.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-delete.md
@@ -52,25 +52,73 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.delete', {
-    			id: 17655,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'crm.item.productrow.delete',
+        params: {
+          id: 17655,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Product row deleted, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteProductRow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.delete',
+            params: {
+              id: 17655,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Product row deleted, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteProductRow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-fields.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-fields.md
@@ -43,23 +43,84 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.fields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.fields', {}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    type FieldItem = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductRowFieldsResult = {
+      fields: Record<string, FieldItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductRowFieldsResult>({
+        method: 'crm.item.productrow.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result.fields))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductRowFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result.fields))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductRowFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-get-available-for-payment.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-get-available-for-payment.md
@@ -54,26 +54,103 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.getAvailableForPayment
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.getAvailableForPayment', {
-    			ownerType: 'D',
-    			ownerId: 13144,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetAvailableForPaymentResult = {
+      productRows: {
+        id: number
+        ownerId: number
+        ownerType: string
+        productId: number
+        productName: string
+        price: number
+        priceAccount: number
+        priceExclusive: number
+        priceNetto: number
+        priceBrutto: number
+        quantity: number
+        discountTypeId: number
+        discountRate: number
+        discountSum: number
+        taxRate: number | null
+        taxIncluded: string
+        customized: string
+        measureCode: number
+        measureName: string
+        sort: number
+        xmlId: string
+        type: number
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetAvailableForPaymentResult>({
+        method: 'crm.item.productrow.getAvailableForPayment',
+        params: {
+          ownerType: 'D',
+          ownerId: 13144,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productRows)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAvailableForPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.getAvailableForPayment',
+            params: {
+              ownerType: 'D',
+              ownerId: 13144,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productRows)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAvailableForPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-get.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-get.md
@@ -52,25 +52,102 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.get', {
-    			id: 17622,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductRowResult = {
+      productRow: {
+        id: number
+        ownerId: number
+        ownerType: string
+        productId: number
+        productName: string
+        price: number
+        priceAccount: number
+        priceExclusive: number
+        priceNetto: number
+        priceBrutto: number
+        quantity: number
+        discountTypeId: number
+        discountRate: number
+        discountSum: number
+        taxRate: number | null
+        taxIncluded: string
+        customized: string
+        measureCode: number
+        measureName: string
+        sort: number
+        xmlId: string
+        type: number
+        storeId: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductRowResult>({
+        method: 'crm.item.productrow.get',
+        params: {
+          id: 17622,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productRow.id, result.productRow.productName, result.productRow.price)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getProductRow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.get',
+            params: {
+              id: 17622,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productRow.id, result.productRow.productName, result.productRow.price)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getProductRow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-list.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-list.md
@@ -104,71 +104,128 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductRowListResult = {
+      productRows: {
+        id: number
+        ownerId: number
+        ownerType: string
+        productId: number
+        productName: string
+        price: number
+        priceAccount: number
+        priceExclusive: number
+        priceNetto: number
+        priceBrutto: number
+        quantity: number
+        discountTypeId: number
+        discountRate: number
+        discountSum: number
+        taxRate: number | null
+        taxIncluded: string
+        customized: string
+        measureCode: number
+        measureName: string
+        sort: number
+        xmlId: string
+        type: number
+        storeId: number
+      }[]
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'crm.item.productrow.list',
-        {
+      // crm.item.productrow.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProductRowListResult>({
+        method: 'crm.item.productrow.list',
+        params: {
           filter: {
-            "=ownerType": 'D',
-            "=ownerId": 13142,
-            ">price": 5000,
+            '=ownerType': 'D',
+            '=ownerId': 13142,
+            '>price': 5000,
           },
           order: {
-            price: "desc"
+            price: 'desc',
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('crm.item.productrow.list', {
-        filter: {
-          "=ownerType": 'D',
-          "=ownerId": 13142,
-          ">price": 5000,
-        },
-        order: {
-          price: "desc"
-        },
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productRows.length, result.productRows)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('crm.item.productrow.list', {
-        filter: {
-          "=ownerType": 'D',
-          "=ownerId": 13142,
-          ">price": 5000,
-        },
-        order: {
-          price: "desc"
-        },
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // crm.item.productrow.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.list',
+            params: {
+              filter: {
+                '=ownerType': 'D',
+                '=ownerId': 13142,
+                '>price': 5000,
+              },
+              order: {
+                price: 'desc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productRows.length, result.productRows)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-set.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-set.md
@@ -98,40 +98,131 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.set', {
-    			ownerType: 'D',
-    			ownerId: 13143,
-    			productRows: [{
-    					productId: 9621,
-    					price: 99999.99,
-    					quantity: 1,
-    					sort: 10,
-    				},
-    				{
-    					productId: 9623,
-    					price: 15900.00,
-    					quantity: 2,
-    					sort: 10,
-    				},
-    
-    			],
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductRowsResult = {
+      productRows: {
+        id: number
+        ownerId: number
+        ownerType: string
+        productId: number
+        productName: string
+        price: number
+        priceAccount: number
+        priceExclusive: number
+        priceNetto: number
+        priceBrutto: number
+        quantity: number
+        discountTypeId: number
+        discountRate: number
+        discountSum: number
+        taxRate: number | null
+        taxIncluded: string
+        customized: string
+        measureCode: number
+        measureName: string
+        sort: number
+        xmlId: string
+        type: number
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductRowsResult>({
+        method: 'crm.item.productrow.set',
+        params: {
+          ownerType: 'D',
+          ownerId: 13143,
+          productRows: [
+            {
+              productId: 9621,
+              price: 99999.99,
+              quantity: 1,
+              sort: 10,
+            },
+            {
+              productId: 9623,
+              price: 15900.00,
+              quantity: 2,
+              sort: 10,
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productRows)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setProductRows() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.set',
+            params: {
+              ownerType: 'D',
+              ownerId: 13143,
+              productRows: [
+                {
+                  productId: 9621,
+                  price: 99999.99,
+                  quantity: 1,
+                  sort: 10,
+                },
+                {
+                  productId: 9623,
+                  price: 15900.00,
+                  quantity: 2,
+                  sort: 10,
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productRows)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setProductRows)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/product-rows/crm-item-productrow-update.md
+++ b/api-reference/crm/universal/product-rows/crm-item-productrow-update.md
@@ -89,36 +89,123 @@
     https://**put_your_bitrix24_address**/rest/crm.item.productrow.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.item.productrow.update', {
-    			id: 17648,
-    			fields: {
-    				productId: 9621,
-    				price: 90000.000000,
-    				quantity: 3,
-    				discountTypeId: 2,
-    				discountRate: 10,
-    				taxRate: 10,
-    				taxIncluded: 'Y',
-    				measureCode: 796,
-    				sort: 20,
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ProductRowUpdateResult = {
+      productRow: {
+        id: number
+        ownerId: number
+        ownerType: string
+        productId: number
+        productName: string
+        price: number
+        priceAccount: number
+        priceExclusive: number
+        priceNetto: number
+        priceBrutto: number
+        quantity: number
+        discountTypeId: number
+        discountRate: number
+        discountSum: number
+        taxRate: number
+        taxIncluded: string
+        customized: string
+        measureCode: number
+        measureName: string
+        sort: number
+        xmlId: string
+        type: number
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ProductRowUpdateResult>({
+        method: 'crm.item.productrow.update',
+        params: {
+          id: 17648,
+          fields: {
+            productId: 9621,
+            price: 90000,
+            quantity: 3,
+            discountTypeId: 2,
+            discountRate: 10,
+            taxRate: 10,
+            taxIncluded: 'Y',
+            measureCode: 796,
+            sort: 20,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.productRow.id, result.productRow.productName, result.productRow.price)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateProductRow() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.item.productrow.update',
+            params: {
+              id: 17648,
+              fields: {
+                productId: 9621,
+                price: 90000,
+                quantity: 3,
+                discountTypeId: 2,
+                discountRate: 10,
+                taxRate: 10,
+                taxIncluded: 'Y',
+                measureCode: 796,
+                sort: 20,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.productRow.id, result.productRow.productName, result.productRow.price)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateProductRow)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-fields/crm-userfield-enumeration-fields.md
+++ b/api-reference/crm/universal/user-defined-fields/crm-userfield-enumeration-fields.md
@@ -45,23 +45,80 @@
     https://**put_your_bitrix24_address**/rest/crm.userfield.enumeration.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.userfield.enumeration.fields",
-    		{}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type FieldInfo = {
+      type: string
+      title: string
+      isReadOnly?: boolean
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EnumerationFieldsResult = Record<string, FieldInfo>
+
+    try {
+      const response = await $b24.actions.v2.call.make<EnumerationFieldsResult>({
+        method: 'crm.userfield.enumeration.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Enumeration field names:', Object.keys(result))
+        console.info('ID field:', result['ID'])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEnumerationFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.userfield.enumeration.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Enumeration field names:', Object.keys(result))
+          console.info('ID field:', result['ID'])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEnumerationFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-fields/crm-userfield-fields.md
+++ b/api-reference/crm/universal/user-defined-fields/crm-userfield-fields.md
@@ -45,23 +45,80 @@
     https://**put_your_bitrix24_address**/rest/crm.userfield.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.userfield.fields",
-    		{}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type FieldDescriptor = {
+      type: string
+      title: string
+      isReadOnly?: boolean
+      isImmutable?: boolean
+      isMultiple?: boolean
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserfieldFieldsResult = Record<string, FieldDescriptor>
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserfieldFieldsResult>({
+        method: 'crm.userfield.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchUserfieldFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.userfield.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchUserfieldFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-fields/crm-userfield-settings-fields.md
+++ b/api-reference/crm/universal/user-defined-fields/crm-userfield-settings-fields.md
@@ -52,25 +52,81 @@
     https://**put_your_bitrix24_address**/rest/crm.userfield.settings.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.userfield.settings.fields",
-    		{
-    			type: "double"
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    type UserfieldSettingsItem = {
+      type: string
+      title: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserfieldSettingsResult = Record<string, UserfieldSettingsItem>
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserfieldSettingsResult>({
+        method: 'crm.userfield.settings.fields',
+        params: {
+          type: 'double',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result), result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchUserfieldSettingsFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.userfield.settings.fields',
+            params: {
+              type: 'double',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result), result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchUserfieldSettingsFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-fields/crm-userfield-types.md
+++ b/api-reference/crm/universal/user-defined-fields/crm-userfield-types.md
@@ -63,23 +63,75 @@
     https://**put_your_bitrix24_address**/rest/crm.userfield.types
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"crm.userfield.types",
-    		{}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type UserfieldTypeItem = {
+      ID: string
+      title: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserfieldTypeItem[]>({
+        method: 'crm.userfield.types',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field types:', result.length, result.map(t => t.ID))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserfieldTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.userfield.types',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field types:', result.length, result.map(t => t.ID))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserfieldTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-add.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-add.md
@@ -166,73 +166,201 @@
     https://**put_your_bitrix24_address**/rest/crm.type.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.type.add',
-    		{
-    			fields: {
-    				title: "Смарт-процесс",
-    				entityTypeId: 2024,
-    				isAutomationEnabled: "Y",
-    				isBeginCloseDatesEnabled: "Y",
-    				isBizProcEnabled: "Y",
-    				isCategoriesEnabled: "Y",
-    				isClientEnabled: "Y",
-    				isDocumentsEnabled: "Y",
-    				isLinkWithProductsEnabled: "Y",
-    				isMycompanyEnabled: "Y",
-    				isObserversEnabled: "Y",
-    				isRecyclebinEnabled: "Y",
-    				isSetOpenPermissions: "Y",
-    				isSourceEnabled: "Y",
-    				isStagesEnabled: "Y",
-    				isUseInUserfieldEnabled: "Y",
-    				linkedUserFields: {
-    					"CALENDAR_EVENT|UF_CRM_CAL_EVENT": "true",
-    					"TASKS_TASK|UF_CRM_TASK": "true",
-    				},
-    				relations: {
-    					parent: [
-    						{
-    							entityTypeId: 1,
-    							isChildrenListEnabled: "true",
-    						},
-    						{
-    							entityTypeId: 2,
-    							isChildrenListEnabled: "true",
-    						},
-    						{
-    							entityTypeId: 31,
-    							isChildrenListEnabled: "true",
-    							
-    						},
-    					],
-    					child: [
-    						{
-    							entityTypeId: 3,
-    							isChildrenListEnabled: "true",
-    						},
-    						{
-    							entityTypeId: 4,
-    						},
-    					],
-    				},
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TypeResult = {
+      type: {
+        id: number,
+        createdBy: number,
+        entityTypeId: number,
+        isCategoriesEnabled: string,
+        isStagesEnabled: string,
+        isBeginCloseDatesEnabled: string,
+        isClientEnabled: string,
+        isUseInUserfieldEnabled: string,
+        isLinkWithProductsEnabled: string,
+        isMycompanyEnabled: string,
+        isDocumentsEnabled: string,
+        isSourceEnabled: string,
+        isObserversEnabled: string,
+        isRecyclebinEnabled: string,
+        isAutomationEnabled: string,
+        isBizProcEnabled: string,
+        isSetOpenPermissions: string,
+        isPaymentsEnabled: string,
+        isCountersEnabled: string,
+        createdTime: ISODate,
+        updatedTime: ISODate,
+        updatedBy: number,
+        title: string,
+        relations: {
+          parent: Array<{ entityTypeId: number, isChildrenListEnabled: string, isPredefined: string }>,
+          child: Array<{ entityTypeId: number, isChildrenListEnabled: string, isPredefined: string }>,
+        },
+        linkedUserFields: Record<string, string>,
+        customSections: unknown[],
+        customSectionId: number | null,
+      },
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TypeResult>({
+        method: 'crm.type.add',
+        params: {
+          fields: {
+            title: "Smart Process",
+            entityTypeId: 2024,
+            isAutomationEnabled: "Y",
+            isBeginCloseDatesEnabled: "Y",
+            isBizProcEnabled: "Y",
+            isCategoriesEnabled: "Y",
+            isClientEnabled: "Y",
+            isDocumentsEnabled: "Y",
+            isLinkWithProductsEnabled: "Y",
+            isMycompanyEnabled: "Y",
+            isObserversEnabled: "Y",
+            isRecyclebinEnabled: "Y",
+            isSetOpenPermissions: "Y",
+            isSourceEnabled: "Y",
+            isStagesEnabled: "Y",
+            isUseInUserfieldEnabled: "Y",
+            linkedUserFields: {
+              "CALENDAR_EVENT|UF_CRM_CAL_EVENT": "true",
+              "TASKS_TASK|UF_CRM_TASK": "true",
+            },
+            relations: {
+              parent: [
+                {
+                  entityTypeId: 1,
+                  isChildrenListEnabled: "true",
+                },
+                {
+                  entityTypeId: 2,
+                  isChildrenListEnabled: "true",
+                },
+                {
+                  entityTypeId: 31,
+                  isChildrenListEnabled: "true",
+                },
+              ],
+              child: [
+                {
+                  entityTypeId: 3,
+                  isChildrenListEnabled: "true",
+                },
+                {
+                  entityTypeId: 4,
+                },
+              ],
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created smart process id:', result.type.id, 'entityTypeId:', result.type.entityTypeId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addCrmType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.type.add',
+            params: {
+              fields: {
+                title: "Smart Process",
+                entityTypeId: 2024,
+                isAutomationEnabled: "Y",
+                isBeginCloseDatesEnabled: "Y",
+                isBizProcEnabled: "Y",
+                isCategoriesEnabled: "Y",
+                isClientEnabled: "Y",
+                isDocumentsEnabled: "Y",
+                isLinkWithProductsEnabled: "Y",
+                isMycompanyEnabled: "Y",
+                isObserversEnabled: "Y",
+                isRecyclebinEnabled: "Y",
+                isSetOpenPermissions: "Y",
+                isSourceEnabled: "Y",
+                isStagesEnabled: "Y",
+                isUseInUserfieldEnabled: "Y",
+                linkedUserFields: {
+                  "CALENDAR_EVENT|UF_CRM_CAL_EVENT": "true",
+                  "TASKS_TASK|UF_CRM_TASK": "true",
+                },
+                relations: {
+                  parent: [
+                    {
+                      entityTypeId: 1,
+                      isChildrenListEnabled: "true",
+                    },
+                    {
+                      entityTypeId: 2,
+                      isChildrenListEnabled: "true",
+                    },
+                    {
+                      entityTypeId: 31,
+                      isChildrenListEnabled: "true",
+                    },
+                  ],
+                  child: [
+                    {
+                      entityTypeId: 3,
+                      isChildrenListEnabled: "true",
+                    },
+                    {
+                      entityTypeId: 4,
+                    },
+                  ],
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created smart process id:', result.type.id, 'entityTypeId:', result.type.entityTypeId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addCrmType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-delete.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-delete.md
@@ -56,26 +56,73 @@
     https://**put_your_bitrix24_address**/rest/crm.type.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.type.delete',
-    		{
-    			id: 16,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<unknown[]>({
+        method: 'crm.type.delete',
+        params: {
+          id: 16,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Smart process deleted, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSmartProcess() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.type.delete',
+            params: {
+              id: 16,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Smart process deleted, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSmartProcess)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-fields.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-fields.md
@@ -45,24 +45,86 @@
     https://**put_your_bitrix24_address**/rest/crm.type.fields?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.type.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each field descriptor returned in result.fields
+    type FieldInfo = {
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
+      isDynamic: boolean
+      title: string
+      upperName: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmTypeFieldsResult = {
+      fields: Record<string, FieldInfo>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmTypeFieldsResult>({
+        method: 'crm.type.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('CRM type fields:', Object.keys(result.fields))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCrmTypeFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.type.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('CRM type fields:', Object.keys(result.fields))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCrmTypeFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-get-by-entity-type-id.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-get-by-entity-type-id.md
@@ -54,26 +54,118 @@
     https://**put_your_bitrix24_address**/rest/crm.type.getByEntityTypeId
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.type.getByEntityTypeId',
-    		{
-    			entityTypeId: 2024,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CrmTypeGetByEntityTypeIdResult = {
+      type: {
+        id: number
+        title: string
+        code: string
+        createdBy: number
+        entityTypeId: number
+        customSectionId: number | null
+        isCategoriesEnabled: string
+        isStagesEnabled: string
+        isBeginCloseDatesEnabled: string
+        isClientEnabled: string
+        isUseInUserfieldEnabled: string
+        isLinkWithProductsEnabled: string
+        isMycompanyEnabled: string
+        isDocumentsEnabled: string
+        isSourceEnabled: string
+        isObserversEnabled: string
+        isRecyclebinEnabled: string
+        isAutomationEnabled: string
+        isBizProcEnabled: string
+        isSetOpenPermissions: string
+        isPaymentsEnabled: string
+        isCountersEnabled: string
+        createdTime: ISODate
+        updatedTime: ISODate
+        updatedBy: number
+        relations: {
+          parent: Array<{
+            entityTypeId: number
+            isChildrenListEnabled: string
+            isPredefined: string
+          }>
+          child: Array<{
+            entityTypeId: number
+            isChildrenListEnabled: string
+            isPredefined: string
+          }>
+        }
+        linkedUserFields: Record<string, string>
+        customSections: unknown[]
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CrmTypeGetByEntityTypeIdResult>({
+        method: 'crm.type.getByEntityTypeId',
+        params: {
+          entityTypeId: 2024,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.type.id, result.type.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTypeByEntityTypeId() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.type.getByEntityTypeId',
+            params: {
+              entityTypeId: 2024,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.type.id, result.type.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTypeByEntityTypeId)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-get.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-get.md
@@ -54,26 +54,110 @@
     https://**put_your_bitrix24_address**/rest/crm.type.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'crm.type.get',
-    		{
-    			id: 16,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TypeGetResult = {
+      type: {
+        id: number
+        title: string
+        code: string
+        createdBy: number
+        entityTypeId: number
+        customSectionId: number | null
+        isCategoriesEnabled: 'Y' | 'N'
+        isStagesEnabled: 'Y' | 'N'
+        isBeginCloseDatesEnabled: 'Y' | 'N'
+        isClientEnabled: 'Y' | 'N'
+        isUseInUserfieldEnabled: 'Y' | 'N'
+        isLinkWithProductsEnabled: 'Y' | 'N'
+        isMycompanyEnabled: 'Y' | 'N'
+        isDocumentsEnabled: 'Y' | 'N'
+        isSourceEnabled: 'Y' | 'N'
+        isObserversEnabled: 'Y' | 'N'
+        isRecyclebinEnabled: 'Y' | 'N'
+        isAutomationEnabled: 'Y' | 'N'
+        isBizProcEnabled: 'Y' | 'N'
+        isSetOpenPermissions: 'Y' | 'N'
+        isPaymentsEnabled: 'Y' | 'N'
+        isCountersEnabled: 'Y' | 'N'
+        createdTime: ISODate | null
+        updatedTime: ISODate | null
+        updatedBy: number
+        relations: {
+          parent: { entityTypeId: number; isChildrenListEnabled: 'Y' | 'N'; isPredefined: 'Y' | 'N' }[]
+          child: { entityTypeId: number; isChildrenListEnabled: 'Y' | 'N'; isPredefined: 'Y' | 'N' }[]
+        }
+        linkedUserFields: Record<string, 'Y' | 'N'>
+        customSections: unknown[]
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TypeGetResult>({
+        method: 'crm.type.get',
+        params: {
+          id: 16,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.type.id, result.type.title, result.type.entityTypeId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getType() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.type.get',
+            params: {
+              id: 16,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.type.id, result.type.title, result.type.entityTypeId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getType)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-list.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-list.md
@@ -106,38 +106,144 @@
         https://**put_your_bitrix24_address**/rest/crm.type.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.type.list', 
-            {
-                filter: {
-                    "0": {
-                        logic: 'OR',
-                        "0": {
-                            "%title": "5",
-                        },
-                        "1": {
-                            "%title": "0",
-                        },
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type CrmTypeItem = {
+          id: number
+          title: string
+          code: string
+          createdBy: number
+          entityTypeId: number
+          customSectionId: number | null
+          isCategoriesEnabled: string
+          isStagesEnabled: string
+          isBeginCloseDatesEnabled: string
+          isClientEnabled: string
+          isUseInUserfieldEnabled: string
+          isLinkWithProductsEnabled: string
+          isMycompanyEnabled: string
+          isDocumentsEnabled: string
+          isSourceEnabled: string
+          isObserversEnabled: string
+          isRecyclebinEnabled: string
+          isAutomationEnabled: string
+          isBizProcEnabled: string
+          isSetOpenPermissions: string
+          isPaymentsEnabled: string
+          isCountersEnabled: string
+          createdTime: ISODate
+          updatedTime: ISODate
+          updatedBy: number
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type CrmTypeListResult = {
+          types: CrmTypeItem[]
+        }
+
+        try {
+          // crm.type.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make<CrmTypeListResult>({
+            method: 'crm.type.list',
+            params: {
+              filter: {
+                '0': {
+                  logic: 'OR',
+                  '0': {
+                    '%title': '5',
+                  },
+                  '1': {
+                    '%title': '0',
+                  },
+                },
+              },
+              order: {
+                id: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Smart process types:', result.types, 'Page size:', result.types.length)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function listCrmTypes() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.type.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.type.list',
+                params: {
+                  filter: {
+                    '0': {
+                      logic: 'OR',
+                      '0': {
+                        '%title': '5',
+                      },
+                      '1': {
+                        '%title': '0',
+                      },
                     },
-                },
-                order: {
+                  },
+                  order: {
                     id: 'DESC',
+                  },
+                  start: 0,
                 },
-            },
-            (result) => {
-                if (result.error())
-                {
-                    console.error(result.error());
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
 
-                    return;
-                }
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
 
-                console.info(result.data());
-            },
-        );
+              const result = response.getData().result
+              console.info('Smart process types:', result.types, 'Page size:', result.types.length)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', listCrmTypes)
+        </script>
         ```
 
     - PHP
@@ -200,30 +306,128 @@
         https://**put_your_bitrix24_address**/rest/crm.type.list
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.type.list',
-            {
-                filter: {
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type CrmTypeItem = {
+          id: number
+          title: string
+          code: string
+          createdBy: number
+          entityTypeId: number
+          customSectionId: number | null
+          isCategoriesEnabled: string
+          isStagesEnabled: string
+          isBeginCloseDatesEnabled: string
+          isClientEnabled: string
+          isUseInUserfieldEnabled: string
+          isLinkWithProductsEnabled: string
+          isMycompanyEnabled: string
+          isDocumentsEnabled: string
+          isSourceEnabled: string
+          isObserversEnabled: string
+          isRecyclebinEnabled: string
+          isAutomationEnabled: string
+          isBizProcEnabled: string
+          isSetOpenPermissions: string
+          isPaymentsEnabled: string
+          isCountersEnabled: string
+          createdTime: ISODate
+          updatedTime: ISODate
+          updatedBy: number
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type CrmTypeListResult = {
+          types: CrmTypeItem[]
+        }
+
+        try {
+          // crm.type.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make<CrmTypeListResult>({
+            method: 'crm.type.list',
+            params: {
+              filter: {
+                isAutomationEnabled: 'Y',
+                isBizProcEnabled: 'Y',
+                isCategoriesEnabled: 'Y',
+                isClientEnabled: 'Y',
+              },
+              start: 0,
+            },
+            requestId: Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info('Smart process types:', result.types, 'Page size:', result.types.length)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
+
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function listCrmTypes() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              // crm.type.list returns a single page (max 50 records). For the whole result set
+              // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+              // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+              // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+              // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.type.list',
+                params: {
+                  filter: {
                     isAutomationEnabled: 'Y',
-                    isBizProcEnabled: "Y",
-                    isCategoriesEnabled: "Y",
-                    isClientEnabled: "Y",
+                    isBizProcEnabled: 'Y',
+                    isCategoriesEnabled: 'Y',
+                    isClientEnabled: 'Y',
+                  },
+                  start: 0,
                 },
-            },
-            (result) => {
-                if (result.error())
-                {
-                    console.error(result.error());
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
 
-                    return;
-                }
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
 
-                console.info(result.data());
-            },
-        );
+              const result = response.getData().result
+              console.info('Smart process types:', result.types, 'Page size:', result.types.length)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', listCrmTypes)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/universal/user-defined-object-types/crm-type-update.md
+++ b/api-reference/crm/universal/user-defined-object-types/crm-type-update.md
@@ -139,37 +139,108 @@
         https://**put_your_bitrix24_address**/rest/crm.type.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.type.update',
-            {
-                id: 20,
-                fields: {
-                    isAutomationEnabled: "N",
-                    isBeginCloseDatesEnabled: "N",
-                    isClientEnabled: "N",
-                    isObserversEnabled: "N",
-                    isSourceEnabled: "Y",
-                    isStagesEnabled: "Y",
-                    isUseInUserfieldEnabled: "Y",
-                    linkedUserFields: {
-                        "TASKS_TASK|UF_CRM_TASK": "true",
-                    },
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type SmartProcessType = {
+          id: number
+          title: string
+          entityTypeId: number
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type TypeUpdateResult = {
+          type: SmartProcessType
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<TypeUpdateResult>({
+            method: 'crm.type.update',
+            params: {
+              id: 20,
+              fields: {
+                isAutomationEnabled: 'N',
+                isBeginCloseDatesEnabled: 'N',
+                isClientEnabled: 'N',
+                isObserversEnabled: 'N',
+                isSourceEnabled: 'Y',
+                isStagesEnabled: 'Y',
+                isUseInUserfieldEnabled: 'Y',
+                linkedUserFields: {
+                  'TASKS_TASK|UF_CRM_TASK': 'true',
                 },
+              },
             },
-            (result) => {
-                if (result.error())
-                {
-                    console.error(result.error());
+            requestId: Text.getUuidRfc4122()
+          })
 
-                    return;
-                }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(`Updated smart process #${result.type.id} (${result.type.title})`)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
 
-                console.info(result.data());
-            },
-        );
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateSmartProcessSettings() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.type.update',
+                params: {
+                  id: 20,
+                  fields: {
+                    isAutomationEnabled: 'N',
+                    isBeginCloseDatesEnabled: 'N',
+                    isClientEnabled: 'N',
+                    isObserversEnabled: 'N',
+                    isSourceEnabled: 'Y',
+                    isStagesEnabled: 'Y',
+                    isUseInUserfieldEnabled: 'Y',
+                    linkedUserFields: {
+                      'TASKS_TASK|UF_CRM_TASK': 'true',
+                    },
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(`Updated smart process #${result.type.id} (${result.type.title})`)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', updateSmartProcessSettings)
+        </script>
         ```
 
     - PHP
@@ -259,40 +330,114 @@
         https://**put_your_bitrix24_address**/rest/crm.type.update
         ```
 
-    - JS
+    - JS (TS)
 
-        ```js
-        BX24.callMethod(
-            'crm.type.update',
-            {
-                id: 20,
-                fields: {
-                    relations: {
-                        parent: [],
-                        child: [
-                            {
-                                "entityTypeId": 1,
-                                "isChildrenListEnabled": "true",
-                            },
-                            {
-                                "entityTypeId": 2,
-                                "isChildrenListEnabled": "false",
-                            }
-                        ],
+        ```ts
+        // This snippet is an ES module: top-level await requires type="module" or a bundler.
+        // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+        import { Text } from '@bitrix24/b24jssdk'
+        import type { B24Frame } from '@bitrix24/b24jssdk'
+
+        declare const $b24: B24Frame
+
+        type SmartProcessType = {
+          id: number
+          title: string
+          entityTypeId: number
+        }
+
+        // Shape of the payload returned in result (match the "response handling" section of the page)
+        type TypeUpdateResult = {
+          type: SmartProcessType
+        }
+
+        try {
+          const response = await $b24.actions.v2.call.make<TypeUpdateResult>({
+            method: 'crm.type.update',
+            params: {
+              id: 20,
+              fields: {
+                relations: {
+                  parent: [],
+                  child: [
+                    {
+                      entityTypeId: 1,
+                      isChildrenListEnabled: 'true',
                     },
+                    {
+                      entityTypeId: 2,
+                      isChildrenListEnabled: 'false',
+                    },
+                  ],
                 },
+              },
             },
-            (result) => {
-                if (result.error())
-                {
-                    console.error(result.error());
+            requestId: Text.getUuidRfc4122()
+          })
 
-                    return;
-                }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+          } else {
+            const result = response.getData()!.result
+            console.info(`Updated smart process #${result.type.id} (${result.type.title})`)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+        ```
 
-                console.info(result.data());
-            },
-        );
+    - JS (UMD)
+
+        ```html
+        <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+        <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+        <script>
+          async function updateSmartProcessRelations() {
+            try {
+              // Initialize the SDK inside a Bitrix24 frame
+              const $b24 = await B24Js.initializeB24Frame()
+
+              const response = await $b24.actions.v2.call.make({
+                method: 'crm.type.update',
+                params: {
+                  id: 20,
+                  fields: {
+                    relations: {
+                      parent: [],
+                      child: [
+                        {
+                          entityTypeId: 1,
+                          isChildrenListEnabled: 'true',
+                        },
+                        {
+                          entityTypeId: 2,
+                          isChildrenListEnabled: 'false',
+                        },
+                      ],
+                    },
+                  },
+                },
+                requestId: B24Js.Text.getUuidRfc4122()
+              })
+
+              // The payload is available only on a successful response
+              if (!response.isSuccess) {
+                console.error(response.getErrorMessages().join('; '))
+                return
+              }
+
+              const result = response.getData().result
+              console.info(`Updated smart process #${result.type.id} (${result.type.title})`)
+            } catch (error) {
+              // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+              console.error(error)
+            }
+          }
+
+          document.addEventListener('DOMContentLoaded', updateSmartProcessRelations)
+        </script>
         ```
 
     - PHP

--- a/api-reference/crm/universal/userfieldconfig/userfieldconfig-add.md
+++ b/api-reference/crm/universal/userfieldconfig/userfieldconfig-add.md
@@ -360,36 +360,134 @@
       "https://**put_your_bitrix24_address**/rest/userfieldconfig.add"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    const endpoint = "https://**put_your_bitrix24_address**/rest/userfieldconfig.add.json";
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    fetch(endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-            auth: "**put_access_token_here**",
-            moduleId: "crm",
-            field: {
-                entityId: "CRM_7",
-                fieldName: "UF_CRM_7_NEW_REST_LIST_2026",
-                userTypeId: "enumeration",
-                multiple: "Y",
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserfieldconfigAddResult = {
+      field: {
+        id: string
+        entityId: string
+        fieldName: string
+        userTypeId: string
+        xmlId: string | null
+        sort: string
+        multiple: string
+        mandatory: string
+        showFilter: string
+        showInList: string
+        editInList: string
+        isSearchable: string
+        settings: Record<string, unknown>
+        languageId: Record<string, string>
+        editFormLabel: Record<string, string | null>
+        listColumnLabel: Record<string, string | null>
+        listFilterLabel: Record<string, string | null>
+        errorMessage: Record<string, string | null>
+        helpMessage: Record<string, string | null>
+        enum?: Array<{
+          id: string
+          userFieldId: string
+          value: string
+          def: string
+          sort: string
+          xmlId: string
+        }>
+      }
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserfieldconfigAddResult>({
+        method: 'userfieldconfig.add',
+        params: {
+          moduleId: 'crm',
+          field: {
+            entityId: 'CRM_7',
+            fieldName: 'UF_CRM_7_NEW_REST_LIST_2026',
+            userTypeId: 'enumeration',
+            multiple: 'Y',
+            editFormLabel: {
+              ru: 'Список характеристик',
+              en: 'List of characteristics',
+            },
+            enum: [
+              { value: 'Characteristic 1', def: 'N', sort: 100 },
+              { value: 'Characteristic 2', def: 'Y', sort: 200 },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created field:', result.field.id, result.field.fieldName)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addUserfield() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userfieldconfig.add',
+            params: {
+              moduleId: 'crm',
+              field: {
+                entityId: 'CRM_7',
+                fieldName: 'UF_CRM_7_NEW_REST_LIST_2026',
+                userTypeId: 'enumeration',
+                multiple: 'Y',
                 editFormLabel: {
-                    ru: "Список характеристик",
-                    en: "List of characteristics",
+                  ru: 'Список характеристик',
+                  en: 'List of characteristics',
                 },
                 enum: [
-                    { value: "Характеристика 1", def: "N", sort: 100 },
-                    { value: "Характеристика 2", def: "Y", sort: 200 },
+                  { value: 'Characteristic 1', def: 'N', sort: 100 },
+                  { value: 'Characteristic 2', def: 'Y', sort: 200 },
                 ],
+              },
             },
-        }),
-    })
-        .then((response) => response.json())
-        .then((data) => console.log(data))
-        .catch((error) => console.error(error));
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created field:', result.field.id, result.field.fieldName)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addUserfield)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/userfieldconfig/userfieldconfig-delete.md
+++ b/api-reference/crm/universal/userfieldconfig/userfieldconfig-delete.md
@@ -56,26 +56,75 @@
     https://**put_your_bitrix24_address**/rest/userfieldconfig.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'userfieldconfig.delete',
-    		{
-    			moduleId: 'crm',
-    			id: 6953,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<null>({
+        method: 'userfieldconfig.delete',
+        params: {
+          moduleId: 'crm',
+          id: 6953,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field deleted successfully')
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteUserField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userfieldconfig.delete',
+            params: {
+              moduleId: 'crm',
+              id: 6953,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field deleted successfully')
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteUserField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/userfieldconfig/userfieldconfig-get-types.md
+++ b/api-reference/crm/universal/userfieldconfig/userfieldconfig-get-types.md
@@ -52,25 +52,83 @@
     https://**put_your_bitrix24_address**/rest/userfieldconfig.getTypes
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'userfieldconfig.getTypes',
-    		{
-    			moduleId: 'crm',
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type TypeItem = {
+      userTypeId: string
+      description: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetTypesResult = {
+      types: Record<string, TypeItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetTypesResult>({
+        method: 'userfieldconfig.getTypes',
+        params: {
+          moduleId: 'crm',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.types)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userfieldconfig.getTypes',
+            params: {
+              moduleId: 'crm',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.types)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/userfieldconfig/userfieldconfig-get.md
+++ b/api-reference/crm/universal/userfieldconfig/userfieldconfig-get.md
@@ -56,26 +56,108 @@
     https://**put_your_bitrix24_address**/rest/userfieldconfig.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'userfieldconfig.get',
-    		{
-    			moduleId: 'crm',
-    			id: 7095,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserfieldconfigGetResult = {
+      field: {
+        id: string
+        entityId: string
+        fieldName: string
+        userTypeId: string
+        xmlId: string | null
+        sort: string
+        multiple: string
+        mandatory: string
+        showFilter: string
+        showInList: string
+        editInList: string
+        isSearchable: string
+        settings: Record<string, unknown>
+        languageId: Record<string, string>
+        editFormLabel: Record<string, string | null>
+        listColumnLabel: Record<string, string | null>
+        listFilterLabel: Record<string, string | null>
+        errorMessage: Record<string, string | null>
+        helpMessage: Record<string, string | null>
+        enum?: Array<{
+          id: string
+          userFieldId: string
+          value: string
+          def: string
+          sort: string
+          xmlId: string
+        }>
+      } | null
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserfieldconfigGetResult>({
+        method: 'userfieldconfig.get',
+        params: {
+          moduleId: 'crm',
+          id: 7095,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.field?.id, result.field?.fieldName, result.field?.userTypeId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserfieldConfig() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userfieldconfig.get',
+            params: {
+              moduleId: 'crm',
+              id: 7095,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.field?.id, result.field?.fieldName, result.field?.userTypeId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserfieldConfig)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/userfieldconfig/userfieldconfig-list.md
+++ b/api-reference/crm/universal/userfieldconfig/userfieldconfig-list.md
@@ -180,36 +180,112 @@
     https://**put_your_bitrix24_address**/rest/userfieldconfig.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'userfieldconfig.list',
-    		{
-    			moduleId: 'crm',
-    			select: {
-    				0: '*',
-    				language: 'ru',
-    			},
-    			order: {
-    				id: 'DESC',
-    			},
-    			filter: {
-    				multiple: 'Y',
-    			},
-    			start: 0,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type UserFieldConfig = {
+      id: string
+      fieldName: string
+      userTypeId: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserFieldConfigListResult = {
+      fields: UserFieldConfig[]
     }
+
+    // userfieldconfig.list returns a single page (max 50 records). For the whole result set
+    // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+    // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+    // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+    // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+    try {
+      const response = await $b24.actions.v2.call.make<UserFieldConfigListResult>({
+        method: 'userfieldconfig.list',
+        params: {
+          moduleId: 'crm',
+          select: ['*'],
+          order: {
+            id: 'DESC',
+          },
+          filter: {
+            multiple: 'Y',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(`Loaded ${result.fields.length} field config(s) on this page`)
+        console.info(result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listUserFieldConfigs() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // userfieldconfig.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'userfieldconfig.list',
+            params: {
+              moduleId: 'crm',
+              select: ['*'],
+              order: {
+                id: 'DESC',
+              },
+              filter: {
+                multiple: 'Y',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(`Loaded ${result.fields.length} field config(s) on this page`)
+          console.info(result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listUserFieldConfigs)
+    </script>
     ```
 
 - PHP

--- a/api-reference/crm/universal/userfieldconfig/userfieldconfig-update.md
+++ b/api-reference/crm/universal/userfieldconfig/userfieldconfig-update.md
@@ -329,33 +329,122 @@
     https://**put_your_bitrix24_address**/rest/userfieldconfig.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'userfieldconfig.update',
-    		{
-    			moduleId: 'crm',
-    			id: 7095,
-    			field: {
-    				mandatory: 'Y',
-    				editFormLabel: {
-    					ru: 'Список характеристик (обновлено)',
-    					en: 'List of characteristics (updated)',
-    				},
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UserfieldconfigUpdateResult = {
+      field: {
+        id: string
+        entityId: string
+        fieldName: string
+        userTypeId: string
+        xmlId: string | null
+        sort: string
+        multiple: string
+        mandatory: string
+        showFilter: string
+        showInList: string
+        editInList: string
+        isSearchable: string
+        settings: Record<string, unknown>
+        languageId: Record<string, string>
+        editFormLabel: Record<string, string | null>
+        listColumnLabel: Record<string, string | null>
+        listFilterLabel: Record<string, string | null>
+        errorMessage: Record<string, string | null>
+        helpMessage: Record<string, string | null>
+        enum?: Array<{
+          id: string
+          userFieldId: string
+          value: string
+          def: string
+          sort: string
+          xmlId: string
+        }>
+      }
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserfieldconfigUpdateResult>({
+        method: 'userfieldconfig.update',
+        params: {
+          moduleId: 'crm',
+          id: 7095,
+          field: {
+            mandatory: 'Y',
+            editFormLabel: {
+              ru: 'Список характеристик (обновлено)',
+              en: 'List of characteristics (updated)',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated field:', result.field.id, result.field.fieldName, result.field.mandatory)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateUserfieldconfig() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userfieldconfig.update',
+            params: {
+              moduleId: 'crm',
+              id: 7095,
+              field: {
+                mandatory: 'Y',
+                editFormLabel: {
+                  ru: 'Список характеристик (обновлено)',
+                  en: 'List of characteristics (updated)',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated field:', result.field.id, result.field.fieldName, result.field.mandatory)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateUserfieldconfig)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.