### PR TITLE
docs(biconnector): actualize JS examples to TS + UMD

### DIFF
--- a/api-reference/biconnector/connector/biconnector-connector-add.md
+++ b/api-reference/biconnector/connector/biconnector-connector-add.md
@@ -138,49 +138,120 @@
          https://**put_your_bitrix24_address**/rest/biconnector.connector.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.connector.add',
-    		{
-    			fields: {
-    				"title": "SUPER REST CONNECTOR",
-    				"logo": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxjaXJjbGUgY3g9IjExIiBjeT0iMTEiIHI9IjEwIiBmaWxsPSIjRkYzQjNCIiAvPgoJPHRleHQgeD0iMTEiIHk9IjEzIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNiIgZmlsbD0iI0ZGRkZGRiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC13ZWlnaHQ9ImJvbGQiPlJFU1Q8L3RleHQ+Cjwvc3ZnPg==",
-    				"description": "Connector with token",
-    				"urlCheck": "http://example.com/api/check",
-    				"urlTableList": "http://example.com/api/table_list",
-    				"urlTableDescription": "http://example.com/api/table_description",
-    				"urlData": "http://example.com/api/data",
-    				"settings": [
-    					{
-    						"name": "Логин",
-    						"type": "STRING",
-    						"code": "login"
-    					},
-    					{
-    						"name": "Пароль",
-    						"type": "STRING",
-    						"code": "password"
-    					}
-    				],
-    				"sort": 100
-    			},
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result.data());
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConnectorAddResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConnectorAddResult>({
+        method: 'biconnector.connector.add',
+        params: {
+          fields: {
+            title: 'SUPER REST CONNECTOR',
+            logo: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxjaXJjbGUgY3g9IjExIiBjeT0iMTEiIHI9IjEwIiBmaWxsPSIjRkYzQjNCIiAvPgoJPHRleHQgeD0iMTEiIHk9IjEzIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNiIgZmlsbD0iI0ZGRkZGRiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC13ZWlnaHQ9ImJvbGQiPlJFU1Q8L3RleHQ+Cjwvc3ZnPg==',
+            description: 'Connector with token',
+            urlCheck: 'http://example.com/api/check',
+            urlTableList: 'http://example.com/api/table_list',
+            urlTableDescription: 'http://example.com/api/table_description',
+            urlData: 'http://example.com/api/data',
+            settings: [
+              {
+                name: 'Login',
+                type: 'STRING',
+                code: 'login',
+              },
+              {
+                name: 'Password',
+                type: 'STRING',
+                code: 'password',
+              },
+            ],
+            sort: 100,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created connector ID:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.connector.add',
+            params: {
+              fields: {
+                title: 'SUPER REST CONNECTOR',
+                logo: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxjaXJjbGUgY3g9IjExIiBjeT0iMTEiIHI9IjEwIiBmaWxsPSIjRkYzQjNCIiAvPgoJPHRleHQgeD0iMTEiIHk9IjEzIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iNiIgZmlsbD0iI0ZGRkZGRiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC13ZWlnaHQ9ImJvbGQiPlJFU1Q8L3RleHQ+Cjwvc3ZnPg==',
+                description: 'Connector with token',
+                urlCheck: 'http://example.com/api/check',
+                urlTableList: 'http://example.com/api/table_list',
+                urlTableDescription: 'http://example.com/api/table_description',
+                urlData: 'http://example.com/api/data',
+                settings: [
+                  {
+                    name: 'Login',
+                    type: 'STRING',
+                    code: 'login',
+                  },
+                  {
+                    name: 'Password',
+                    type: 'STRING',
+                    code: 'password',
+                  },
+                ],
+                sort: 100,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created connector ID:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/connector/biconnector-connector-delete.md
+++ b/api-reference/biconnector/connector/biconnector-connector-delete.md
@@ -59,26 +59,73 @@
          https://**put_your_bitrix24_address**/rest/biconnector.connector.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.connector.delete',
-    		{
-    			id: 4,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error() ? console.error(result.error()) : console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.connector.delete',
+        params: {
+          id: 4,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connector deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.connector.delete',
+            params: {
+              id: 4,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connector deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/connector/biconnector-connector-fields.md
+++ b/api-reference/biconnector/connector/biconnector-connector-fields.md
@@ -46,26 +46,81 @@
          https://**put_your_bitrix24_address**/rest/biconnector.connector.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.connector.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConnectorFieldsResult = {
+      fields: {
+        title: string
+        type: string
+        isRequired: boolean
+        isReadOnly: boolean
+        isImmutable: boolean
+        isMultiple: boolean
+      }[]
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConnectorFieldsResult>({
+        method: 'biconnector.connector.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getConnectorFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.connector.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getConnectorFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/connector/biconnector-connector-get.md
+++ b/api-reference/biconnector/connector/biconnector-connector-get.md
@@ -57,26 +57,94 @@
          https://**put_your_bitrix24_address**/rest/biconnector.connector.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.connector.get',
-    		{
-    			id: 4,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error() ? console.error(result.error()) : console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ConnectorGetResult = {
+      item: {
+        id: number
+        title: string
+        dateCreate: ISODate | null
+        logo: string
+        description: string
+        sort: number
+        urlCheck: string
+        settings: Array<{
+          name: string
+          code: string
+          type: string
+        }>
+        urlData: string
+        urlTableList: string
+        urlTableDescription: string
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ConnectorGetResult>({
+        method: 'biconnector.connector.get',
+        params: {
+          id: 4,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.id, result.item.title, result.item.settings)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.connector.get',
+            params: {
+              id: 4,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.id, result.item.title, result.item.settings)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/connector/biconnector-connector-list.md
+++ b/api-reference/biconnector/connector/biconnector-connector-list.md
@@ -139,90 +139,117 @@
          https://**put_your_bitrix24_address**/rest/biconnector.connector.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each connector returned in result[]
+    type ConnectorItem = {
+      id: string
+      title: string
+      urlCheck: string
+      dateCreate: ISODate | null
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'biconnector.connector.list',
-        {
+      // biconnector.connector.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ConnectorItem[]>({
+        method: 'biconnector.connector.list',
+        params: {
           select: [
-            "id",
-            "title",
-            "urlCheck",
-            "dateCreate"
+            'id',
+            'title',
+            'urlCheck',
+            'dateCreate',
           ],
           filter: {
-            '%=title': "MyConnector%",
-            '!description': ''
+            '%=title': 'MyConnector%',
+            '!description': '',
           },
           order: {
-            dateCreate: "DESC"
-          }
+            dateCreate: 'DESC',
+          },
+          start: 0,
         },
-        (progress) => { 
-          result.error()
-            ? console.error(result.error())
-            : console.info(result.data());
-        }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('biconnector.connector.list', {
-        select: [
-          "id",
-          "title",
-          "urlCheck",
-          "dateCreate"
-        ],
-        filter: {
-          '%=title': "MyConnector%",
-          '!description': ''
-        },
-        order: {
-          dateCreate: "DESC"
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connectors:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('biconnector.connector.list', {
-        select: [
-          "id",
-          "title",
-          "urlCheck",
-          "dateCreate"
-        ],
-        filter: {
-          '%=title': "MyConnector%",
-          '!description': ''
-        },
-        order: {
-          dateCreate: "DESC"
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function loadConnectorList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // biconnector.connector.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.connector.list',
+            params: {
+              select: [
+                'id',
+                'title',
+                'urlCheck',
+                'dateCreate',
+              ],
+              filter: {
+                '%=title': 'MyConnector%',
+                '!description': '',
+              },
+              order: {
+                dateCreate: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connectors:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', loadConnectorList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/connector/biconnector-connector-update.md
+++ b/api-reference/biconnector/connector/biconnector-connector-update.md
@@ -142,50 +142,117 @@
          https://**put_your_bitrix24_address**/rest/biconnector.connector.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.connector.update',
-    		{
-    			id: 4,
-    			fields: {
-    				"title": "UPDATED REST CONNECTOR",
-    				"logo": "data:image/svg+xml;base64,NEWLOGODATA",
-    				"description": "Updated description",
-    				"urlCheck": "http://example.com/api/new_check",
-    				"urlTableList": "http://example.com/api/new_table_list",
-    				"urlTableDescription": "http://example.com/api/new_table_description",
-    				"urlData": "http://example.com/api/new_data",
-    				"settings": [
-    					{
-    						"name": "Идентификатор сотрудника",
-    						"type": "STRING",
-    						"code": "id"
-    					},
-    					{
-    						"name": "Пароль",
-    						"type": "STRING",
-    						"code": "password"
-    					}
-    				],
-    				"sort": 200
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.connector.update',
+        params: {
+          id: 4,
+          fields: {
+            title: 'UPDATED REST CONNECTOR',
+            logo: 'data:image/svg+xml;base64,NEWLOGODATA',
+            description: 'Updated description',
+            urlCheck: 'http://example.com/api/new_check',
+            urlTableList: 'http://example.com/api/new_table_list',
+            urlTableDescription: 'http://example.com/api/new_table_description',
+            urlData: 'http://example.com/api/new_data',
+            settings: [
+              {
+                name: 'Employee ID',
+                type: 'STRING',
+                code: 'id',
+              },
+              {
+                name: 'Password',
+                type: 'STRING',
+                code: 'password',
+              },
+            ],
+            sort: 200,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Connector updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.connector.update',
+            params: {
+              id: 4,
+              fields: {
+                title: 'UPDATED REST CONNECTOR',
+                logo: 'data:image/svg+xml;base64,NEWLOGODATA',
+                description: 'Updated description',
+                urlCheck: 'http://example.com/api/new_check',
+                urlTableList: 'http://example.com/api/new_table_list',
+                urlTableDescription: 'http://example.com/api/new_table_description',
+                urlData: 'http://example.com/api/new_data',
+                settings: [
+                  {
+                    name: 'Employee ID',
+                    type: 'STRING',
+                    code: 'id',
+                  },
+                  {
+                    name: 'Password',
+                    type: 'STRING',
+                    code: 'password',
+                  },
+                ],
+                sort: 200,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Connector updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateConnector)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-add.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-add.md
@@ -118,42 +118,106 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.dataset.add',
-    		{
-    			fields: {
-    				"sourceId": 3,
-    				"name": "rest_dataset",
-    				"externalName": "extranalName",
-    				"externalCode": "extrnalCode",
-    				"description": "Описание датасета",
-    				"fields": [
-    					{ "type": "int", "name": "ID", "externalCode": "ID" },
-    					{ "type": "string", "name": "NAME", "externalCode": "NAME" },
-    					{ "type": "string", "name": "SURNAME", "externalCode": "SURNAME" },
-    					{ "type": "double", "name": "SCORE", "externalCode": "SCORE" },
-    					{ "type": "date", "name": "DATA", "externalCode": "DATA" },
-    					{ "type": "datetime", "name": "TIME", "externalCode": "TIME" }
-    				]
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DatasetAddResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DatasetAddResult>({
+        method: 'biconnector.dataset.add',
+        params: {
+          fields: {
+            sourceId: 3,
+            name: 'rest_dataset',
+            externalName: 'extranalName',
+            externalCode: 'extrnalCode',
+            description: 'Dataset description',
+            fields: [
+              { type: 'int', name: 'ID', externalCode: 'ID' },
+              { type: 'string', name: 'NAME', externalCode: 'NAME' },
+              { type: 'string', name: 'SURNAME', externalCode: 'SURNAME' },
+              { type: 'double', name: 'SCORE', externalCode: 'SCORE' },
+              { type: 'date', name: 'DATA', externalCode: 'DATA' },
+              { type: 'datetime', name: 'TIME', externalCode: 'TIME' },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created dataset id:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addDataset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.add',
+            params: {
+              fields: {
+                sourceId: 3,
+                name: 'rest_dataset',
+                externalName: 'extranalName',
+                externalCode: 'extrnalCode',
+                description: 'Dataset description',
+                fields: [
+                  { type: 'int', name: 'ID', externalCode: 'ID' },
+                  { type: 'string', name: 'NAME', externalCode: 'NAME' },
+                  { type: 'string', name: 'SURNAME', externalCode: 'SURNAME' },
+                  { type: 'double', name: 'SCORE', externalCode: 'SCORE' },
+                  { type: 'date', name: 'DATA', externalCode: 'DATA' },
+                  { type: 'datetime', name: 'TIME', externalCode: 'TIME' },
+                ],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created dataset id:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addDataset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-delete.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-delete.md
@@ -52,28 +52,73 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.dataset.delete',
-    		{
-    			id: 4,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.dataset.delete',
+        params: {
+          id: 4,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dataset deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteDataset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.delete',
+            params: {
+              id: 4,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dataset deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteDataset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-fields-update.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-fields-update.md
@@ -137,54 +137,119 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.fields.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.dataset.fields.update',
-    		{
-    			id: 10,
-    			add: [
-    				{
-    					type: "int",
-    					name: "NAME",
-    					externalCode: "NAME"
-    				},
-    				{
-    					type: "int",
-    					name: "ID",
-    					externalCode: "ID"
-    				}
-    			],
-    			update: [
-    				{
-    					"id": 12,
-    					"visible": false
-    				},
-    				{
-    					"id": 13,
-    					"visible": true
-    				}
-    			],
-    			delete: [
-    				14,
-    				15
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.dataset.fields.update',
+        params: {
+          id: 10,
+          add: [
+            {
+              type: 'int',
+              name: 'NAME',
+              externalCode: 'NAME',
+            },
+            {
+              type: 'int',
+              name: 'ID',
+              externalCode: 'ID',
+            },
+          ],
+          update: [
+            {
+              id: 12,
+              visible: false,
+            },
+            {
+              id: 13,
+              visible: true,
+            },
+          ],
+          delete: [14, 15],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dataset fields updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDatasetFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.fields.update',
+            params: {
+              id: 10,
+              add: [
+                {
+                  type: 'int',
+                  name: 'NAME',
+                  externalCode: 'NAME',
+                },
+                {
+                  type: 'int',
+                  name: 'ID',
+                  externalCode: 'ID',
+                },
+              ],
+              update: [
+                {
+                  id: 12,
+                  visible: false,
+                },
+                {
+                  id: 13,
+                  visible: true,
+                },
+              ],
+              delete: [14, 15],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dataset fields updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDatasetFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-fields.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-fields.md
@@ -46,26 +46,81 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.dataset.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DatasetFieldsResult = {
+      fields: {
+        title: string
+        type: string
+        isRequired: boolean
+        isReadOnly: boolean
+        isImmutable: boolean
+        isMultiple: boolean
+      }[]
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DatasetFieldsResult>({
+        method: 'biconnector.dataset.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dataset fields count:', result.fields.length, result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDatasetFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dataset fields count:', result.fields.length, result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDatasetFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-get.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-get.md
@@ -50,28 +50,98 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.dataset.get',
-    		{
-    			id: 2,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DatasetGetResult = {
+      item: {
+        id: number
+        type: string
+        name: string
+        description: string
+        externalCode: string
+        externalName: string
+        dateCreate: string
+        dateUpdate: string
+        createdById: number
+        updatedById: number
+        externalId: number
+        fields: Array<{
+          id: number
+          datasetId: number
+          type: string
+          name: string
+          externalCode: string
+          visible: boolean
+        }>
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DatasetGetResult>({
+        method: 'biconnector.dataset.get',
+        params: {
+          id: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.id, result.item.name, result.item.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDataset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.get',
+            params: {
+              id: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.id, result.item.name, result.item.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDataset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-list.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-list.md
@@ -134,74 +134,108 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each DatasetItem returned in result[]
+    type DatasetItem = {
+      id: string
+      name: string
+      description: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'biconnector.dataset.list',
-        {
-          select: ["id", "name", "description"],
+      // biconnector.dataset.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DatasetItem[]>({
+        method: 'biconnector.dataset.list',
+        params: {
+          select: ['id', 'name', 'description'],
           filter: {
-            '%=name': "Sales%",
-            '!description': "",
-            "@sourceId": [2, 4]
+            '%=name': 'Sales%',
+            '!description': '',
+            '@sourceId': [2, 4],
           },
           order: {
-            dateCreate: "DESC"
-          }
+            dateCreate: 'DESC',
+          },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('biconnector.dataset.list', {
-        select: ["id", "name", "description"],
-        filter: {
-          '%=name': "Sales%",
-          '!description': "",
-          "@sourceId": [2, 4]
-        },
-        order: {
-          dateCreate: "DESC"
-        }
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Datasets page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('biconnector.dataset.list', {
-        select: ["id", "name", "description"],
-        filter: {
-          '%=name': "Sales%",
-          '!description': "",
-          "@sourceId": [2, 4]
-        },
-        order: {
-          dateCreate: "DESC"
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listDatasets() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // biconnector.dataset.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.list',
+            params: {
+              select: ['id', 'name', 'description'],
+              filter: {
+                '%=name': 'Sales%',
+                '!description': '',
+                '@sourceId': [2, 4],
+              },
+              order: {
+                dateCreate: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Datasets page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', listDatasets)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/dataset/biconnector-dataset-update.md
+++ b/api-reference/biconnector/dataset/biconnector-dataset-update.md
@@ -91,31 +91,79 @@
     https://**put_your_bitrix24_address**/rest/biconnector.dataset.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.dataset.update',
-    		{
-    			id: 10,
-    			fields: {
-    				"description": "Новое описание",
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.dataset.update',
+        params: {
+          id: 10,
+          fields: {
+            description: 'New description',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dataset updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDataset() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.dataset.update',
+            params: {
+              id: 10,
+              fields: {
+                description: 'New description',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dataset updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDataset)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/source/biconnector-source-add.md
+++ b/api-reference/biconnector/source/biconnector-source-add.md
@@ -85,34 +85,94 @@
     https://**put_your_bitrix24_address**/rest/biconnector.source.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.source.add',
-    		{
-    			fields: {
-    				"title": "CRM Source",
-    				"description": "Источник данных CRM",
-    				"connectorId": 123,
-    				"settings": {
-    					"login": "admin",
-    					"password": "qwerty"
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error() ? console.error(result.error()) : console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SourceAddResult = {
+      id: number
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SourceAddResult>({
+        method: 'biconnector.source.add',
+        params: {
+          fields: {
+            title: 'CRM Source',
+            description: 'CRM data source',
+            connectorId: 123,
+            settings: {
+              login: 'admin',
+              password: 'qwerty',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created source id:', result.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.source.add',
+            params: {
+              fields: {
+                title: 'CRM Source',
+                description: 'CRM data source',
+                connectorId: 123,
+                settings: {
+                  login: 'admin',
+                  password: 'qwerty',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created source id:', result.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/source/biconnector-source-delete.md
+++ b/api-reference/biconnector/source/biconnector-source-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/biconnector.source.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.source.delete',
-    		{
-    			id: 4,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error() ? console.error(result.error()) : console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.source.delete',
+        params: {
+          id: 4,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Source deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.source.delete',
+            params: {
+              id: 4,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Source deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/source/biconnector-source-fields.md
+++ b/api-reference/biconnector/source/biconnector-source-fields.md
@@ -46,26 +46,83 @@
     https://**put_your_bitrix24_address**/rest/biconnector.source.fields
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.source.fields',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    type FieldDescription = {
+      title: string
+      type: string
+      isRequired: boolean
+      isReadOnly: boolean
+      isImmutable: boolean
+      isMultiple: boolean
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SourceFieldsResult = {
+      fields: FieldDescription[]
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SourceFieldsResult>({
+        method: 'biconnector.source.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Source fields:', result.fields)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSourceFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.source.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Source fields:', result.fields)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSourceFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/source/biconnector-source-get.md
+++ b/api-reference/biconnector/source/biconnector-source-get.md
@@ -52,26 +52,99 @@
     https://**put_your_bitrix24_address**/rest/biconnector.source.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.source.get',
-    		{
-    			id: 6,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error() ? console.error(result.error()) : console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SourceGetResult = {
+      item: {
+        connection: {
+          id: number
+          type: string
+          code: string
+          title: string
+          description: string
+          active: boolean
+          dateCreate: ISODate | null
+          dateUpdate: ISODate | null
+          createdById: number
+          updatedById: number
+        }
+        connectorId: number
+        settings: Array<{
+          code: string
+          name: string
+          type: string
+          value: string
+          id: number
+        }>
+      }
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SourceGetResult>({
+        method: 'biconnector.source.get',
+        params: {
+          id: 6,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.connection.id, result.item.connection.title, result.item.settings)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.source.get',
+            params: {
+              id: 6,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.connection.id, result.item.connection.title, result.item.settings)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSource)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/source/biconnector-source-list.md
+++ b/api-reference/biconnector/source/biconnector-source-list.md
@@ -112,95 +112,109 @@
     https://**put_your_bitrix24_address**/rest/biconnector.source.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    const selectFields = [
-        "id",
-        "title",
-        "active",
-        "dateCreate"
-    ];
-    
-    try {
-        const response = await $b24.callListMethod(
-            'biconnector.source.list',
-            {
-                select: selectFields,
-                filter: {
-                    '%=title': "Sql%",
-                    '!description': "",
-                    "@connectorId": [2, 4]
-                },
-                order: {
-                    dateCreate: "DESC"
-                }
-            },
-            (progress) => { console.log('Progress:', progress) }
-        );
-        const items = response.getData() || [];
-        for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
+    declare const $b24: B24Frame
+
+    // Shape of each SourceItem returned in result[]
+    type SourceItem = {
+      id: string
+      title: string
+      active: boolean
+      dateCreate: ISODate
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    const selectFields = [
-        "id",
-        "title",
-        "active",
-        "dateCreate"
-    ];
-    
+
     try {
-        const generator = $b24.fetchListMethod('biconnector.source.list', {
-            select: selectFields,
-            filter: {
-                '%=title': "Sql%",
-                '!description': "",
-                "@connectorId": [2, 4]
+      // biconnector.source.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SourceItem[]>({
+        method: 'biconnector.source.list',
+        params: {
+          select: ['id', 'title', 'active', 'dateCreate'],
+          filter: {
+            '%=title': 'Sql%',
+            '!description': '',
+            '@connectorId': [2, 4],
+          },
+          order: {
+            dateCreate: 'DESC',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sources fetched:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSourceList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // biconnector.source.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.source.list',
+            params: {
+              select: ['id', 'title', 'active', 'dateCreate'],
+              filter: {
+                '%=title': 'Sql%',
+                '!description': '',
+                '@connectorId': [2, 4],
+              },
+              order: {
+                dateCreate: 'DESC',
+              },
+              start: 0,
             },
-            order: {
-                dateCreate: "DESC"
-            }
-        }, 'ID');
-        for await (const page of generator) {
-            for (const entity of page) { console.log('Entity:', entity); }
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sources fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    const selectFields = [
-        "id",
-        "title",
-        "active",
-        "dateCreate"
-    ];
-    
-    try {
-        const response = await $b24.callMethod('biconnector.source.list', {
-            select: selectFields,
-            filter: {
-                '%=title': "Sql%",
-                '!description': "",
-                "@connectorId": [2, 4]
-            },
-            order: {
-                dateCreate: "DESC"
-            }
-        }, 0);
-        const result = response.getData().result || [];
-        for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-        console.error('Request failed', error);
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSourceList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/biconnector/source/biconnector-source-update.md
+++ b/api-reference/biconnector/source/biconnector-source-update.md
@@ -109,37 +109,91 @@
     https://**put_your_bitrix24_address**/rest/biconnector.source.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'biconnector.source.update',
-    		{
-    			id: 4,
-    			fields: {
-    				"title": "Новое название источника",
-    				"description": "Обновленное описание источника",
-    				"active": false,
-    				"settings": {
-    					"login": "new_admin",
-    					"password": "new_password"
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	result.error()
-    		? console.error(result.error())
-    		: console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'biconnector.source.update',
+        params: {
+          id: 4,
+          fields: {
+            title: 'New source title',
+            description: 'Updated source description',
+            active: false,
+            settings: {
+              login: 'new_admin',
+              password: 'new_password',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Source updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSource() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'biconnector.source.update',
+            params: {
+              id: 4,
+              fields: {
+                title: 'New source title',
+                description: 'Updated source description',
+                active: false,
+                settings: {
+                  login: 'new_admin',
+                  password: 'new_password',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Source updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSource)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.