### PR TITLE
docs(chats): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/chats/_includes/rest-command.md
+++ b/api-reference/chats/_includes/rest-command.md
@@ -1,5 +1,5 @@
 {% note info %}
 
-В примере используется функция `restCommand`. Это метод отправки данных в *Битрикс24*. Другой пример использования метода вы найдете в примере [ЭхоБота](https://dev.1c-bitrix.ru/~b24bots). Вы можете использовать для вызова метода свою функцию, javascript-метод [BX24.callMethod](/sdk/bx24-js-sdk/how-to-call-rest-methods/bx24-call-method.html) или [bitrix24-php-sdk](https://github.com/mesilov/bitrix24-php-sdk).
+В примере используется функция `restCommand`. Это метод отправки данных в *Битрикс24*. Другой пример использования метода вы найдёте в примере [ЭхоБота](https://dev.1c-bitrix.ru/~b24bots). Вы можете использовать для вызова метода свою функцию, javascript-метод [BX24.callMethod](../../../sdk/bx24-js-sdk/how-to-call-rest-methods/bx24-call-method.md) или [bitrix24-php-sdk](https://github.com/mesilov/bitrix24-php-sdk).
 
 {% endnote %}

--- a/api-reference/chats/chat-update/im-chat-set-owner.md
+++ b/api-reference/chats/chat-update/im-chat-set-owner.md
@@ -58,28 +58,75 @@
     https://**put_your_bitrix24_address**/rest/im.chat.setOwner
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.setOwner',
-            {
-                CHAT_ID: 2935,
-                USER_ID: 1271
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Set chat owner:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.setOwner',
+        params: {
+          CHAT_ID: 2935,
+          USER_ID: 1271,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat owner changed successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setChatOwner() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.setOwner',
+            params: {
+              CHAT_ID: 2935,
+              USER_ID: 1271,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat owner changed successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setChatOwner)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-update/im-chat-update-avatar.md
+++ b/api-reference/chats/chat-update/im-chat-update-avatar.md
@@ -58,28 +58,75 @@
     https://**put_your_bitrix24_address**/rest/im.chat.updateAvatar
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.updateAvatar',
-            {
-                CHAT_ID: 2935,
-                AVATAR: '/9j/4QAYRXhpZgAAS...CgCgCgCgP/9k='
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated chat avatar:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.updateAvatar',
+        params: {
+          CHAT_ID: 2935,
+          AVATAR: '/9j/4QAYRXhpZgAAS...CgCgCgCgP/9k=',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Avatar updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateChatAvatar() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.updateAvatar',
+            params: {
+              CHAT_ID: 2935,
+              AVATAR: '/9j/4QAYRXhpZgAAS...CgCgCgCgP/9k=',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Avatar updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateChatAvatar)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-update/im-chat-update-color.md
+++ b/api-reference/chats/chat-update/im-chat-update-color.md
@@ -72,28 +72,75 @@
     https://**put_your_bitrix24_address**/rest/im.chat.updateColor
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.updateColor',
-            {
-                CHAT_ID: 2935,
-                COLOR: 'SAND'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated chat color:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.updateColor',
+        params: {
+          CHAT_ID: 2935,
+          COLOR: 'SAND',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat color updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateChatColor() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.updateColor',
+            params: {
+              CHAT_ID: 2935,
+              COLOR: 'SAND',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat color updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateChatColor)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-update/im-chat-update-title.md
+++ b/api-reference/chats/chat-update/im-chat-update-title.md
@@ -58,28 +58,75 @@
     https://**put_your_bitrix24_address**/rest/im.chat.updateTitle
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.updateTitle',
-            {
-                CHAT_ID: 2935,
-                TITLE: 'Чат по проекту'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated chat title:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.updateTitle',
+        params: {
+          CHAT_ID: 2935,
+          TITLE: 'Project Chat',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat title updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateChatTitle() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.updateTitle',
+            params: {
+              CHAT_ID: 2935,
+              TITLE: 'Project Chat',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat title updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateChatTitle)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-users/im-chat-leave.md
+++ b/api-reference/chats/chat-users/im-chat-leave.md
@@ -54,27 +54,73 @@
     https://**put_your_bitrix24_address**/rest/im.chat.leave
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.leave',
-            {
-                CHAT_ID: 2935
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Left chat:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.leave',
+        params: {
+          CHAT_ID: 2935,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Left chat:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function leaveChat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.leave',
+            params: {
+              CHAT_ID: 2935,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Left chat:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', leaveChat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-users/im-chat-user-add.md
+++ b/api-reference/chats/chat-users/im-chat-user-add.md
@@ -64,29 +64,77 @@
     https://**put_your_bitrix24_address**/rest/im.chat.user.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.user.add',
-            {
-                CHAT_ID: 2935,
-                USERS: [99, 1271],
-                HIDE_HISTORY: 'N'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Added users to chat:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.user.add',
+        params: {
+          CHAT_ID: 2935,
+          USERS: [99, 1271],
+          HIDE_HISTORY: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Users added to chat:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addChatUsers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.user.add',
+            params: {
+              CHAT_ID: 2935,
+              USERS: [99, 1271],
+              HIDE_HISTORY: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Users added to chat:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addChatUsers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-users/im-chat-user-delete.md
+++ b/api-reference/chats/chat-users/im-chat-user-delete.md
@@ -58,28 +58,75 @@
     https://**put_your_bitrix24_address**/rest/im.chat.user.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.user.delete',
-            {
-                CHAT_ID: 2935,
-                USER_ID: 1291
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted user from chat:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.user.delete',
+        params: {
+          CHAT_ID: 2935,
+          USER_ID: 1291,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('User deleted from chat:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteChatUser() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.user.delete',
+            params: {
+              CHAT_ID: 2935,
+              USER_ID: 1291,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('User deleted from chat:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteChatUser)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-users/im-chat-user-list.md
+++ b/api-reference/chats/chat-users/im-chat-user-list.md
@@ -54,27 +54,85 @@
     https://**put_your_bitrix24_address**/rest/im.chat.user.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.user.list',
-            {
-                CHAT_ID: 2935
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Chat user list:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      // im.chat.user.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<number[]>({
+        method: 'im.chat.user.list',
+        params: {
+          CHAT_ID: 2935,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat user IDs:', result, 'Count:', result.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getChatUserList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // im.chat.user.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.user.list',
+            params: {
+              CHAT_ID: 2935,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat user IDs:', result, 'Count:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getChatUserList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/chat-users/im-dialog-users-list.md
+++ b/api-reference/chats/chat-users/im-dialog-users-list.md
@@ -76,27 +76,121 @@
     https://**put_your_bitrix24_address**/rest/im.dialog.users.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.users.list',
-            {
-                DIALOG_ID: 'chat13',
-                SKIP_EXTERNAL: 'Y',
-                LIMIT: 20,
-                start: 0
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of each DialogUser returned in result[]
+    type DialogUser = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string | null
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { work_phone?: string; personal_mobile?: string; personal_phone?: string } | false
+      bot_data: object | null
+      type: string
+      website: string
+      email: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      // im.dialog.users.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DialogUser[]>({
+        method: 'im.dialog.users.list',
+        params: {
+          DIALOG_ID: 'chat13',
+          SKIP_EXTERNAL: 'Y',
+          LIMIT: 20,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(`Retrieved ${result.length} dialog users:`, result.map(u => u.name))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchDialogUsers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // im.dialog.users.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.users.list',
+            params: {
+              DIALOG_ID: 'chat13',
+              SKIP_EXTERNAL: 'Y',
+              LIMIT: 20,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(`Retrieved ${result.length} dialog users:`, result.map(u => u.name))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchDialogUsers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/departments/im-department-colleagues-list.md
+++ b/api-reference/chats/departments/im-department-colleagues-list.md
@@ -58,28 +58,119 @@
       https://**put_your_bitrix24_address**/rest/im.department.colleagues.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.department.colleagues.list',
-            {
-                USER_DATA: 'Y',
-                OFFSET: 0,
-                LIMIT: 5,
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
-        console.log(response.getData().total);
-        console.log(response.getData().next);
+    declare const $b24: B24Frame
+
+    // Shape of each ColleagueUser returned in result[]
+    type ColleagueUser = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { personal_mobile?: string; inner_phone?: string } | false
+      bot_data: object | null
+      type: string
+      website: string
+      email: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      // im.department.colleagues.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ColleagueUser[]>({
+        method: 'im.department.colleagues.list',
+        params: {
+          USER_DATA: 'Y',
+          OFFSET: 0,
+          LIMIT: 5,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Colleagues:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchColleagueList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // im.department.colleagues.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.department.colleagues.list',
+            params: {
+              USER_DATA: 'Y',
+              OFFSET: 0,
+              LIMIT: 5,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Colleagues:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchColleagueList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/departments/im-department-employees-get.md
+++ b/api-reference/chats/departments/im-department-employees-get.md
@@ -60,25 +60,111 @@
       https://**put_your_bitrix24_address**/rest/im.department.employees.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.department.employees.get',
-            {
-                ID: [3, 7],
-                USER_DATA: 'Y'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    type UserData = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { inner_phone?: string; personal_mobile?: string } | false
+      bot_data: object | null
+      type: string
+      website: string
+      email: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DepartmentEmployeesResult = Record<string, UserData[]>
+
+    try {
+      const response = await $b24.actions.v2.call.make<DepartmentEmployeesResult>({
+        method: 'im.department.employees.get',
+        params: {
+          ID: [3, 7],
+          USER_DATA: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Departments with employees:', Object.keys(result))
+        console.info('First department employees:', result[Object.keys(result)[0]])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDepartmentEmployees() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.department.employees.get',
+            params: {
+              ID: [3, 7],
+              USER_DATA: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Departments with employees:', Object.keys(result))
+          console.info('First department employees:', result[Object.keys(result)[0]])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDepartmentEmployees)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/departments/im-department-get.md
+++ b/api-reference/chats/departments/im-department-get.md
@@ -61,25 +61,115 @@
       https://**put_your_bitrix24_address**/rest/im.department.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.department.get',
-            {
-                ID: [3, 7],
-                USER_DATA: 'Y'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    type ManagerUserData = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { personal_mobile?: string; inner_phone?: string } | false
+      bot_data: null
+      type: string
+      website: string
+      email: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    // Shape of each department returned in result[]
+    type DepartmentInfo = {
+      id: number
+      name: string
+      full_name: string
+      manager_user_id: number
+      manager_user_data?: ManagerUserData
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<DepartmentInfo[]>({
+        method: 'im.department.get',
+        params: {
+          ID: [3, 7],
+          USER_DATA: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Departments fetched:', result.length, result.map(d => d.name))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDepartments() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.department.get',
+            params: {
+              ID: [3, 7],
+              USER_DATA: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Departments fetched:', result.length, result.map(d => d.name))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDepartments)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/departments/im-department-managers-get.md
+++ b/api-reference/chats/departments/im-department-managers-get.md
@@ -61,25 +61,113 @@
       https://**put_your_bitrix24_address**/rest/im.department.managers.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.department.managers.get',
-            {
-                ID: [3, 7],
-                USER_DATA: 'Y'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    type ManagerUser = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { personal_mobile: string; inner_phone: string } | false
+      bot_data: Record<string, unknown> | null
+      type: string
+      website: string
+      email: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DepartmentManagersResult = Record<string, ManagerUser[]>
+
+    try {
+      const response = await $b24.actions.v2.call.make<DepartmentManagersResult>({
+        method: 'im.department.managers.get',
+        params: {
+          ID: [3, 7],
+          USER_DATA: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        for (const [deptId, managers] of Object.entries(result)) {
+          console.info(`Department ${deptId}:`, managers.map(m => `${m.name} (id: ${m.id})`))
+        }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDepartmentManagers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.department.managers.get',
+            params: {
+              ID: [3, 7],
+              USER_DATA: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          for (const [deptId, managers] of Object.entries(result)) {
+            console.info(`Department ${deptId}:`, managers.map(m => `${m.name} (id: ${m.id})`))
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDepartmentManagers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/files/im-disk-file-commit.md
+++ b/api-reference/chats/files/im-disk-file-commit.md
@@ -95,26 +95,115 @@
       https://**put_your_bitrix24_address**/rest/im.disk.file.commit
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.disk.file.commit',
-            {
-                CHAT_ID: 1489,
-                FILE_ID: [5249, 5250],
-                MESSAGE: 'Документы по проекту',
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    type FileUploadItem = {
+      id: number
+      chatId: number
+      name: string
+      extension: string
+      size: number
+      status: string
+      authorId: number
+      authorName: string
+      urlPreview: string
+      urlShow: string
+      urlDownload: string
+      isTranscribable: boolean
+      isVideoNote: boolean
+      isVoiceNote: boolean
     }
-    catch (error)
-    {
-        console.error(error);
+
+    type FileModelItem = {
+      id: number
+      name: string
+      storageId: number
+      size: number
+      etag: string
+      links: {
+        download: string
+        showInGrid: string
+        preview: string
+      }
     }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImDiskFileCommitResult = {
+      FILES: Record<string, FileUploadItem>
+      DISK_ID: string[]
+      FILE_MODELS: Record<string, FileModelItem>
+      MESSAGE_ID: number
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImDiskFileCommitResult>({
+        method: 'im.disk.file.commit',
+        params: {
+          CHAT_ID: 1489,
+          FILE_ID: [5249, 5250],
+          MESSAGE: 'Project documents',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.MESSAGE_ID, result.DISK_ID, result.FILES)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function commitFileToChat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.disk.file.commit',
+            params: {
+              CHAT_ID: 1489,
+              FILE_ID: [5249, 5250],
+              MESSAGE: 'Project documents',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.MESSAGE_ID, result.DISK_ID, result.FILES)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', commitFileToChat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/files/im-disk-file-delete.md
+++ b/api-reference/chats/files/im-disk-file-delete.md
@@ -56,25 +56,75 @@
       https://**put_your_bitrix24_address**/rest/im.disk.file.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.disk.file.delete',
-            {
-                CHAT_ID: 1489,
-                FILE_ID: 5163
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.disk.file.delete',
+        params: {
+          CHAT_ID: 1489,
+          FILE_ID: 5163,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.disk.file.delete',
+            params: {
+              CHAT_ID: 1489,
+              FILE_ID: 5163,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/files/im-disk-file-save.md
+++ b/api-reference/chats/files/im-disk-file-save.md
@@ -54,24 +54,85 @@
       https://**put_your_bitrix24_address**/rest/im.disk.file.save
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.disk.file.save',
-            {
-                FILE_ID: 5155
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FileSaveResult = {
+      folder: {
+        id: number
+        name: string
+      }
+      file: {
+        id: number
+        name: string
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FileSaveResult>({
+        method: 'im.disk.file.save',
+        params: {
+          FILE_ID: 5155,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.folder, result.file)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function saveFileToDisk() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.disk.file.save',
+            params: {
+              FILE_ID: 5155,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.folder, result.file)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', saveFileToDisk)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/files/im-disk-folder-get.md
+++ b/api-reference/chats/files/im-disk-folder-get.md
@@ -58,24 +58,78 @@
       https://**put_your_bitrix24_address**/rest/im.disk.folder.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.disk.folder.get',
-            {
-                DIALOG_ID: 'chat1489'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DiskFolderGetResult = {
+      ID: number
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DiskFolderGetResult>({
+        method: 'im.disk.folder.get',
+        params: {
+          DIALOG_ID: 'chat1489',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDiskFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.disk.folder.get',
+            params: {
+              DIALOG_ID: 'chat1489',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDiskFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-chat-add.md
+++ b/api-reference/chats/im-chat-add.md
@@ -136,31 +136,87 @@
       https://**put_your_bitrix24_address**/rest/im.chat.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.add',
-            {
-                USERS: [103, 547],
-                TYPE: 'CHAT',
-                TITLE: 'Чат по сделке',
-                DESCRIPTION: 'Здесь обсуждаем сделку',
-                COLOR: 'PINK',
-                MESSAGE: 'Добро пожаловать в чат сделки',
-                ENTITY_TYPE: 'CRM',
-                ENTITY_ID: 'DEAL|1663'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'im.chat.add',
+        params: {
+          USERS: [103, 547],
+          TYPE: 'CHAT',
+          TITLE: 'Chat about deal',
+          DESCRIPTION: 'Discuss the deal here',
+          COLOR: 'PINK',
+          MESSAGE: 'Welcome to the deal chat',
+          ENTITY_TYPE: 'CRM',
+          ENTITY_ID: 'DEAL|1663',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created chat ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createChat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.add',
+            params: {
+              USERS: [103, 547],
+              TYPE: 'CHAT',
+              TITLE: 'Chat about deal',
+              DESCRIPTION: 'Discuss the deal here',
+              COLOR: 'PINK',
+              MESSAGE: 'Welcome to the deal chat',
+              ENTITY_TYPE: 'CRM',
+              ENTITY_ID: 'DEAL|1663',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created chat ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createChat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-chat-get.md
+++ b/api-reference/chats/im-chat-get.md
@@ -83,25 +83,80 @@
       https://**put_your_bitrix24_address**/rest/im.chat.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.get',
-            {
-                ENTITY_TYPE: 'CRM',
-                ENTITY_ID: 'DEAL|1663'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImChatGetResult = {
+      ID: number
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImChatGetResult>({
+        method: 'im.chat.get',
+        params: {
+          ENTITY_TYPE: 'CRM',
+          ENTITY_ID: 'DEAL|1663',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat ID:', result.ID)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getChatId() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.get',
+            params: {
+              ENTITY_TYPE: 'CRM',
+              ENTITY_ID: 'DEAL|1663',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat ID:', result.ID)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getChatId)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-counters-get.md
+++ b/api-reference/chats/im-counters-get.md
@@ -45,18 +45,97 @@
       https://**put_your_bitrix24_address**/rest/im.counters.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod('im.counters.get', {});
-        console.log(response.getData().result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CountersResult = {
+      TYPE: {
+        ALL: number
+        NOTIFY: number
+        CHAT: number
+        LINES: number
+        DIALOG: number
+        MESSENGER: number
+      }
+      CHAT: Record<string, number>
+      CHAT_MUTED: Record<string, number>
+      CHAT_UNREAD: number[]
+      LINES: Record<string, number>
+      DIALOG: Record<string, number>
+      DIALOG_UNREAD: number[]
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CountersResult>({
+        method: 'im.counters.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          'Total unread:', result.TYPE.ALL,
+          'Notifications:', result.TYPE.NOTIFY,
+          'Chats:', result.TYPE.CHAT,
+          'Dialogs:', result.TYPE.DIALOG
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getCounters() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.counters.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            'Total unread:', result.TYPE.ALL,
+            'Notifications:', result.TYPE.NOTIFY,
+            'Chats:', result.TYPE.CHAT,
+            'Dialogs:', result.TYPE.DIALOG
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getCounters)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-dialog-get.md
+++ b/api-reference/chats/im-dialog-get.md
@@ -57,24 +57,147 @@
       https://**put_your_bitrix24_address**/rest/im.dialog.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.get',
-            {
-                DIALOG_ID: 'chat1435'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImDialogGetResult = {
+      id: number
+      parent_chat_id: number
+      parent_message_id: number
+      name: string
+      description: string
+      owner: number
+      extranet: boolean
+      avatar: string
+      color: string
+      type: string
+      counter: number
+      user_counter: number
+      message_count: number
+      unread_id: number
+      restrictions: {
+        avatar: boolean
+        rename: boolean
+        extend: boolean
+        call: boolean
+        mute: boolean
+        leave: boolean
+        leave_owner: boolean
+        send: boolean
+        user_list: boolean
+        path: string
+        path_title: string
+      }
+      last_message_id: number
+      last_id: number
+      marked_id: number
+      disk_folder_id: number
+      entity_type: string
+      entity_id: string
+      entity_data_1: string
+      entity_data_2: string
+      entity_data_3: string
+      mute_list: number[]
+      date_create: ISODate
+      message_type: string
+      public: string
+      role: string
+      entity_link: {
+        type: string
+        url: string
+        id: string
+      }
+      text_field_enabled: boolean
+      background_id: number | null
+      permissions: {
+        manage_users_add: string
+        manage_users_delete: string
+        manage_ui: string
+        manage_settings: string
+        manage_messages: string
+        can_post: string
+      }
+      is_new: boolean
+      readed_list: {
+        user_id: number
+        user_name: string
+        message_id: number
+        date: ISODate | null
+      }[]
+      manager_list: number[]
+      last_message_views: {
+        message_id: number
+        first_viewers: number[]
+        count_of_viewers: number
+      }
+      dialog_id: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImDialogGetResult>({
+        method: 'im.dialog.get',
+        params: {
+          DIALOG_ID: 'chat1435',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog:', result.id, result.name, result.type, result.role)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.get',
+            params: {
+              DIALOG_ID: 'chat1435',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog:', result.id, result.name, result.type, result.role)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-recent-get.md
+++ b/api-reference/chats/im-recent-get.md
@@ -78,25 +78,108 @@
       https://**put_your_bitrix24_address**/rest/im.recent.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.recent.get',
-            {
-                SKIP_OPENLINES: 'Y',
-                LAST_UPDATE: '2026-02-25T18:30:00+01:00'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type ImRecentItem = {
+      id: string
+      chat_id: number
+      type: string
+      title: string
+      counter: number
+      last_id: number
+      pinned: boolean
+      unread: boolean
+      has_reminder: boolean
+      date_update: ISODate
+      date_last_activity: ISODate
+      avatar: {
+        url: string
+        color: string
+      }
+      message: {
+        id: number
+        text: string
+        file: boolean
+        author_id: number
+        attach: boolean
+        sticker: number | null
+        date: ISODate
+        status: string
+        uuid: string | null
+      }
+      chat: Record<string, unknown>
+      user: { id: number }
+      options: unknown[]
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImRecentItem[]>({
+        method: 'im.recent.get',
+        params: {
+          SKIP_OPENLINES: 'Y',
+          LAST_UPDATE: '2026-02-25T18:30:00+01:00',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recent chats count:', result.length, 'First chat title:', result[0]?.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRecentChats() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.recent.get',
+            params: {
+              SKIP_OPENLINES: 'Y',
+              LAST_UPDATE: '2026-02-25T18:30:00+01:00',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recent chats count:', result.length, 'First chat title:', result[0]?.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRecentChats)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-recent-list.md
+++ b/api-reference/chats/im-recent-list.md
@@ -124,36 +124,117 @@
       https://**put_your_bitrix24_address**/rest/im.recent.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.recent.list',
-            {
-                LAST_MESSAGE_DATE: '2026-02-25T18:30:00+03:00',
-                SKIP_OPENLINES: 'N',
-                SKIP_DIALOG: 'N',
-                SKIP_CHAT: 'N',
-                UNREAD_ONLY: 'Y',
-                PARSE_TEXT: 'Y',
-                GET_ORIGINAL_TEXT: 'N',
-                SKIP_UNDISTRIBUTED_OPENLINES: 'Y',
-                ONLY_COPILOT: 'N',
-                ONLY_CHANNEL: 'N',
-                CAN_MANAGE_MESSAGES: 'Y',
-                OFFSET: 0,
-                LIMIT: 20
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RecentListResult = {
+      items: Array<{
+        id: string | number
+        chat_id: number
+        type: string
+        title: string
+        counter: number
+        pinned: boolean
+        unread: boolean
+        has_reminder: boolean
+        date_update: ISODate
+        date_last_activity: ISODate
+      }>
+      hasMorePages: boolean
+      hasMore: boolean
+      copilot: object | null
+      messagesAutoDeleteConfigs: object[]
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RecentListResult>({
+        method: 'im.recent.list',
+        params: {
+          LAST_MESSAGE_DATE: '2026-02-25T18:30:00+03:00',
+          SKIP_OPENLINES: 'N',
+          SKIP_DIALOG: 'N',
+          SKIP_CHAT: 'N',
+          UNREAD_ONLY: 'Y',
+          PARSE_TEXT: 'Y',
+          GET_ORIGINAL_TEXT: 'N',
+          SKIP_UNDISTRIBUTED_OPENLINES: 'Y',
+          ONLY_COPILOT: 'N',
+          ONLY_CHANNEL: 'N',
+          CAN_MANAGE_MESSAGES: 'Y',
+          OFFSET: 0,
+          LIMIT: 20,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Loaded dialogs:', result.items.length, 'hasMore:', result.hasMore)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchRecentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.recent.list',
+            params: {
+              LAST_MESSAGE_DATE: '2026-02-25T18:30:00+03:00',
+              SKIP_OPENLINES: 'N',
+              SKIP_DIALOG: 'N',
+              SKIP_CHAT: 'N',
+              UNREAD_ONLY: 'Y',
+              PARSE_TEXT: 'Y',
+              GET_ORIGINAL_TEXT: 'N',
+              SKIP_UNDISTRIBUTED_OPENLINES: 'Y',
+              ONLY_COPILOT: 'N',
+              ONLY_CHANNEL: 'N',
+              CAN_MANAGE_MESSAGES: 'Y',
+              OFFSET: 0,
+              LIMIT: 20,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Loaded dialogs:', result.items.length, 'hasMore:', result.hasMore)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchRecentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/im-revision-get.md
+++ b/api-reference/chats/im-revision-get.md
@@ -47,20 +47,78 @@
       https://**put_your_bitrix24_address**/rest/im.revision.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod('im.revision.get', {});
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('IM revisions:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImRevisionGetResult = {
+      rest: number
+      web: number
+      mobile: number
+      desktop: number
+      im_revision_mobile: number
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImRevisionGetResult>({
+        method: 'im.revision.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('IM revisions:', result.rest, result.web, result.mobile)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getImRevisions() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.revision.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('IM revisions:', result.rest, result.web, result.mobile)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getImRevisions)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/attachments.md
+++ b/api-reference/chats/messages/attachments.md
@@ -44,32 +44,92 @@
     https://**put_your_bitrix24_address**/rest/im.message.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try {
-      const response = await $b24.callMethod(
-          'im.message.add',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'im.message.add',
+        params: {
+          DIALOG_ID: 'chat2725',
+          MESSAGE: 'Card',
+          ATTACH: {
+            ID: 1,
+            COLOR_TOKEN: 'primary',
+            BLOCKS: [
+              { MESSAGE: '[B]New request[/B]' },
+              { LINK: { NAME: 'Open', LINK: 'https://example.com' } },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created message ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendMessageWithAttach() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.add',
+            params: {
               DIALOG_ID: 'chat2725',
-              MESSAGE: 'Карточка',
+              MESSAGE: 'Card',
               ATTACH: {
-                  ID: 1,
-                  COLOR_TOKEN: 'primary',
-                  BLOCKS: [
-                      { MESSAGE: '[B]Новая заявка[/B]' },
-                      { LINK: { NAME: 'Открыть', LINK: 'https://example.com' } },
-                  ],
+                ID: 1,
+                COLOR_TOKEN: 'primary',
+                BLOCKS: [
+                  { MESSAGE: '[B]New request[/B]' },
+                  { LINK: { NAME: 'Open', LINK: 'https://example.com' } },
+                ],
               },
-          }
-      );
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log('Created message ID:', result);
-  } catch (error) {
-      console.error('Error:', error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created message ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendMessageWithAttach)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/chats/messages/formatting.md
+++ b/api-reference/chats/messages/formatting.md
@@ -46,24 +46,76 @@ BB-коды позволяют форматировать текст сообщ�
     https://**put_your_bitrix24_address**/rest/im.message.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try {
-      const response = await $b24.callMethod(
-          'im.message.add',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'im.message.add',
+        params: {
+          DIALOG_ID: 'chat2725',
+          MESSAGE: '[B]Important[/B][BR]Open [URL=https://bitrix24.ru]site[/URL][BR][SEND=/help]Help[/SEND]',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created message ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.add',
+            params: {
               DIALOG_ID: 'chat2725',
-              MESSAGE: '[B]Важное[/B][BR]Откройте [URL=https://bitrix24.ru]сайт[/URL][BR][SEND=/help]Помощь[/SEND]',
-          }
-      );
+              MESSAGE: '[B]Important[/B][BR]Open [URL=https://bitrix24.ru]site[/URL][BR][SEND=/help]Help[/SEND]',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log('Created message ID:', result);
-  } catch (error) {
-      console.error('Error:', error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created message ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addMessage)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/chats/messages/im-dialog-messages-get.md
+++ b/api-reference/chats/messages/im-dialog-messages-get.md
@@ -74,26 +74,119 @@
       https://**put_your_bitrix24_address**/rest/im.dialog.messages.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.messages.get',
-            {
-                DIALOG_ID: 'chat1489',
-                FIRST_ID: 84869,
-                LIMIT: 10
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DialogMessagesGetResult = {
+      chat_id: number
+      messages: {
+        id: number
+        chat_id: number
+        author_id: number
+        date: ISODate
+        text: string
+        unread: boolean
+        uuid: string | null
+        replaces: unknown[]
+        params: Record<string, unknown>
+        disappearing_date: ISODate | null
+      }[]
+      users: {
+        id: number
+        active: boolean
+        name: string
+        first_name: string
+        last_name: string
+        status: string
+        last_activity_date: ISODate
+        type: string
+      }[]
+      files: {
+        id: number
+        chatId: number
+        date: ISODate
+        type: string
+        name: string
+        size: number
+        status: string
+        authorId: number
+        authorName: string
+        urlDownload: string
+        isTranscribable: boolean
+        isVideoNote: boolean
+        isVoiceNote: boolean
+      }[]
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DialogMessagesGetResult>({
+        method: 'im.dialog.messages.get',
+        params: {
+          DIALOG_ID: 'chat1489',
+          FIRST_ID: 84869,
+          LIMIT: 10,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.chat_id, result.messages.length, result.messages)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDialogMessages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.messages.get',
+            params: {
+              DIALOG_ID: 'chat1489',
+              FIRST_ID: 84869,
+              LIMIT: 10,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.chat_id, result.messages.length, result.messages)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDialogMessages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-dialog-messages-search.md
+++ b/api-reference/chats/messages/im-dialog-messages-search.md
@@ -78,28 +78,105 @@
     https://**put_your_bitrix24_address**/rest/im.dialog.messages.search
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.messages.search',
-            {
-                CHAT_ID: 3,
-                SEARCH_MESSAGE: 'test',
-                ORDER: { ID: 'DESC' },
-                LIMIT: 20
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Search result:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DialogMessagesSearchResult = {
+      messages: Array<{
+        id: number
+        chat_id: number
+        author_id: number
+        date: ISODate
+        text: string
+        isSystem: boolean
+        uuid: string | null
+        forward: object | null
+        params: unknown[]
+        viewedByOthers: boolean
+        unread: boolean
+        viewed: boolean
+      }>
+      users: unknown[]
+      files: unknown[]
+      additionalMessages: unknown[]
+      copilot: object | null
+      stickers: unknown[]
+      reactions: unknown[]
+      tariffRestrictions: { isHistoryLimitExceeded: boolean }
+      usersShort: unknown[]
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DialogMessagesSearchResult>({
+        method: 'im.dialog.messages.search',
+        params: {
+          CHAT_ID: 3,
+          SEARCH_MESSAGE: 'test',
+          ORDER: { ID: 'DESC' },
+          LIMIT: 20,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Found messages:', result.messages.length, result.messages)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchDialogMessages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.messages.search',
+            params: {
+              CHAT_ID: 3,
+              SEARCH_MESSAGE: 'test',
+              ORDER: { ID: 'DESC' },
+              LIMIT: 20,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Found messages:', result.messages.length, result.messages)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchDialogMessages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-dialog-read.md
+++ b/api-reference/chats/messages/im-dialog-read.md
@@ -60,25 +60,83 @@
       https://**put_your_bitrix24_address**/rest/im.dialog.read
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.read',
-            {
-                DIALOG_ID: 'chat1489',
-                MESSAGE_ID: 84875
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImDialogReadResult = {
+      dialogId: string,
+      chatId: number,
+      lastId: number,
+      counter: number,
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImDialogReadResult>({
+        method: 'im.dialog.read',
+        params: {
+          DIALOG_ID: 'chat1489',
+          MESSAGE_ID: 84875,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.dialogId, result.chatId, result.lastId, result.counter)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markDialogAsRead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.read',
+            params: {
+              DIALOG_ID: 'chat1489',
+              MESSAGE_ID: 84875,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.dialogId, result.chatId, result.lastId, result.counter)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markDialogAsRead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-dialog-unread.md
+++ b/api-reference/chats/messages/im-dialog-unread.md
@@ -60,25 +60,75 @@
       https://**put_your_bitrix24_address**/rest/im.dialog.unread
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.unread',
-            {
-                DIALOG_ID: 'chat1489',
-                MESSAGE_ID: 84869
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.dialog.unread',
+        params: {
+          DIALOG_ID: 'chat1489',
+          MESSAGE_ID: 84869,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unread flag set:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setDialogUnread() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.unread',
+            params: {
+              DIALOG_ID: 'chat1489',
+              MESSAGE_ID: 84869,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unread flag set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setDialogUnread)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-dialog-writing.md
+++ b/api-reference/chats/messages/im-dialog-writing.md
@@ -58,27 +58,73 @@
     https://**put_your_bitrix24_address**/rest/im.dialog.writing
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.writing',
-            {
-                DIALOG_ID: 'chat2935'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Writing status indicated:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.dialog.writing',
+        params: {
+          DIALOG_ID: 'chat2935',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Writing indicator sent:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function indicateWriting() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.writing',
+            params: {
+              DIALOG_ID: 'chat2935',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Writing indicator sent:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', indicateWriting)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-message-add.md
+++ b/api-reference/chats/messages/im-message-add.md
@@ -98,30 +98,81 @@
     https://**put_your_bitrix24_address**/rest/im.message.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.message.add',
-            {
-                DIALOG_ID: 'chat2941',
-                MESSAGE: 'Текст сообщения',
-                SYSTEM: 'N',
-                URL_PREVIEW: 'Y',
-                REPLY_ID: 34237
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created message with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'im.message.add',
+        params: {
+          DIALOG_ID: 'chat2941',
+          MESSAGE: 'Message text',
+          SYSTEM: 'N',
+          URL_PREVIEW: 'Y',
+          REPLY_ID: 34237,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created message with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.add',
+            params: {
+              DIALOG_ID: 'chat2941',
+              MESSAGE: 'Message text',
+              SYSTEM: 'N',
+              URL_PREVIEW: 'Y',
+              REPLY_ID: 34237,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created message with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-message-command.md
+++ b/api-reference/chats/messages/im-message-command.md
@@ -64,29 +64,79 @@
     https://**put_your_bitrix24_address**/rest/im.message.command
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.message.command',
-            {
-                MESSAGE_ID: 34261,
-                BOT_ID: 1291,
-                COMMAND: 'task',
-                COMMAND_PARAMS: 'task №1'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Executed command with result:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.message.command',
+        params: {
+          MESSAGE_ID: 34261,
+          BOT_ID: 1291,
+          COMMAND: 'task',
+          COMMAND_PARAMS: 'task №1',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Command executed successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function executeMessageCommand() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.command',
+            params: {
+              MESSAGE_ID: 34261,
+              BOT_ID: 1291,
+              COMMAND: 'task',
+              COMMAND_PARAMS: 'task №1',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Command executed successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', executeMessageCommand)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-message-delete.md
+++ b/api-reference/chats/messages/im-message-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/im.message.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.message.delete',
-            {
-                MESSAGE_ID: 34247
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.message.delete',
+        params: {
+          MESSAGE_ID: 34247,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Message deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.delete',
+            params: {
+              MESSAGE_ID: 34247,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Message deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-message-like.md
+++ b/api-reference/chats/messages/im-message-like.md
@@ -63,27 +63,75 @@
     https://**put_your_bitrix24_address**/rest/im.message.like
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.message.like',
-            {
-                MESSAGE_ID: 34247,
-                ACTION: 'plus'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Liked message with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.message.like',
+        params: {
+          MESSAGE_ID: 34247,
+          ACTION: 'plus',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Like action result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function likeMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.like',
+            params: {
+              MESSAGE_ID: 34247,
+              ACTION: 'plus',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Like action result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', likeMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-message-share.md
+++ b/api-reference/chats/messages/im-message-share.md
@@ -70,28 +70,77 @@
     https://**put_your_bitrix24_address**/rest/im.message.share
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.message.share',
-            {
-                MESSAGE_ID: 34261,
-                DIALOG_ID: 'chat2941',
-                TYPE: 'TASK'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.message.share',
+        params: {
+          MESSAGE_ID: 34261,
+          DIALOG_ID: 'chat2941',
+          TYPE: 'TASK',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Object created:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function shareMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.share',
+            params: {
+              MESSAGE_ID: 34261,
+              DIALOG_ID: 'chat2941',
+              TYPE: 'TASK',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Object created:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', shareMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/im-message-update.md
+++ b/api-reference/chats/messages/im-message-update.md
@@ -91,28 +91,77 @@
     https://**put_your_bitrix24_address**/rest/im.message.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.message.update',
-            {
-                MESSAGE_ID: 34239,
-                MESSAGE: 'Обновленный текст',
-                KEYBOARD: 'N'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.message.update',
+        params: {
+          MESSAGE_ID: 34239,
+          MESSAGE: 'Updated text',
+          KEYBOARD: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Message updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.update',
+            params: {
+              MESSAGE_ID: 34239,
+              MESSAGE: 'Updated text',
+              KEYBOARD: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Message updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/messages/keyboards.md
+++ b/api-reference/chats/messages/keyboards.md
@@ -45,31 +45,90 @@
     https://**put_your_bitrix24_address**/rest/im.message.add
   ```
 
-- JS
+- JS (TS)
 
-  ```js
-  try {
-      const response = await $b24.callMethod(
-          'im.message.add',
-          {
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'im.message.add',
+        params: {
+          DIALOG_ID: 'chat2725',
+          MESSAGE: 'Choose an action',
+          KEYBOARD: {
+            BUTTONS: [
+              { TEXT: 'Open site', LINK: 'https://www.example.ru/' },
+              { TYPE: 'NEWLINE' },
+              { TEXT: 'Insert command', ACTION: 'PUT', ACTION_VALUE: '/help' },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created message ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendMessageWithKeyboard() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.add',
+            params: {
               DIALOG_ID: 'chat2725',
-              MESSAGE: 'Выберите действие',
+              MESSAGE: 'Choose an action',
               KEYBOARD: {
-                  BUTTONS: [
-                      { TEXT: 'Открыть сайт', LINK: 'https://www.example.ru/' },
-                      { TYPE: 'NEWLINE' },
-                      { TEXT: 'Подставить команду', ACTION: 'PUT', ACTION_VALUE: '/help' },
-                  ],
+                BUTTONS: [
+                  { TEXT: 'Open site', LINK: 'https://www.example.ru/' },
+                  { TYPE: 'NEWLINE' },
+                  { TEXT: 'Insert command', ACTION: 'PUT', ACTION_VALUE: '/help' },
+                ],
               },
-          }
-      );
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log('Created message ID:', result);
-  } catch (error) {
-      console.error('Error:', error);
-  }
-  ```
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created message ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendMessageWithKeyboard)
+    </script>
+    ```
 
 - PHP
 

--- a/api-reference/chats/messages/menu.md
+++ b/api-reference/chats/messages/menu.md
@@ -154,38 +154,103 @@
     https://**put_your_bitrix24_address**/rest/im.message.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'im.message.add',
-            {
-                DIALOG_ID: 'chat2725',
-                MESSAGE: 'Выберите действие в меню',
-                URL_PREVIEW: 'Y',
-                MENU: {
-                    ITEMS: [
-                        {
-                            TEXT: 'Открыть сайт',
-                            LINK: 'https://www.example.ru/'
-                        },
-                        {
-                            TEXT: 'Отправить текст',
-                            ACTION: 'SEND',
-                            ACTION_VALUE: 'Готово'
-                        }
-                    ]
-                }
-            }
-        );
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'im.message.add',
+        params: {
+          DIALOG_ID: 'chat2725',
+          MESSAGE: 'Select an action from the menu',
+          URL_PREVIEW: 'Y',
+          MENU: {
+            ITEMS: [
+              {
+                TEXT: 'Open website',
+                LINK: 'https://www.example.ru/',
+              },
+              {
+                TEXT: 'Send text',
+                ACTION: 'SEND',
+                ACTION_VALUE: 'Done',
+              },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const result = response.getData().result;
-        console.log('Created message with ID:', result);
-        processResult(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created message with ID:', result)
+      }
     } catch (error) {
-        console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addMessageWithMenu() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.message.add',
+            params: {
+              DIALOG_ID: 'chat2725',
+              MESSAGE: 'Select an action from the menu',
+              URL_PREVIEW: 'Y',
+              MENU: {
+                ITEMS: [
+                  {
+                    TEXT: 'Open website',
+                    LINK: 'https://www.example.ru/',
+                  },
+                  {
+                    TEXT: 'Send text',
+                    ACTION: 'SEND',
+                    ACTION_VALUE: 'Done',
+                  },
+                ],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created message with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addMessageWithMenu)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-answer.md
+++ b/api-reference/chats/notifications/im-notify-answer.md
@@ -56,20 +56,80 @@
       https://**put_your_bitrix24_address**/rest/im.notify.answer
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.notify.answer', {
-        NOTIFY_ID: 270,
-        ANSWER_TEXT: 'Приму участие',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NotifyAnswerResult = {
+      result_message: string[] | boolean
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<NotifyAnswerResult>({
+        method: 'im.notify.answer',
+        params: {
+          NOTIFY_ID: 270,
+          ANSWER_TEXT: 'I will participate',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.result_message)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function notifyAnswer() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.answer',
+            params: {
+              NOTIFY_ID: 270,
+              ANSWER_TEXT: 'I will participate',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.result_message)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', notifyAnswer)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-confirm.md
+++ b/api-reference/chats/notifications/im-notify-confirm.md
@@ -62,20 +62,80 @@
       https://**put_your_bitrix24_address**/rest/im.notify.confirm
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.notify.confirm', {
-        NOTIFY_ID: 288,
-        NOTIFY_VALUE: 'Y',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NotifyConfirmResult = {
+      result_message: string[] | false
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<NotifyConfirmResult>({
+        method: 'im.notify.confirm',
+        params: {
+          NOTIFY_ID: 288,
+          NOTIFY_VALUE: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.result_message)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function confirmNotification() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.confirm',
+            params: {
+              NOTIFY_ID: 288,
+              NOTIFY_VALUE: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.result_message)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', confirmNotification)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-delete.md
+++ b/api-reference/chats/notifications/im-notify-delete.md
@@ -64,19 +64,73 @@
       https://**put_your_bitrix24_address**/rest/im.notify.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.notify.delete', {
-        ID: 101,
-      });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.notify.delete',
+        params: {
+          ID: 101,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notification deleted:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteNotification() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.delete',
+            params: {
+              ID: 101,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notification deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteNotification)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-get.md
+++ b/api-reference/chats/notifications/im-notify-get.md
@@ -79,22 +79,139 @@
       https://**put_your_bitrix24_address**/rest/im.notify.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.notify.get', {
-        LAST_ID: 1500,
-        LAST_TYPE: 3,
-        LIMIT: 20,
-        CONVERT_TEXT: 'Y',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    type NotificationItem = {
+      id: number
+      chat_id: number
+      author_id: number
+      date: ISODate
+      notify_type: number
+      notify_module: string
+      notify_event: string
+      notify_tag: string
+      notify_sub_tag: string
+      notify_title: string
+      setting_name: string
+      text: string
+      notify_read: string
+      notify_buttons?: string
+      params: object | null
     }
+
+    type UserItem = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: Record<string, string> | false
+      bot_data: object | null
+      type: string
+      website: string
+      email: string
+    }
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImNotifyGetResult = {
+      total_count: number
+      total_unread_count: number
+      chat_id: number
+      notifications: NotificationItem[]
+      users: UserItem[]
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImNotifyGetResult>({
+        method: 'im.notify.get',
+        params: {
+          LAST_ID: 1500,
+          LAST_TYPE: 3,
+          LIMIT: 20,
+          CONVERT_TEXT: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Total notifications:', result.total_count, 'Unread:', result.total_unread_count)
+        console.info('Notifications on page:', result.notifications.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNotifications() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.get',
+            params: {
+              LAST_ID: 1500,
+              LAST_TYPE: 3,
+              LIMIT: 20,
+              CONVERT_TEXT: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Total notifications:', result.total_count, 'Unread:', result.total_unread_count)
+          console.info('Notifications on page:', result.notifications.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNotifications)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-history-search.md
+++ b/api-reference/chats/notifications/im-notify-history-search.md
@@ -74,25 +74,145 @@
       https://**put_your_bitrix24_address**/rest/im.notify.history.search
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.notify.history.search', {
-        SEARCH_TEXT: 'счет',
-        SEARCH_TYPE: 'tasks|task_update',
-        SEARCH_DATE: '2026-03-03T16:52:29+03:00',
-        LAST_ID: 1500,
-        LIMIT: 20,
-        CONVERT_TEXT: 'Y',
-        GROUP_TAG: 'TASK|42',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NotifyHistorySearchResult = {
+      chat_id: number
+      total_results: number
+      notifications: Array<{
+        id: number
+        chat_id: number
+        author_id: number
+        date: ISODate | null
+        notify_type: number
+        notify_module: string
+        notify_event: string
+        notify_tag: string
+        notify_sub_tag: string
+        notify_title: string
+        setting_name: string
+        text: string
+        notify_read: string
+        params: object | null
+      }>
+      users: Array<{
+        id: number
+        active: boolean
+        name: string
+        first_name: string
+        last_name: string
+        work_position: string
+        color: string
+        avatar: string
+        avatar_hr: string
+        gender: string
+        birthday: string
+        extranet: boolean
+        network: boolean
+        bot: boolean
+        connector: boolean
+        external_auth_id: string
+        status: string
+        idle: ISODate | false
+        last_activity_date: ISODate | null
+        mobile_last_date: ISODate | false
+        desktop_last_date: ISODate | false
+        absent: ISODate | false
+        departments: number[]
+        phones: { work_phone?: string; inner_phone?: string } | false
+        bot_data: object | null
+        type: string
+        website: string
+        email: string
+      }>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<NotifyHistorySearchResult>({
+        method: 'im.notify.history.search',
+        params: {
+          SEARCH_TEXT: 'invoice',
+          SEARCH_TYPE: 'tasks|task_update',
+          SEARCH_DATE: '2026-03-03T16:52:29+03:00',
+          LAST_ID: 1500,
+          LIMIT: 20,
+          CONVERT_TEXT: 'Y',
+          GROUP_TAG: 'TASK|42',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          result.chat_id,
+          result.total_results,
+          result.notifications.length,
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchNotifyHistory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.history.search',
+            params: {
+              SEARCH_TEXT: 'invoice',
+              SEARCH_TYPE: 'tasks|task_update',
+              SEARCH_DATE: '2026-03-03T16:52:29+03:00',
+              LAST_ID: 1500,
+              LIMIT: 20,
+              CONVERT_TEXT: 'Y',
+              GROUP_TAG: 'TASK|42',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            result.chat_id,
+            result.total_results,
+            result.notifications.length,
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchNotifyHistory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-personal-add.md
+++ b/api-reference/chats/notifications/im-notify-personal-add.md
@@ -71,23 +71,81 @@
       https://**put_your_bitrix24_address**/rest/im.notify.personal.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.notify.personal.add', {
-        USER_ID: 5,
-        MESSAGE: 'Напоминание по задаче',
-        MESSAGE_OUT: 'Напоминание по задаче (email)',
-        TAG: 'TASK_REMINDER_42',
-        SUB_TAG: 'TASK_REMINDER|42',
-      });
+      const response = await $b24.actions.v2.call.make<number | false>({
+        method: 'im.notify.personal.add',
+        params: {
+          USER_ID: 5,
+          MESSAGE: 'Task reminder',
+          MESSAGE_OUT: 'Task reminder (email)',
+          TAG: 'TASK_REMINDER_42',
+          SUB_TAG: 'TASK_REMINDER|42',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Notification ID:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notification ID:', result)
+      }
     } catch (error) {
-      console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendPersonalNotification() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.personal.add',
+            params: {
+              USER_ID: 5,
+              MESSAGE: 'Task reminder',
+              MESSAGE_OUT: 'Task reminder (email)',
+              TAG: 'TASK_REMINDER_42',
+              SUB_TAG: 'TASK_REMINDER|42',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notification ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendPersonalNotification)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-read-all.md
+++ b/api-reference/chats/notifications/im-notify-read-all.md
@@ -44,16 +44,75 @@
       https://**put_your_bitrix24_address**/rest/im.notify.read.all
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.notify.read.all', {});
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NotifyReadAllResult = {
+      result: boolean
+      newCounter: number
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<NotifyReadAllResult>({
+        method: 'im.notify.read.all',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Success:', result.result, 'New unread counter:', result.newCounter)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function readAllNotifications() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.read.all',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Success:', result.result, 'New unread counter:', result.newCounter)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', readAllNotifications)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-read-list.md
+++ b/api-reference/chats/notifications/im-notify-read-list.md
@@ -60,19 +60,75 @@
       https://**put_your_bitrix24_address**/rest/im.notify.read.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.notify.read.list', {
-        IDS: [101, 102, 103],
-        ACTION: 'Y',
-      });
-      const { result } = response.getData();
-      console.log('Result:', result);
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.notify.read.list',
+        params: {
+          IDS: [101, 102, 103],
+          ACTION: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notifications marked as read:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function readNotificationList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.read.list',
+            params: {
+              IDS: [101, 102, 103],
+              ACTION: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notifications marked as read:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', readNotificationList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-read.md
+++ b/api-reference/chats/notifications/im-notify-read.md
@@ -60,21 +60,77 @@
       https://**put_your_bitrix24_address**/rest/im.notify.read
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.notify.read', {
-        ID: 101,
-        ACTION: 'Y',
-        ONLY_CURRENT: 'Y',
-      });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.notify.read',
+        params: {
+          ID: 101,
+          ACTION: 'Y',
+          ONLY_CURRENT: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notification marked as read:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markNotificationRead() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.read',
+            params: {
+              ID: 101,
+              ACTION: 'Y',
+              ONLY_CURRENT: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notification marked as read:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markNotificationRead)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-schema-get.md
+++ b/api-reference/chats/notifications/im-notify-schema-get.md
@@ -44,16 +44,81 @@
       https://**put_your_bitrix24_address**/rest/im.notify.schema.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.notify.schema.get', {});
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NotificationSchemaResult = Record<string, ModuleSchema>
+
+    type ModuleSchema = {
+      name: string
+      module_id: string
+      list: Array<{
+        id: string
+        name: string
+      }>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<NotificationSchemaResult>({
+        method: 'im.notify.schema.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result), result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNotificationSchema() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.schema.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result), result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNotificationSchema)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify-system-add.md
+++ b/api-reference/chats/notifications/im-notify-system-add.md
@@ -71,23 +71,81 @@
       https://**put_your_bitrix24_address**/rest/im.notify.system.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.notify.system.add', {
-        USER_ID: 5,
-        MESSAGE: 'Системное уведомление',
-        MESSAGE_OUT: 'Системное уведомление для email',
-        TAG: 'SYSTEM_EVENT_42',
-        SUB_TAG: 'SYSTEM_EVENT|42',
-      });
+      const response = await $b24.actions.v2.call.make<number | false>({
+        method: 'im.notify.system.add',
+        params: {
+          USER_ID: 5,
+          MESSAGE: 'System notification',
+          MESSAGE_OUT: 'System notification for email',
+          TAG: 'SYSTEM_EVENT_42',
+          SUB_TAG: 'SYSTEM_EVENT|42',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Notification ID:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notification ID:', result)
+      }
     } catch (error) {
-      console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendSystemNotification() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify.system.add',
+            params: {
+              USER_ID: 5,
+              MESSAGE: 'System notification',
+              MESSAGE_OUT: 'System notification for email',
+              TAG: 'SYSTEM_EVENT_42',
+              SUB_TAG: 'SYSTEM_EVENT|42',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notification ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendSystemNotification)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/notifications/im-notify.md
+++ b/api-reference/chats/notifications/im-notify.md
@@ -79,24 +79,83 @@
       https://**put_your_bitrix24_address**/rest/im.notify
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.notify', {
-        USER_ID: 5,
-        TYPE: 'USER',
-        MESSAGE: 'Напоминание',
-        MESSAGE_OUT: 'Напоминание (email)',
-        TAG: 'TASK_42',
-        SUB_TAG: 'TASK|42',
-      });
+      const response = await $b24.actions.v2.call.make<number | false>({
+        method: 'im.notify',
+        params: {
+          USER_ID: 5,
+          TYPE: 'USER',
+          MESSAGE: 'Reminder',
+          MESSAGE_OUT: 'Reminder (email)',
+          TAG: 'TASK_42',
+          SUB_TAG: 'TASK|42',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Notification ID:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notification ID:', result)
+      }
     } catch (error) {
-      console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendNotification() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.notify',
+            params: {
+              USER_ID: 5,
+              TYPE: 'USER',
+              MESSAGE: 'Reminder',
+              MESSAGE_OUT: 'Reminder (email)',
+              TAG: 'TASK_42',
+              SUB_TAG: 'TASK|42',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notification ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendNotification)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/outdated/iframe.md
+++ b/api-reference/chats/outdated/iframe.md
@@ -183,3 +183,5 @@ if (strpos($_SERVER['HTTP_REFERER'], $_GET['DOMAIN'])!== 0)
 echo 'OK';
 }
 ```
+
+Работа в таком режиме подробно рассмотрена в демо-примере, который вы можете скачать [здесь](https://dev.1c-bitrix.ru/images/chat_bot/im_app/iframe.zip).

--- a/api-reference/chats/search/im-search-chat-list.md
+++ b/api-reference/chats/search/im-search-chat-list.md
@@ -66,22 +66,150 @@
       https://**put_your_bitrix24_address**/rest/im.search.chat.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.search.chat.list', {
-        FIND: 'Проект',
-        FIND_LINES: 'Линия',
-        OFFSET: 0,
-        LIMIT: 10,
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result, total, next } = response.getData();
-      console.log(result, total, next);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of each ChatItem returned in result[]
+    type ChatItem = {
+      id: number
+      parent_chat_id: number
+      parent_message_id: number
+      name: string
+      description: string | null
+      owner: number
+      extranet: boolean
+      avatar: string | null
+      color: string
+      type: string
+      counter: number
+      user_counter: number
+      message_count: number
+      unread_id: number
+      restrictions: {
+        avatar: boolean
+        rename: boolean
+        extend: boolean
+        call: boolean
+        mute: boolean
+        leave: boolean
+        leave_owner: boolean
+        send: boolean
+        user_list: boolean
+        path: string
+        path_title: string
+      }
+      last_message_id: number
+      last_id: number
+      marked_id: number
+      disk_folder_id: number
+      entity_type: string
+      entity_id: string
+      entity_data_1: string
+      entity_data_2: string
+      entity_data_3: string
+      mute_list: unknown[]
+      date_create: ISODate | null
+      message_type: string
+      public: string | { code: string; link: string }
+      role: string
+      entity_link: {
+        type: string
+        url: string
+        id: string | number
+      }
+      text_field_enabled: boolean
+      background_id: number | null
+      permissions: {
+        manage_users_add: string
+        manage_users_delete: string
+        manage_ui: string
+        manage_settings: string
+        manage_messages: string
+        can_post: string
+      }
+      is_new: boolean
     }
+
+    try {
+      // im.search.chat.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ChatItem[]>({
+        method: 'im.search.chat.list',
+        params: {
+          FIND: 'Project',
+          FIND_LINES: 'Line',
+          OFFSET: 0,
+          LIMIT: 10,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Found chats:', result.length, result[0]?.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchChatList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // im.search.chat.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.search.chat.list',
+            params: {
+              FIND: 'Project',
+              FIND_LINES: 'Line',
+              OFFSET: 0,
+              LIMIT: 10,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Found chats:', result.length, result[0]?.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchChatList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/search/im-search-department-list.md
+++ b/api-reference/chats/search/im-search-department-list.md
@@ -64,22 +64,129 @@
       https://**put_your_bitrix24_address**/rest/im.search.department.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.search.department.list', {
-        FIND: 'Отдел',
-        USER_DATA: 'Y',
-        OFFSET: 0,
-        LIMIT: 10,
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result, total, next } = response.getData();
-      console.log(result, total, next);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    type ManagerUserData = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { work_phone?: string; inner_phone?: string } | false
+      bot_data: object | null
+      type: string
+      website: string
+      email: string
     }
+
+    // Shape of each department item returned in result[]
+    type DepartmentItem = {
+      id: number
+      name: string
+      full_name: string
+      manager_user_id: number
+      manager_user_data?: ManagerUserData
+    }
+
+    try {
+      // im.search.department.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DepartmentItem[]>({
+        method: 'im.search.department.list',
+        params: {
+          FIND: 'Department',
+          USER_DATA: 'Y',
+          OFFSET: 0,
+          LIMIT: 10,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Found departments:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchDepartmentList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // im.search.department.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.search.department.list',
+            params: {
+              FIND: 'Department',
+              USER_DATA: 'Y',
+              OFFSET: 0,
+              LIMIT: 10,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Found departments:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchDepartmentList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/search/im-search-last-add.md
+++ b/api-reference/chats/search/im-search-last-add.md
@@ -58,19 +58,73 @@
       https://**put_your_bitrix24_address**/rest/im.search.last.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.search.last.add', {
-        DIALOG_ID: 'chat17',
-      });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.search.last.add',
+        params: {
+          DIALOG_ID: 'chat17',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog added to search history:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSearchLast() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.search.last.add',
+            params: {
+              DIALOG_ID: 'chat17',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog added to search history:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSearchLast)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/search/im-search-last-delete.md
+++ b/api-reference/chats/search/im-search-last-delete.md
@@ -58,19 +58,73 @@
       https://**put_your_bitrix24_address**/rest/im.search.last.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.search.last.delete', {
-        DIALOG_ID: 'chat17',
-      });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.search.last.delete',
+        params: {
+          DIALOG_ID: 'chat17',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSearchLast() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.search.last.delete',
+            params: {
+              DIALOG_ID: 'chat17',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSearchLast)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/search/im-search-last-get.md
+++ b/api-reference/chats/search/im-search-last-get.md
@@ -76,21 +76,135 @@
       https://**put_your_bitrix24_address**/rest/im.search.last.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.search.last.get', {
-        SKIP_OPENLINES: 'N',
-        SKIP_CHAT: 'N',
-        SKIP_DIALOG: 'N',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of each SearchLastItem returned in result[]
+    type SearchLastItem = {
+      id: string | number
+      type: 'chat' | 'user'
+      avatar: {
+        url: string
+        color: string
+      }
+      title: string
+      chat?: {
+        id: number
+        name: string
+        owner: number
+        extranet: boolean
+        avatar: string
+        color: string
+        type: string
+        entity_type: string
+        entity_id: string
+        entity_data_1: string
+        entity_data_2: string
+        entity_data_3: string
+        mute_list: unknown[]
+        date_create: ISODate
+        message_type: string
+      }
+      user?: {
+        id: number
+        active: boolean
+        name: string
+        first_name: string
+        last_name: string
+        work_position: string
+        color: string
+        avatar: string
+        avatar_hr: string
+        gender: string
+        birthday: string
+        extranet: boolean
+        network: boolean
+        bot: boolean
+        connector: boolean
+        external_auth_id: string
+        status: string
+        idle: ISODate | false
+        last_activity_date: ISODate
+        mobile_last_date: ISODate | false
+        desktop_last_date: ISODate | false
+        absent: ISODate | false
+        departments: number[]
+        phones: { personal_mobile: string; work_phone: string; inner_phone: string } | false
+        bot_data: object | null
+        type: string
+        website: string
+        email: string
+      }
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<SearchLastItem[]>({
+        method: 'im.search.last.get',
+        params: {
+          SKIP_OPENLINES: 'N',
+          SKIP_CHAT: 'N',
+          SKIP_DIALOG: 'N',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Search history entries:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSearchHistory() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.search.last.get',
+            params: {
+              SKIP_OPENLINES: 'N',
+              SKIP_CHAT: 'N',
+              SKIP_DIALOG: 'N',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Search history entries:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSearchHistory)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/search/im-search-user-list.md
+++ b/api-reference/chats/search/im-search-user-list.md
@@ -65,22 +65,120 @@
       https://**put_your_bitrix24_address**/rest/im.search.user.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.search.user.list', {
-        FIND: 'Иван',
-        BUSINESS: 'N',
-        OFFSET: 0,
-        LIMIT: 10,
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result, total, next } = response.getData();
-      console.log(result, total, next);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of each user returned in result[]
+    type UserResult = {
+      id: number
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string | null
+      gender: string
+      birthday: string | false
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate | false
+      mobile_last_date: ISODate | false
+      departments: number[]
+      absent: ISODate | false
+      phones: {
+        work_phone: string
+        personal_mobile: string
+        inner_phone: string
+      } | false
     }
+
+    try {
+      // im.search.user.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<UserResult[]>({
+        method: 'im.search.user.list',
+        params: {
+          FIND: 'Ivan',
+          BUSINESS: 'N',
+          OFFSET: 0,
+          LIMIT: 10,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Found users:', result.length, result[0]?.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchUserList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // im.search.user.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.search.user.list',
+            params: {
+              FIND: 'Ivan',
+              BUSINESS: 'N',
+              OFFSET: 0,
+              LIMIT: 10,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Found users:', result.length, result[0]?.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchUserList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/special-operations/im-chat-mute.md
+++ b/api-reference/chats/special-operations/im-chat-mute.md
@@ -69,28 +69,75 @@
     https://**put_your_bitrix24_address**/rest/im.chat.mute
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.chat.mute',
-            {
-                CHAT_ID: 1489,
-                MUTE: 'Y'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Muted chat:', result);
+    declare const $b24: B24Frame
 
-        processResult(result);
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.chat.mute',
+        params: {
+          CHAT_ID: 1489,
+          MUTE: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Notifications muted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function muteChat() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.chat.mute',
+            params: {
+              CHAT_ID: 1489,
+              MUTE: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Notifications muted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', muteChat)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/special-operations/im-dialog-read-all.md
+++ b/api-reference/chats/special-operations/im-dialog-read-all.md
@@ -45,25 +45,69 @@
     https://**put_your_bitrix24_address**/rest/im.dialog.read.all
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.dialog.read.all',
-            {}
-        );
-        
-        const result = response.getData().result;
-        console.log('Read all dialogs:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.dialog.read.all',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('All dialogs marked as read:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function readAllDialogs() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.dialog.read.all',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('All dialogs marked as read:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', readAllDialogs)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/special-operations/im-recent-hide.md
+++ b/api-reference/chats/special-operations/im-recent-hide.md
@@ -60,27 +60,73 @@
     https://**put_your_bitrix24_address**/rest/im.recent.hide
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.recent.hide',
-            {
-                DIALOG_ID: 'chat1489'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Hidden dialog:', result);
+    declare const $b24: B24Frame
 
-        processResult(result);
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.recent.hide',
+        params: {
+          DIALOG_ID: 'chat1489',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog hidden:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function hideRecentDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.recent.hide',
+            params: {
+              DIALOG_ID: 'chat1489',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog hidden:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', hideRecentDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/special-operations/im-recent-pin.md
+++ b/api-reference/chats/special-operations/im-recent-pin.md
@@ -65,28 +65,75 @@
     https://**put_your_bitrix24_address**/rest/im.recent.pin
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.recent.pin',
-            {
-                DIALOG_ID: 'chat1489',
-                PIN: 'Y'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Pinned dialog:', result);
+    declare const $b24: B24Frame
 
-        processResult(result);
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.recent.pin',
+        params: {
+          DIALOG_ID: 'chat1489',
+          PIN: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Dialog pinned:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pinRecentDialog() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.recent.pin',
+            params: {
+              DIALOG_ID: 'chat1489',
+              PIN: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Dialog pinned:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pinRecentDialog)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/special-operations/im-recent-unread.md
+++ b/api-reference/chats/special-operations/im-recent-unread.md
@@ -64,28 +64,75 @@
     https://**put_your_bitrix24_address**/rest/im.recent.unread
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'im.recent.unread',
-            {
-                DIALOG_ID: 'chat2941',
-                ACTION: 'Y'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Marked dialog as unread:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.recent.unread',
+        params: {
+          DIALOG_ID: 'chat2941',
+          ACTION: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unread flag set or removed successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markRecentUnread() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.recent.unread',
+            params: {
+              DIALOG_ID: 'chat2941',
+              ACTION: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unread flag set or removed successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markRecentUnread)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/users/im-user-get.md
+++ b/api-reference/chats/users/im-user-get.md
@@ -58,20 +58,111 @@
       https://**put_your_bitrix24_address**/rest/im.user.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.user.get', {
-        ID: 5,
-        AVATAR_HR: 'Y',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ImUserGetResult = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: false | {
+        work_phone: string
+        personal_mobile: string
+        inner_phone: string
+      }
+      website: string
+      email: string
+      bot_data: null | Record<string, unknown>
+      type: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImUserGetResult>({
+        method: 'im.user.get',
+        params: {
+          ID: 5,
+          AVATAR_HR: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getImUser() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.user.get',
+            params: {
+              ID: 5,
+              AVATAR_HR: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getImUser)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/users/im-user-list-get.md
+++ b/api-reference/chats/users/im-user-list-get.md
@@ -63,21 +63,109 @@
       https://**put_your_bitrix24_address**/rest/im.user.list.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-      const response = await $b24.callMethod('im.user.list.get', {
-        ID: [4, 5],
-        AVATAR_HR: 'Y',
-        RESULT_TYPE: 'array',
-      });
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-      const { result } = response.getData();
-      console.log(result);
-    } catch (error) {
-      console.error(error);
+    declare const $b24: B24Frame
+
+    // Shape of each user returned in result[] (match the "response handling" section of the page)
+    type ImUserInfo = {
+      id: number
+      active: boolean
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      color: string
+      avatar: string
+      avatar_hr: string
+      gender: string
+      birthday: string
+      extranet: boolean
+      network: boolean
+      bot: boolean
+      connector: boolean
+      external_auth_id: string
+      status: string
+      idle: ISODate | false
+      last_activity_date: ISODate
+      mobile_last_date: ISODate | false
+      desktop_last_date: ISODate | false
+      absent: ISODate | false
+      departments: number[]
+      phones: { work_phone: string; personal_mobile: string; inner_phone: string } | false
+      website: string
+      email: string
+      bot_data: object | null
+      type: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<ImUserInfo[]>({
+        method: 'im.user.list.get',
+        params: {
+          ID: [4, 5],
+          AVATAR_HR: 'Y',
+          RESULT_TYPE: 'array',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Users:', result.length, result.map(u => u.name))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getImUserList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.user.list.get',
+            params: {
+              ID: [4, 5],
+              AVATAR_HR: 'Y',
+              RESULT_TYPE: 'array',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Users:', result.length, result.map(u => u.name))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getImUserList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/users/im-user-status-get.md
+++ b/api-reference/chats/users/im-user-status-get.md
@@ -50,16 +50,69 @@
       https://**put_your_bitrix24_address**/rest/im.user.status.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.user.status.get', {});
-      const { result } = response.getData();
-      console.log(result);
+      const response = await $b24.actions.v2.call.make<string | false>({
+        method: 'im.user.status.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Current user status:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getUserStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.user.status.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Current user status:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getUserStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/users/im-user-status-idle-end.md
+++ b/api-reference/chats/users/im-user-status-idle-end.md
@@ -52,16 +52,69 @@
       https://**put_your_bitrix24_address**/rest/im.user.status.idle.end
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.user.status.idle.end', {});
-      const { result } = response.getData();
-      console.log(result);
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.user.status.idle.end',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Idle status disabled:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function disableIdleStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.user.status.idle.end',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Idle status disabled:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', disableIdleStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/users/im-user-status-idle-start.md
+++ b/api-reference/chats/users/im-user-status-idle-start.md
@@ -60,19 +60,73 @@
       https://**put_your_bitrix24_address**/rest/im.user.status.idle.start
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.user.status.idle.start', {
-        AGO: 10,
-      });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.user.status.idle.start',
+        params: {
+          AGO: 10,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Idle status started:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function startIdleStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.user.status.idle.start',
+            params: {
+              AGO: 10,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Idle status started:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', startIdleStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/chats/users/im-user-status-set.md
+++ b/api-reference/chats/users/im-user-status-set.md
@@ -69,19 +69,73 @@
       https://**put_your_bitrix24_address**/rest/im.user.status.set
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod('im.user.status.set', {
-        STATUS: 'dnd',
-      });
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'im.user.status.set',
+        params: {
+          STATUS: 'dnd',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Status set:', result)
+      }
     } catch (error) {
-      console.error(error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setUserStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'im.user.status.set',
+            params: {
+              STATUS: 'dnd',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Status set:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setUserStatus)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.