### PR TITLE
docs(events): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/events/event-bind.md
+++ b/api-reference/events/event-bind.md
@@ -75,15 +75,77 @@
     https://**put_your_bitrix24_address**/rest/event.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    BX24.callBind(
-        'ONCRMLEADADD',
-        'https://www.my-domain.ru/handler/',
-        15,
-        (result) => console.log(result)
-    );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.bind',
+        params: {
+          event: 'ONCRMLEADADD',
+          handler: 'https://www.my-domain.ru/handler/',
+          auth_type: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handler registered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'ONCRMLEADADD',
+              handler: 'https://www.my-domain.ru/handler/',
+              auth_type: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handler registered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/event-get.md
+++ b/api-reference/events/event-get.md
@@ -33,24 +33,83 @@
     https://**put_your_bitrix24_address**/rest/event.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each event handler returned in result[]
+    type EventHandlerItem = {
+      event: string,
+      handler: string,
+      auth_type: string,
+      offline: number,
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<EventHandlerItem[]>({
+        method: 'event.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          'Registered event handlers:',
+          result.map(h => `${h.event} → ${h.handler}`)
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEventHandlers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            'Registered event handlers:',
+            result.map(h => `${h.event} → ${h.handler}`)
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEventHandlers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/event-offline-clear.md
+++ b/api-reference/events/event-offline-clear.md
@@ -50,34 +50,75 @@
     https://**put_your_bitrix24_address**/rest/event.offline.clear
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.offline.clear',
-    		{
-    			'process_id': 'yh3gu929sf0d32lsfysqas2y1hlpp09q',
-    			'id': [2]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.offline.clear',
+        params: {
+          process_id: 'yh3gu929sf0d32lsfysqas2y1hlpp09q',
+          id: [2],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Clear result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function clearOfflineEvents() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.offline.clear',
+            params: {
+              process_id: 'yh3gu929sf0d32lsfysqas2y1hlpp09q',
+              id: [2],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Clear result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', clearOfflineEvents)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/event-offline-error.md
+++ b/api-reference/events/event-offline-error.md
@@ -48,34 +48,75 @@
     https://**put_your_bitrix24_address**/rest/event.offline.error
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'event.offline.error',
-    		{
-    			'process_id': 'yh3gu929sf0d32lsfysqas2y1hlpp09q',
-    			'message_id': [2]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    	{
-    		console.error(result.error());
-    	}
-    	else
-    	{
-    		console.dir(result);
-    	}
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.offline.error',
+        params: {
+          process_id: 'yh3gu929sf0d32lsfysqas2y1hlpp09q',
+          message_id: [2],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Offline error registered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerOfflineError() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.offline.error',
+            params: {
+              process_id: 'yh3gu929sf0d32lsfysqas2y1hlpp09q',
+              message_id: [2],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Offline error registered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerOfflineError)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/event-offline-get.md
+++ b/api-reference/events/event-offline-get.md
@@ -69,32 +69,96 @@
     https://**put_your_bitrix24_address**/rest/event.offline.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'event.offline.get',
-            {
-                filter: {
-                    '=MESSAGE_ID': 1,
-                    '=EVENT_NAME': 'ONCRMLEADADD',
-                    '>=ID': 1
-                },
-                auth_connector: 'BxTest'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Result:', result);
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OfflineGetResult = {
+      process_id: string | null,
+      events: {
+        ID: string,
+        TIMESTAMP_X: ISODate,
+        EVENT_NAME: string,
+        EVENT_DATA: unknown,
+        EVENT_ADDITIONAL: unknown,
+        MESSAGE_ID: string,
+      }[],
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<OfflineGetResult>({
+        method: 'event.offline.get',
+        params: {
+          filter: {
+            '=MESSAGE_ID': 1,
+            '=EVENT_NAME': 'ONCRMLEADADD',
+            '>=ID': 1,
+          },
+          auth_connector: 'BxTest',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Offline events:', result.events, 'Process ID:', result.process_id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOfflineEvents() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.offline.get',
+            params: {
+              filter: {
+                '=MESSAGE_ID': 1,
+                '=EVENT_NAME': 'ONCRMLEADADD',
+                '>=ID': 1,
+              },
+              auth_connector: 'BxTest',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Offline events:', result.events, 'Process ID:', result.process_id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOfflineEvents)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/event-offline-list.md
+++ b/api-reference/events/event-offline-list.md
@@ -66,51 +66,107 @@
     https://**put_your_bitrix24_address**/rest/event.offline.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'event.offline.list',
-        {
-          "filter": {
-            "ERROR": 0
-          },
-          "order": {
-            "ID": "DESC"
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each OfflineEventItem returned in result[]
+    type OfflineEventItem = {
+      ID: string
+      TIMESTAMP_X: ISODate
+      EVENT_NAME: string
+      EVENT_DATA: unknown
+      EVENT_ADDITIONAL: unknown
+      MESSAGE_ID: string
+      PROCESS_ID: string
+      ERROR: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('event.offline.list', { "filter": { "ERROR": 0 }, "order": { "ID": "DESC" } }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // event.offline.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<OfflineEventItem[]>({
+        method: 'event.offline.list',
+        params: {
+          filter: {
+            ERROR: 0,
+          },
+          order: {
+            ID: 'DESC',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Offline events:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('event.offline.list', { "filter": { "ERROR": 0 }, "order": { "ID": "DESC" } }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchOfflineEvents() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // event.offline.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.offline.list',
+            params: {
+              filter: {
+                ERROR: 0,
+              },
+              order: {
+                ID: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Offline events:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchOfflineEvents)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/event-unbind.md
+++ b/api-reference/events/event-unbind.md
@@ -61,15 +61,82 @@
     https://**put_your_bitrix24_address**/rest/event.unbind
         ```
 
-- JS
+- JS (TS)
 
-    ```js
-    BX24.callUnbind(
-        'ONCRMLEADADD',
-        'https://www.my-domain.ru/handler/',
-        15,
-        (result) => console.log(result)
-    );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EventUnbindResult = {
+      count: number
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<EventUnbindResult>({
+        method: 'event.unbind',
+        params: {
+          event: 'ONCRMLEADADD',
+          handler: 'https://www.my-domain.ru/handler/',
+          auth_type: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unbound handlers count:', result.count)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unbindEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.unbind',
+            params: {
+              event: 'ONCRMLEADADD',
+              handler: 'https://www.my-domain.ru/handler/',
+              auth_type: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unbound handlers count:', result.count)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unbindEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/offline-events.md
+++ b/api-reference/events/offline-events.md
@@ -52,24 +52,73 @@
     https://**put_your_bitrix24_address**/rest/feature.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'feature.get',
-            {
-                CODE: 'rest_offline_extended'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'feature.get',
+        params: {
+          CODE: 'rest_offline_extended',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Feature available:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkFeature() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'feature.get',
+            params: {
+              CODE: 'rest_offline_extended',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Feature available:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkFeature)
+    </script>
     ```
 
 - PHP
@@ -150,25 +199,75 @@
     https://**put_your_bitrix24_address**/rest/event.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'event.bind',
-            {
-                event: 'ONCRMDEALUPDATE',
-                event_type: 'offline'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.bind',
+        params: {
+          event: 'ONCRMDEALUPDATE',
+          event_type: 'offline',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event handler registered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindOfflineEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'ONCRMDEALUPDATE',
+              event_type: 'offline',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event handler registered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindOfflineEvent)
+    </script>
     ```
 
 - PHP
@@ -256,27 +355,87 @@
     https://**put_your_bitrix24_address**/rest/event.offline.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'event.offline.get',
-            {
-                limit: 50
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const events = response.getData().result.events;
-        for (const event of events) {
-            console.log(event.EVENT_NAME, event.MESSAGE_ID);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OfflineGetResult = {
+      events: {
+        EVENT_NAME: string
+        MESSAGE_ID: string
+      }[]
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<OfflineGetResult>({
+        method: 'event.offline.get',
+        params: {
+          limit: 50,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Events received:', result.events.length)
+        for (const event of result.events) {
+          console.info(event.EVENT_NAME, event.MESSAGE_ID)
         }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getOfflineEvents() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.offline.get',
+            params: {
+              limit: 50,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Events received:', result.events.length)
+          for (const event of result.events) {
+            console.info(event.EVENT_NAME, event.MESSAGE_ID)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getOfflineEvents)
+    </script>
     ```
 
 - PHP
@@ -383,39 +542,127 @@
     https://**put_your_bitrix24_address**/rest/event.offline.clear
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        // Шаг 1. Зарезервировать пакет
-        const response = await $b24.callMethod(
-            'event.offline.get',
-            {
-                clear: 0,
-                limit: 50
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const { process_id, events } = response.getData().result;
+    declare const $b24: B24Frame
 
-        // Шаг 2. Обработать события
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type OfflineGetResult = {
+      process_id: string
+      events: {
+        EVENT_NAME: string
+        MESSAGE_ID: string
+      }[]
+    }
+
+    try {
+      // Step 1. Reserve the batch
+      const getResponse = await $b24.actions.v2.call.make<OfflineGetResult>({
+        method: 'event.offline.get',
+        params: {
+          clear: 0,
+          limit: 50,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!getResponse.isSuccess) {
+        console.error(getResponse.getErrorMessages().join('; '))
+      } else {
+        const result = getResponse.getData()!.result
+        const { process_id, events } = result
+
+        // Step 2. Process events
         for (const event of events) {
-            console.log(event.EVENT_NAME, event.MESSAGE_ID);
+          console.info(event.EVENT_NAME, event.MESSAGE_ID)
         }
 
-        // Шаг 3. Подтвердить обработку
-        await $b24.callMethod(
-            'event.offline.clear',
-            {
-                process_id: process_id
-            }
-        );
+        // Step 3. Confirm processing
+        const clearResponse = await $b24.actions.v2.call.make<boolean>({
+          method: 'event.offline.clear',
+          params: {
+            process_id,
+          },
+          requestId: Text.getUuidRfc4122()
+        })
+
+        if (!clearResponse.isSuccess) {
+          console.error(clearResponse.getErrorMessages().join('; '))
+        } else {
+          console.info('Batch cleared:', clearResponse.getData()!.result)
+        }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function processOfflineEvents() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // Step 1. Reserve the batch
+          const getResponse = await $b24.actions.v2.call.make({
+            method: 'event.offline.get',
+            params: {
+              clear: 0,
+              limit: 50,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!getResponse.isSuccess) {
+            console.error(getResponse.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = getResponse.getData().result
+          const { process_id, events } = result
+
+          // Step 2. Process events
+          for (const event of events) {
+            console.info(event.EVENT_NAME, event.MESSAGE_ID)
+          }
+
+          // Step 3. Confirm processing
+          const clearResponse = await $b24.actions.v2.call.make({
+            method: 'event.offline.clear',
+            params: {
+              process_id,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          if (!clearResponse.isSuccess) {
+            console.error(clearResponse.getErrorMessages().join('; '))
+            return
+          }
+
+          console.info('Batch cleared:', clearResponse.getData().result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', processOfflineEvents)
+    </script>
     ```
 
 - PHP
@@ -554,25 +801,77 @@
     https://**put_your_bitrix24_address**/rest/event.offline.error
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'event.offline.error',
-            {
-                process_id: processId,
-                message_id: [messageId]
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+    declare const processId: string
+    declare const messageId: string
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.offline.error',
+        params: {
+          process_id: processId,
+          message_id: [messageId],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Errors marked:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markOfflineErrors() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.offline.error',
+            params: {
+              process_id: processId,
+              message_id: [messageId],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Errors marked:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markOfflineErrors)
+    </script>
     ```
 
 - PHP
@@ -662,26 +961,77 @@
     https://**put_your_bitrix24_address**/rest/event.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'event.bind',
-            {
-                event: 'ONCRMDEALUPDATE',
-                event_type: 'offline',
-                auth_connector: 'my_connector'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.bind',
+        params: {
+          event: 'ONCRMDEALUPDATE',
+          event_type: 'offline',
+          auth_connector: 'my_connector',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event handler with connector registered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindOfflineEventWithConnector() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'ONCRMDEALUPDATE',
+              event_type: 'offline',
+              auth_connector: 'my_connector',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event handler with connector registered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindOfflineEventWithConnector)
+    </script>
     ```
 
 - PHP
@@ -768,28 +1118,81 @@
     https://**put_your_bitrix24_address**/rest/crm.deal.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'crm.deal.update',
-            {
-                id: 1,
-                fields: {
-                    TITLE: 'Новое название'
-                },
-                auth_connector: 'my_connector'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'crm.deal.update',
+        params: {
+          id: 1,
+          fields: {
+            TITLE: 'New title',
+          },
+          auth_connector: 'my_connector',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deal updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateDeal() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'crm.deal.update',
+            params: {
+              id: 1,
+              fields: {
+                TITLE: 'New title',
+              },
+              auth_connector: 'my_connector',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deal updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateDeal)
+    </script>
     ```
 
 - PHP

--- a/api-reference/events/test-handler.md
+++ b/api-reference/events/test-handler.md
@@ -49,21 +49,75 @@
     https://**put_your_bitrix24_address**/rest/event.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```javascript
-    BX24.callMethod(
-        'event.bind',
-        {
-            'event': 'ONAPPTEST',
-            'handler': 'https://example.com/handler.php'
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.bind',
+        params: {
+          event: 'ONAPPTEST',
+          handler: 'https://example.com/handler.php',
         },
-        function(eventBind) {
-            if (eventBind.data()) {
-                console.log('event bind successful');
-            }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('event.bind result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.bind',
+            params: {
+              event: 'ONAPPTEST',
+              handler: 'https://example.com/handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('event.bind result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    );
+      }
+
+      document.addEventListener('DOMContentLoaded', bindEvent)
+    </script>
     ```
 
 - PHP
@@ -102,20 +156,73 @@
     https://**put_your_bitrix24_address**/rest/event.test
     ```
 
-- JS
+- JS (TS)
 
-    ```javascript
-    BX24.callMethod(
-        'event.test',
-        {
-            'any': 'data'
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'event.test',
+        params: {
+          any: 'data',
         },
-        function(result) {
-            if (result.data()) {
-                console.log('successful');
-            }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('event.test result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function testEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'event.test',
+            params: {
+              any: 'data',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('event.test result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-    );
+      }
+
+      document.addEventListener('DOMContentLoaded', testEvent)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.