### PR TITLE
docs(entity): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/entity/entities/entity-add.md
+++ b/api-reference/entity/entities/entity-add.md
@@ -79,30 +79,83 @@
     https://**put_your_bitrix24_address**/rest/entity.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.add',
-    		{
-    			ENTITY: 'dish',
-    			NAME: 'Dishes',
-    			ACCESS: {
-    				U1: 'W',
-    				AU: 'R',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.add',
+        params: {
+          ENTITY: 'dish',
+          NAME: 'Dishes',
+          ACCESS: {
+            U1: 'W',
+            AU: 'R',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Entity created:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addEntity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.add',
+            params: {
+              ENTITY: 'dish',
+              NAME: 'Dishes',
+              ACCESS: {
+                U1: 'W',
+                AU: 'R',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Entity created:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addEntity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/entities/entity-delete.md
+++ b/api-reference/entity/entities/entity-delete.md
@@ -53,25 +53,73 @@
     https://**put_your_bitrix24_address**/rest/entity.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.delete',
-    		{
-    			ENTITY: 'dish_v2',
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.delete',
+        params: {
+          ENTITY: 'dish_v2',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('entity.delete result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteEntity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.delete',
+            params: {
+              ENTITY: 'dish_v2',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('entity.delete result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteEntity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/entities/entity-get.md
+++ b/api-reference/entity/entities/entity-get.md
@@ -55,25 +55,81 @@
     https://**put_your_bitrix24_address**/rest/entity.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.get',
-    		{
-    			ENTITY: 'dish_v2',
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EntityGetResult = {
+      ID: string
+      IBLOCK_TYPE_ID: string
+      ENTITY: string
+      NAME: string
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<EntityGetResult>({
+        method: 'entity.get',
+        params: {
+          ENTITY: 'dish_v2',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.ENTITY, result.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEntity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.get',
+            params: {
+              ENTITY: 'dish_v2',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.ENTITY, result.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEntity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/entities/entity-rights.md
+++ b/api-reference/entity/entities/entity-rights.md
@@ -77,29 +77,84 @@
     https://**put_your_bitrix24_address**/rest/entity.rights
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.rights',
-    		{
-    			ENTITY: 'dish',
-    			ACCESS: {
-    				U1: 'W',
-    				AU: 'R',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EntityRightsResult = Record<string, string> | null
+
+    try {
+      const response = await $b24.actions.v2.call.make<EntityRightsResult>({
+        method: 'entity.rights',
+        params: {
+          ENTITY: 'dish',
+          ACCESS: {
+            U1: 'W',
+            AU: 'R',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Access rights:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setEntityRights() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.rights',
+            params: {
+              ENTITY: 'dish',
+              ACCESS: {
+                U1: 'W',
+                AU: 'R',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Access rights:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setEntityRights)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/entities/entity-update.md
+++ b/api-reference/entity/entities/entity-update.md
@@ -86,31 +86,85 @@
     https://**put_your_bitrix24_address**/rest/entity.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.update',
-    		{
-    			ENTITY: 'dish',
-    			NAME: 'Dishes v2',
-    			ENTITY_NEW: 'dish_v2',
-    			ACCESS: {
-    				U1: 'W',
-    				AU: 'R',
-    			},
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.update',
+        params: {
+          ENTITY: 'dish',
+          NAME: 'Dishes v2',
+          ENTITY_NEW: 'dish_v2',
+          ACCESS: {
+            U1: 'W',
+            AU: 'R',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('entity.update result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateEntity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.update',
+            params: {
+              ENTITY: 'dish',
+              NAME: 'Dishes v2',
+              ENTITY_NEW: 'dish_v2',
+              ACCESS: {
+                U1: 'W',
+                AU: 'R',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('entity.update result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateEntity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/entity-item-add.md
+++ b/api-reference/entity/items/entity-item-add.md
@@ -79,31 +79,85 @@
     https://**put_your_bitrix24_address**/rest/entity.item.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.add',
-    		{
-    			ENTITY: 'dish',
-    			NAME: 'Hello, world!',
-    			PROPERTY_VALUES: {
-    				test: 11,
-    				test1: 22,
-    			},
-    			SECTION: 219,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'entity.item.add',
+        params: {
+          ENTITY: 'dish',
+          NAME: 'Hello, world!',
+          PROPERTY_VALUES: {
+            test: 11,
+            test1: 22,
+          },
+          SECTION: 219,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created item ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addEntityItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.add',
+            params: {
+              ENTITY: 'dish',
+              NAME: 'Hello, world!',
+              PROPERTY_VALUES: {
+                test: 11,
+                test1: 22,
+              },
+              SECTION: 219,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created item ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addEntityItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/entity-item-delete.md
+++ b/api-reference/entity/items/entity-item-delete.md
@@ -59,26 +59,75 @@
     https://**put_your_bitrix24_address**/rest/entity.item.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.delete',
-    		{
-    			ENTITY: 'dish',
-    			ID: 2333,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.item.delete',
+        params: {
+          ENTITY: 'dish',
+          ID: 2333,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteEntityItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.delete',
+            params: {
+              ENTITY: 'dish',
+              ID: 2333,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteEntityItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/entity-item-get.md
+++ b/api-reference/entity/items/entity-item-get.md
@@ -114,34 +114,123 @@
     https://**put_your_bitrix24_address**/rest/entity.item.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.get',
-    		{
-    			ENTITY: 'dish_v2',
-    			SORT: {
-    				DATE_ACTIVE_FROM: 'ASC',
-    				ID: 'ASC',
-    			},
-    			FILTER: {
-    				'>=DATE_ACTIVE_FROM': '2026-03-01T00:00:00+03:00',
-    				'<DATE_ACTIVE_FROM': '2026-04-01T00:00:00+03:00',
-    			},
-    			start: 0,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each item returned in result[]
+    type EntityItem = {
+      ID: string
+      TIMESTAMP_X: ISODate
+      MODIFIED_BY: string
+      DATE_CREATE: ISODate
+      CREATED_BY: string
+      ACTIVE: string
+      DATE_ACTIVE_FROM: ISODate | string
+      DATE_ACTIVE_TO: ISODate | string
+      SORT: string
+      NAME: string
+      PREVIEW_PICTURE: string | null
+      PREVIEW_TEXT: string | null
+      DETAIL_PICTURE: string | null
+      DETAIL_TEXT: string | null
+      CODE: string | null
+      ENTITY: string
+      SECTION: string | null
+      PROPERTY_VALUES?: Record<string, unknown>
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      // entity.item.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<EntityItem[]>({
+        method: 'entity.item.get',
+        params: {
+          ENTITY: 'dish_v2',
+          SORT: {
+            DATE_ACTIVE_FROM: 'ASC',
+            ID: 'ASC',
+          },
+          FILTER: {
+            '>=DATE_ACTIVE_FROM': '2026-03-01T00:00:00+03:00',
+            '<DATE_ACTIVE_FROM': '2026-04-01T00:00:00+03:00',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Items count:', result.length, 'First item:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEntityItems() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // entity.item.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.get',
+            params: {
+              ENTITY: 'dish_v2',
+              SORT: {
+                DATE_ACTIVE_FROM: 'ASC',
+                ID: 'ASC',
+              },
+              FILTER: {
+                '>=DATE_ACTIVE_FROM': '2026-03-01T00:00:00+03:00',
+                '<DATE_ACTIVE_FROM': '2026-04-01T00:00:00+03:00',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Items count:', result.length, 'First item:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEntityItems)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/entity-item-update.md
+++ b/api-reference/entity/items/entity-item-update.md
@@ -86,32 +86,87 @@
     https://**put_your_bitrix24_address**/rest/entity.item.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.update',
-    		{
-    			ENTITY: 'dish',
-    			ID: 2333,
-    			NAME: 'Hello, updated world!',
-    			PROPERTY_VALUES: {
-    				test: 33,
-    				test1: 44,
-    			},
-    			SECTION: 219,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.item.update',
+        params: {
+          ENTITY: 'dish',
+          ID: 2333,
+          NAME: 'Hello, updated world!',
+          PROPERTY_VALUES: {
+            test: 33,
+            test1: 44,
+          },
+          SECTION: 219,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Item updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateEntityItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.update',
+            params: {
+              ENTITY: 'dish',
+              ID: 2333,
+              NAME: 'Hello, updated world!',
+              PROPERTY_VALUES: {
+                test: 33,
+                test1: 44,
+              },
+              SECTION: 219,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Item updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateEntityItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/properties/entity-item-property-add.md
+++ b/api-reference/entity/items/properties/entity-item-property-add.md
@@ -71,29 +71,81 @@
     https://**put_your_bitrix24_address**/rest/entity.item.property.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.property.add',
-    		{
-    			ENTITY: 'dish',
-    			PROPERTY: 'new_prop',
-    			NAME: 'Новое свойство',
-    			TYPE: 'S',
-    			SORT: 100,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.item.property.add',
+        params: {
+          ENTITY: 'dish',
+          PROPERTY: 'new_prop',
+          NAME: 'New property',
+          TYPE: 'S',
+          SORT: 100,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Property added:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addEntityItemProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.property.add',
+            params: {
+              ENTITY: 'dish',
+              PROPERTY: 'new_prop',
+              NAME: 'New property',
+              TYPE: 'S',
+              SORT: 100,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Property added:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addEntityItemProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/properties/entity-item-property-delete.md
+++ b/api-reference/entity/items/properties/entity-item-property-delete.md
@@ -59,26 +59,75 @@
     https://**put_your_bitrix24_address**/rest/entity.item.property.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.property.delete',
-    		{
-    			ENTITY: 'dish',
-    			PROPERTY: 'new_prop',
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.item.property.delete',
+        params: {
+          ENTITY: 'dish',
+          PROPERTY: 'new_prop',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Property deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteEntityItemProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.property.delete',
+            params: {
+              ENTITY: 'dish',
+              PROPERTY: 'new_prop',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Property deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteEntityItemProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/properties/entity-item-property-get.md
+++ b/api-reference/entity/items/properties/entity-item-property-get.md
@@ -59,25 +59,81 @@
     https://**put_your_bitrix24_address**/rest/entity.item.property.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.property.get',
-    		{
-    			ENTITY: 'dish',
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each PropertyItem returned in result[]
+    type PropertyItem = {
+      PROPERTY: string
+      NAME: string
+      TYPE: string
+      SORT: string
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PropertyItem[]>({
+        method: 'entity.item.property.get',
+        params: {
+          ENTITY: 'dish',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.map(p => `${p.PROPERTY}: ${p.NAME} (${p.TYPE})`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEntityItemProperties() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.property.get',
+            params: {
+              ENTITY: 'dish',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.map(p => `${p.PROPERTY}: ${p.NAME} (${p.TYPE})`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEntityItemProperties)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/items/properties/entity-item-property-update.md
+++ b/api-reference/entity/items/properties/entity-item-property-update.md
@@ -73,29 +73,81 @@
     https://**put_your_bitrix24_address**/rest/entity.item.property.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.item.property.update',
-    		{
-    			ENTITY: 'dish',
-    			PROPERTY: 'new_prop',
-    			PROPERTY_NEW: 'updated_prop',
-    			NAME: 'Обновленное свойство',
-    			SORT: 200,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.item.property.update',
+        params: {
+          ENTITY: 'dish',
+          PROPERTY: 'new_prop',
+          PROPERTY_NEW: 'updated_prop',
+          NAME: 'Updated property',
+          SORT: 200,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Property updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateEntityItemProperty() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.item.property.update',
+            params: {
+              ENTITY: 'dish',
+              PROPERTY: 'new_prop',
+              PROPERTY_NEW: 'updated_prop',
+              NAME: 'Updated property',
+              SORT: 200,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Property updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateEntityItemProperty)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/sections/entity-section-add.md
+++ b/api-reference/entity/sections/entity-section-add.md
@@ -78,33 +78,89 @@
     https://**put_your_bitrix24_address**/rest/entity.section.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.section.add',
-    		{
-    			ENTITY: 'dish',
-    			NAME: 'Тестовый раздел',
-    			SECTION: 671,
-    			ACTIVE: 'Y',
-    			SORT: 500,
-    			CODE: 'testovyy-razdel',
-    			DESCRIPTION: 'Описание тестового раздела',
-    			PICTURE: ['section.jpg', '**base64_section_image**'],
-    			DETAIL_PICTURE: ['section-detail.jpg', '**base64_section_detail_image**'],
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'entity.section.add',
+        params: {
+          ENTITY: 'dish',
+          NAME: 'Test section',
+          SECTION: 671,
+          ACTIVE: 'Y',
+          SORT: 500,
+          CODE: 'testovyy-razdel',
+          DESCRIPTION: 'Test section description',
+          PICTURE: ['section.jpg', '**base64_section_image**'],
+          DETAIL_PICTURE: ['section-detail.jpg', '**base64_section_detail_image**'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created section ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addEntitySection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.section.add',
+            params: {
+              ENTITY: 'dish',
+              NAME: 'Test section',
+              SECTION: 671,
+              ACTIVE: 'Y',
+              SORT: 500,
+              CODE: 'testovyy-razdel',
+              DESCRIPTION: 'Test section description',
+              PICTURE: ['section.jpg', '**base64_section_image**'],
+              DETAIL_PICTURE: ['section-detail.jpg', '**base64_section_detail_image**'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created section ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addEntitySection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/sections/entity-section-delete.md
+++ b/api-reference/entity/sections/entity-section-delete.md
@@ -57,26 +57,75 @@
     https://**put_your_bitrix24_address**/rest/entity.section.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.section.delete',
-    		{
-    			ENTITY: 'dish',
-    			ID: 673,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.section.delete',
+        params: {
+          ENTITY: 'dish',
+          ID: 673,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteEntitySection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.section.delete',
+            params: {
+              ENTITY: 'dish',
+              ID: 673,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteEntitySection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/sections/entity-section-get.md
+++ b/api-reference/entity/sections/entity-section-get.md
@@ -116,28 +116,110 @@
     https://**put_your_bitrix24_address**/rest/entity.section.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.section.get',
-    		{
-    			ENTITY: 'dish',
-    			SORT: { NAME: 'ASC' },
-    			FILTER: { ACTIVE: 'Y' },
-    			start: 0,
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each SectionItem returned in result[]
+    type SectionItem = {
+      ID: string
+      CODE: string | null
+      TIMESTAMP_X: ISODate
+      DATE_CREATE: ISODate
+      CREATED_BY: string
+      MODIFIED_BY: string
+      ACTIVE: 'Y' | 'N'
+      SORT: string
+      NAME: string
+      PICTURE: string | null
+      DETAIL_PICTURE: string | null
+      DESCRIPTION: string | null
+      LEFT_MARGIN: string
+      RIGHT_MARGIN: string
+      DEPTH_LEVEL: string
+      ENTITY: string
+      SECTION: string | null
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
+
+    try {
+      // entity.section.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SectionItem[]>({
+        method: 'entity.section.get',
+        params: {
+          ENTITY: 'dish',
+          SORT: { NAME: 'ASC' },
+          FILTER: { ACTIVE: 'Y' },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('sections:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSections() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // entity.section.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.section.get',
+            params: {
+              ENTITY: 'dish',
+              SORT: { NAME: 'ASC' },
+              FILTER: { ACTIVE: 'Y' },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('sections:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSections)
+    </script>
     ```
 
 - PHP

--- a/api-reference/entity/sections/entity-section-update.md
+++ b/api-reference/entity/sections/entity-section-update.md
@@ -78,35 +78,93 @@
     https://**put_your_bitrix24_address**/rest/entity.section.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'entity.section.update',
-    		{
-    			ENTITY: 'dish',
-    			ID: 673,
-    			NAME: 'Тестовый раздел (обновлен)',
-    			SECTION: 671,
-    			ACTIVE: 'Y',
-    			DESCRIPTION: 'Обновленное описание',
-    			CODE: 'testovyy-razdel-updated',
-    			SORT: 550,
-    			PICTURE: ['section.jpg', '**base64_section_image**'],
-    			DETAIL_PICTURE: ['section-detail.jpg', '**base64_section_detail_image**'],
-    			UF_COLOR: '#ff6600',
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'entity.section.update',
+        params: {
+          ENTITY: 'dish',
+          ID: 673,
+          NAME: 'Test section (updated)',
+          SECTION: 671,
+          ACTIVE: 'Y',
+          DESCRIPTION: 'Updated description',
+          CODE: 'testovyy-razdel-updated',
+          SORT: 550,
+          PICTURE: ['section.jpg', '**base64_section_image**'],
+          DETAIL_PICTURE: ['section-detail.jpg', '**base64_section_detail_image**'],
+          UF_COLOR: '#ff6600',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Section updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateEntitySection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'entity.section.update',
+            params: {
+              ENTITY: 'dish',
+              ID: 673,
+              NAME: 'Test section (updated)',
+              SECTION: 671,
+              ACTIVE: 'Y',
+              DESCRIPTION: 'Updated description',
+              CODE: 'testovyy-razdel-updated',
+              SORT: 550,
+              PICTURE: ['section.jpg', '**base64_section_image**'],
+              DETAIL_PICTURE: ['section-detail.jpg', '**base64_section_detail_image**'],
+              UF_COLOR: '#ff6600',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Section updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateEntitySection)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.