### PR TITLE
docs(landing): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/landing/block/methods/landing-block-add-card.md
+++ b/api-reference/landing/block/methods/landing-block-add-card.md
@@ -99,28 +99,79 @@
       "https://**put.your-domain-here**/rest/landing.block.addcard.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.block.addcard',
-            {
-                lid: 351,
-                block: 6428,
-                selector: '.landing-block-node-menu-list-item@0',
-                content: '<li class="landing-block-node-menu-list-item nav-item"><a href="#services" class="landing-block-node-menu-list-item-link nav-link">Услуги</a></li>'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.addcard',
+        params: {
+          lid: 351,
+          block: 6428,
+          selector: '.landing-block-node-menu-list-item@0',
+          content: '<li class="landing-block-node-menu-list-item nav-item"><a href="#services" class="landing-block-node-menu-list-item-link nav-link">Services</a></li>',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Card added successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBlockCard() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.addcard',
+            params: {
+              lid: 351,
+              block: 6428,
+              selector: '.landing-block-node-menu-list-item@0',
+              content: '<li class="landing-block-node-menu-list-item nav-item"><a href="#services" class="landing-block-node-menu-list-item-link nav-link">Services</a></li>',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Card added successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBlockCard)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-change-anchor.md
+++ b/api-reference/landing/block/methods/landing-block-change-anchor.md
@@ -87,28 +87,79 @@
       "https://**put.your-domain-here**/rest/landing.block.changeAnchor.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.changeAnchor',
-    		{
-    			lid: 311,
-    			block: 6058,
-    			data: 'about-us',
-    			preventHistory: true
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.changeAnchor',
+        params: {
+          lid: 311,
+          block: 6058,
+          data: 'about-us',
+          preventHistory: true,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Anchor changed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function changeBlockAnchor() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.changeAnchor',
+            params: {
+              lid: 311,
+              block: 6058,
+              data: 'about-us',
+              preventHistory: true,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Anchor changed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', changeBlockAnchor)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-change-node-name.md
+++ b/api-reference/landing/block/methods/landing-block-change-node-name.md
@@ -139,31 +139,85 @@
       "https://**put.your-domain-here**/rest/landing.block.changeNodeName.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.changeNodeName',
-    		{
-    			lid: 311,
-    			block: 6058,
-    			data: {
-    				'.landing-block-node-title@0': 'h1',
-    				'.landing-block-node-text@2': 'p'
-    			},
-    			preventHistory: true
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.changeNodeName',
+        params: {
+          lid: 311,
+          block: 6058,
+          data: {
+            '.landing-block-node-title@0': 'h1',
+            '.landing-block-node-text@2': 'p',
+          },
+          preventHistory: true,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Node name changed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function changeNodeName() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.changeNodeName',
+            params: {
+              lid: 311,
+              block: 6058,
+              data: {
+                '.landing-block-node-title@0': 'h1',
+                '.landing-block-node-text@2': 'p',
+              },
+              preventHistory: true,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Node name changed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', changeNodeName)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-clone-card.md
+++ b/api-reference/landing/block/methods/landing-block-clone-card.md
@@ -87,27 +87,77 @@
       "https://**put.your-domain-here**/rest/landing.block.clonecard.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.block.clonecard',
-            {
-                lid: 351,
-                block: 6428,
-                selector: '.landing-block-card@0'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.clonecard',
+        params: {
+          lid: 351,
+          block: 6428,
+          selector: '.landing-block-card@0',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Card cloned successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function cloneBlockCard() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.clonecard',
+            params: {
+              lid: 351,
+              block: 6428,
+              selector: '.landing-block-card@0',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Card cloned successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', cloneBlockCard)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-by-id.md
+++ b/api-reference/landing/block/methods/landing-block-get-by-id.md
@@ -90,29 +90,107 @@
       "https://**put.your-domain-here**/rest/landing.block.getbyid.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getbyid',
-    		{
-    			block: 39556,
-    			params: {
-    				edit_mode: true,
-    				get_content: true
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BlockByIdResult = {
+      id: number
+      lid: number
+      code: string
+      name: string
+      active: boolean
+      meta: {
+        LID: string
+        FAVORITE_META: string
+        CREATED_BY_ID: string
+        DATE_CREATE: string
+        MODIFIED_BY_ID: string
+        DATE_MODIFY: string
+        SITE_TYPE: string
+        LANDING_TITLE: string
+        LANDING_TPL_CODE: string
+        SITE_TPL_CODE: string
+        XML_ID: string
+        DESIGNER_MODE: string
+      }
+      content?: string
+      css?: string[]
+      js?: string[]
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BlockByIdResult>({
+        method: 'landing.block.getbyid',
+        params: {
+          block: 39556,
+          params: {
+            edit_mode: true,
+            get_content: true,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.name, result.active, result.content)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlockById() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getbyid',
+            params: {
+              block: 39556,
+              params: {
+                edit_mode: true,
+                get_content: true,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.name, result.active, result.content)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlockById)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-content-from-repository.md
+++ b/api-reference/landing/block/methods/landing-block-get-content-from-repository.md
@@ -67,25 +67,73 @@
       "https://**put.your-domain-here**/rest/landing.block.getContentFromRepository.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getContentFromRepository',
-    		{
-    			code: '01.big_with_text'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string | null>({
+        method: 'landing.block.getContentFromRepository',
+        params: {
+          code: '01.big_with_text',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('HTML content:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlockContent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getContentFromRepository',
+            params: {
+              code: '01.big_with_text',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('HTML content:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlockContent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-content.md
+++ b/api-reference/landing/block/methods/landing-block-get-content.md
@@ -108,30 +108,103 @@
       "https://**put.your-domain-here**/rest/landing.block.getcontent.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getcontent',
-    		{
-    			lid: 4858,
-    			block: 39556,
-    			editMode: true,
-    			params: {
-    				wrapper_show: false
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BlockContentResult = {
+      id: number
+      sections: string
+      active: boolean
+      access: string
+      anchor: string
+      php: boolean
+      designed: boolean
+      repoId: number | null
+      content: string
+      content_ext: string
+      css: string[]
+      js: string[]
+      assetStrings: string[]
+      lang: string[] | Record<string, string>
+      manifest: Record<string, unknown>
+      dynamicParams: unknown[]
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<BlockContentResult>({
+        method: 'landing.block.getcontent',
+        params: {
+          lid: 4858,
+          block: 39556,
+          editMode: true,
+          params: {
+            wrapper_show: false,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.content, result.active)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlockContent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getcontent',
+            params: {
+              lid: 4858,
+              block: 39556,
+              editMode: true,
+              params: {
+                wrapper_show: false,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.content, result.active)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlockContent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-list.md
+++ b/api-reference/landing/block/methods/landing-block-get-list.md
@@ -102,29 +102,106 @@
       "https://**put.your-domain-here**/rest/landing.block.getlist.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getlist',
-    		{
-    			lid: 4858,
-    			params: {
-    				edit_mode: true,
-    				get_content: true
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each LandingBlock returned in result[]
+    type LandingBlock = {
+      id: number
+      lid: number
+      code: string
+      name: string
+      active: boolean
+      meta: Record<string, string>
+      content?: string
+      css?: string[]
+      js?: string[]
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // landing.block.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<LandingBlock[]>({
+        method: 'landing.block.getlist',
+        params: {
+          lid: 4858,
+          params: {
+            edit_mode: true,
+            get_content: true,
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Blocks on page:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlockList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.block.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getlist',
+            params: {
+              lid: 4858,
+              params: {
+                edit_mode: true,
+                get_content: true,
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Blocks on page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlockList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-manifest-file.md
+++ b/api-reference/landing/block/methods/landing-block-get-manifest-file.md
@@ -63,25 +63,84 @@
       "https://**put.your-domain-here**/rest/landing.block.getmanifestfile.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getmanifestfile',
-    		{
-    			code: '01.big_with_text'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ManifestFileResult = {
+      block?: Record<string, unknown>
+      cards?: Record<string, unknown>
+      nodes?: Record<string, unknown>
+      style?: Record<string, unknown>
+      attrs?: Record<string, unknown>
+      assets?: Record<string, unknown>
+      menu?: Record<string, unknown>
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ManifestFileResult>({
+        method: 'landing.block.getmanifestfile',
+        params: {
+          code: '01.big_with_text',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.block, result.nodes)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getManifestFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getmanifestfile',
+            params: {
+              code: '01.big_with_text',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.block, result.nodes)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getManifestFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-manifest.md
+++ b/api-reference/landing/block/methods/landing-block-get-manifest.md
@@ -88,29 +88,108 @@
       "https://**put.your-domain-here**/rest/landing.block.getmanifest.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getmanifest',
-    		{
-    			lid: 4858,
-    			block: 39556,
-    			params: {
-    				edit_mode: true
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetManifestResult = {
+      block: {
+        name: string
+        section: string[]
+        dynamic: boolean
+        subtype?: string | string[]
+      }
+      nodes: Record<string, unknown>
+      style: Record<string, unknown>
+      assets: {
+        css: string[]
+        js: string[]
+        ext: string[]
+        class: string[]
+        callbacks: unknown[]
+      }
+      timestamp: number
+      callbacks: Record<string, unknown>
+      attrs: Record<string, unknown>
+      cards: unknown[]
+      menu: unknown[]
+      namespace: string
+      code: string
+      preview: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetManifestResult>({
+        method: 'landing.block.getmanifest',
+        params: {
+          lid: 4858,
+          block: 39556,
+          params: {
+            edit_mode: true,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.block.name, result.code, result.preview)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlockManifest() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getmanifest',
+            params: {
+              lid: 4858,
+              block: 39556,
+              params: {
+                edit_mode: true,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.block.name, result.code, result.preview)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlockManifest)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-get-repository.md
+++ b/api-reference/landing/block/methods/landing-block-get-repository.md
@@ -69,25 +69,105 @@
       "https://**put.your-domain-here**/rest/landing.block.getrepository.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.getrepository',
-    		{
-    			section: 'text'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type BlockItem = {
+      id: string | null
+      name: string
+      namespace: string
+      new: boolean
+      version: string | null
+      type: string[]
+      section: string | string[]
+      description: string | null
+      preview: string
+      restricted: boolean
+      repo_id: number | string | boolean
+      app_code: string | boolean
+      requires_updates: boolean
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RepositorySection = {
+      name: string
+      meta: Record<string, unknown> | unknown[]
+      new: boolean
+      type: string | string[] | null
+      specialType: string | null
+      separator: boolean
+      app_code: string | boolean
+      items: Record<string, BlockItem>
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<RepositorySection | false>({
+        method: 'landing.block.getrepository',
+        params: {
+          section: 'text',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        if (result !== false) {
+          console.info('Section name:', result.name, 'Blocks count:', Object.keys(result.items).length)
+        }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRepository() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.getrepository',
+            params: {
+              section: 'text',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          if (result !== false) {
+            console.info('Section name:', result.name, 'Blocks count:', Object.keys(result.items).length)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRepository)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-remove-card.md
+++ b/api-reference/landing/block/methods/landing-block-remove-card.md
@@ -89,27 +89,77 @@
       "https://**put.your-domain-here**/rest/landing.block.removecard.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.block.removecard',
-            {
-                lid: 351,
-                block: 6428,
-                selector: '.landing-block-card@0'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.removecard',
+        params: {
+          lid: 351,
+          block: 6428,
+          selector: '.landing-block-card@0',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Card removed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function removeBlockCard() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.removecard',
+            params: {
+              lid: 351,
+              block: 6428,
+              selector: '.landing-block-card@0',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Card removed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', removeBlockCard)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-update-attrs.md
+++ b/api-reference/landing/block/methods/landing-block-update-attrs.md
@@ -141,32 +141,87 @@
       "https://**put.your-domain-here**/rest/landing.block.updateattrs.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.updateattrs',
-    		{
-    			lid: 313,
-    			block: 6134,
-    			data: {
-    				'.bitrix24forms': {
-    					'data-b24form': '#crmFormInline45',
-    					'data-b24form-use-style': 'N'
-    				}
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.updateattrs',
+        params: {
+          lid: 313,
+          block: 6134,
+          data: {
+            '.bitrix24forms': {
+              'data-b24form': '#crmFormInline45',
+              'data-b24form-use-style': 'N',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Update attributes result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBlockAttrs() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.updateattrs',
+            params: {
+              lid: 313,
+              block: 6134,
+              data: {
+                '.bitrix24forms': {
+                  'data-b24form': '#crmFormInline45',
+                  'data-b24form-use-style': 'N',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Update attributes result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBlockAttrs)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-update-cards.md
+++ b/api-reference/landing/block/methods/landing-block-update-cards.md
@@ -202,46 +202,115 @@
       "https://**put.your-domain-here**/rest/landing.block.updateCards.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.updateCards',
-    		{
-    			lid: 311,
-    			block: 6058,
-    			data: {
-    				'.landing-block-card': {
-    					source: [
-    						{
-    							type: 'card',
-    							value: 0
-    						},
-    						{
-    							type: 'preset',
-    							value: 'preset_code'
-    						}
-    					],
-    					values: [
-    						{
-    							'.landing-block-node-title@0': 'Первая карточка',
-    							'.landing-block-node-title@1': 'Карточка из пресета'
-    						}
-    					]
-    				}
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.updateCards',
+        params: {
+          lid: 311,
+          block: 6058,
+          data: {
+            '.landing-block-card': {
+              source: [
+                {
+                  type: 'card',
+                  value: 0,
+                },
+                {
+                  type: 'preset',
+                  value: 'preset_code',
+                },
+              ],
+              values: [
+                {
+                  '.landing-block-node-title@0': 'First card',
+                  '.landing-block-node-title@1': 'Card from preset',
+                },
+              ],
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Cards updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBlockCards() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.updateCards',
+            params: {
+              lid: 311,
+              block: 6058,
+              data: {
+                '.landing-block-card': {
+                  source: [
+                    {
+                      type: 'card',
+                      value: 0,
+                    },
+                    {
+                      type: 'preset',
+                      value: 'preset_code',
+                    },
+                  ],
+                  values: [
+                    {
+                      '.landing-block-node-title@0': 'First card',
+                      '.landing-block-node-title@1': 'Card from preset',
+                    },
+                  ],
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Cards updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBlockCards)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-update-content.md
+++ b/api-reference/landing/block/methods/landing-block-update-content.md
@@ -87,28 +87,79 @@
       "https://**put.your-domain-here**/rest/landing.block.updatecontent.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.updatecontent',
-    		{
-    			lid: 311,
-    			block: 6058,
-    			content: '<section class="g-pt-60 g-pb-60"><div class="container"><h2 class="landing-block-node-title">Весенняя акция</h2><p class="landing-block-node-text" bxstyle="color:#1d1d1d;">Скидка 15% до конца месяца</p></div></section>',
-    			preventHistory: true
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info('Результат обновления блока:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean | null>({
+        method: 'landing.block.updatecontent',
+        params: {
+          lid: 311,
+          block: 6058,
+          content: '<section class="g-pt-60 g-pb-60"><div class="container"><h2 class="landing-block-node-title">Spring Sale</h2><p class="landing-block-node-text" bxstyle="color:#1d1d1d;">15% discount until the end of the month</p></div></section>',
+          preventHistory: true,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block content update result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBlockContent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.updatecontent',
+            params: {
+              lid: 311,
+              block: 6058,
+              content: '<section class="g-pt-60 g-pb-60"><div class="container"><h2 class="landing-block-node-title">Spring Sale</h2><p class="landing-block-node-text" bxstyle="color:#1d1d1d;">15% discount until the end of the month</p></div></section>',
+              preventHistory: true,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block content update result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBlockContent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-update-nodes.md
+++ b/api-reference/landing/block/methods/landing-block-update-nodes.md
@@ -178,43 +178,109 @@
       "https://**put.your-domain-here**/rest/landing.block.updatenodes.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.updatenodes',
-    		{
-    			lid: 311,
-    			block: 6058,
-    			data: {
-    				'.landing-block-node-text': 'Новый текст блока',
-    				'.landing-block-node-img': {
-    					src: 'https://cdn.bitrix24.site/bitrix/images/landing/business/1920x1280/img12.jpg',
-    					alt: 'Новый баннер'
-    				},
-    				'.landing-block-node-link': {
-    					text: 'Подробнее',
-    					href: 'https://www.bitrix24.ru',
-    					target: '_blank'
-    				},
-    				'.landing-block-node-icon': ['fa', 'fa-telegram'],
-    				'.landing-block-node-embed': {
-    					src: '//www.youtube.com/embed/q4d8g9Dn3ww?autoplay=1&controls=0&loop=1&mute=1&rel=0',
-    					source: 'https://www.youtube.com/watch?v=q4d8g9Dn3ww'
-    				}
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.updatenodes',
+        params: {
+          lid: 311,
+          block: 6058,
+          data: {
+            '.landing-block-node-text': 'New block text',
+            '.landing-block-node-img': {
+              src: 'https://cdn.bitrix24.site/bitrix/images/landing/business/1920x1280/img12.jpg',
+              alt: 'New banner',
+            },
+            '.landing-block-node-link': {
+              text: 'Learn more',
+              href: 'https://www.bitrix24.ru',
+              target: '_blank',
+            },
+            '.landing-block-node-icon': ['fa', 'fa-telegram'],
+            '.landing-block-node-embed': {
+              src: '//www.youtube.com/embed/q4d8g9Dn3ww?autoplay=1&controls=0&loop=1&mute=1&rel=0',
+              source: 'https://www.youtube.com/watch?v=q4d8g9Dn3ww',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block nodes updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBlockNodes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.updatenodes',
+            params: {
+              lid: 311,
+              block: 6058,
+              data: {
+                '.landing-block-node-text': 'New block text',
+                '.landing-block-node-img': {
+                  src: 'https://cdn.bitrix24.site/bitrix/images/landing/business/1920x1280/img12.jpg',
+                  alt: 'New banner',
+                },
+                '.landing-block-node-link': {
+                  text: 'Learn more',
+                  href: 'https://www.bitrix24.ru',
+                  target: '_blank',
+                },
+                '.landing-block-node-icon': ['fa', 'fa-telegram'],
+                '.landing-block-node-embed': {
+                  src: '//www.youtube.com/embed/q4d8g9Dn3ww?autoplay=1&controls=0&loop=1&mute=1&rel=0',
+                  source: 'https://www.youtube.com/watch?v=q4d8g9Dn3ww',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block nodes updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBlockNodes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-update-styles.md
+++ b/api-reference/landing/block/methods/landing-block-update-styles.md
@@ -165,42 +165,107 @@
       "https://**put.your-domain-here**/rest/landing.block.updateStyles.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.block.updateStyles',
-            {
-                lid: 313,
-                block: 6134,
-                data: {
-                    '.landing-block-node-text': {
-                        classList: [
-                            'landing-block-node-text',
-                            'g-color-white',
-                            'text-right'
-                        ],
-                        affect: [
-                            'text-align',
-                            'color'
-                        ],
-                        style: {
-                            'font-weight': '700'
-                        }
-                    }
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.block.updateStyles',
+        params: {
+          lid: 313,
+          block: 6134,
+          data: {
+            '.landing-block-node-text': {
+              classList: [
+                'landing-block-node-text',
+                'g-color-white',
+                'text-right',
+              ],
+              affect: [
+                'text-align',
+                'color',
+              ],
+              style: {
+                'font-weight': '700',
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Styles updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBlockStyles() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.updateStyles',
+            params: {
+              lid: 313,
+              block: 6134,
+              data: {
+                '.landing-block-node-text': {
+                  classList: [
+                    'landing-block-node-text',
+                    'g-color-white',
+                    'text-right',
+                  ],
+                  affect: [
+                    'text-align',
+                    'color',
+                  ],
+                  style: {
+                    'font-weight': '700',
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Styles updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBlockStyles)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/block/methods/landing-block-upload-file.md
+++ b/api-reference/landing/block/methods/landing-block-upload-file.md
@@ -128,30 +128,89 @@
       "https://**put.your-domain-here**/rest/landing.block.uploadfile.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.block.uploadfile',
-    		{
-    			block: 39556,
-    			picture: ['banner.png', '**base64_image_content**'],
-    			params: {
-    				width: 1200,
-    				height: 675
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type UploadFileResult = {
+      id: number
+      src: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UploadFileResult>({
+        method: 'landing.block.uploadfile',
+        params: {
+          block: 39556,
+          picture: ['banner.png', '**base64_image_content**'],
+          params: {
+            width: 1200,
+            height: 675,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.id, result.src)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function uploadFile() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.block.uploadfile',
+            params: {
+              block: 39556,
+              picture: ['banner.png', '**base64_image_content**'],
+              params: {
+                width: 1200,
+                height: 675,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.id, result.src)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', uploadFile)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/demos/landing-demos-get-list.md
+++ b/api-reference/landing/demos/landing-demos-get-list.md
@@ -184,29 +184,100 @@
       "https://**put.your-domain-here**/rest/landing.demos.getList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.demos.getList',
-    		{
-    			params: {
-    				select: ['ID', 'XML_ID', 'TITLE', 'TYPE', 'DATE_MODIFY'],
-    				filter: { ACTIVE: 'Y' },
-    				order: { ID: 'DESC' },
-    				group: ['TYPE']
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.info(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of each DemoItem returned in result[]
+    type DemoItem = {
+      ID: string
+      XML_ID: string
+      TITLE: string
+      TYPE: string
+      DATE_MODIFY: string
+      MANIFEST: object | boolean
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // landing.demos.getList returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<DemoItem[]>({
+        method: 'landing.demos.getList',
+        params: {
+          params: {
+            select: ['ID', 'XML_ID', 'TITLE', 'TYPE', 'DATE_MODIFY'],
+            filter: { ACTIVE: 'Y' },
+            order: { ID: 'DESC' },
+            group: ['TYPE'],
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Demo templates:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDemoList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.demos.getList',
+            params: {
+              params: {
+                select: ['ID', 'XML_ID', 'TITLE', 'TYPE', 'DATE_MODIFY'],
+                filter: { ACTIVE: 'Y' },
+                order: { ID: 'DESC' },
+                group: ['TYPE'],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Demo templates:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDemoList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/demos/landing-demos-get-page-list.md
+++ b/api-reference/landing/demos/landing-demos-get-page-list.md
@@ -91,27 +91,102 @@
       "https://**put.your-domain-here**/rest/landing.demos.getPageList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.demos.getPageList',
-    		{
-    			type: 'page',
-    			filter: {
-    				TYPE: 'PAGE'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.info(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PageTemplatesResult = Record<string, PageTemplate>
+
+    type PageTemplate = {
+      ID: string
+      XML_ID: string
+      TYPE: string[] | string
+      TITLE: string
+      ACTIVE: boolean
+      PUBLICATION: boolean
+      LOCK_DELETE: boolean
+      AVAILABLE: boolean
+      SINGLETON: boolean
+      SECTION: string[]
+      DESCRIPTION: string
+      PREVIEW: string
+      PREVIEW2X: string
+      PREVIEW3X: string
+      APP_CODE: string
+      REST: number
+      DATA: object
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<PageTemplatesResult>({
+        method: 'landing.demos.getPageList',
+        params: {
+          type: 'page',
+          filter: {
+            TYPE: 'PAGE',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Page templates:', Object.keys(result).length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPageList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.demos.getPageList',
+            params: {
+              type: 'page',
+              filter: {
+                TYPE: 'PAGE',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Page templates:', Object.keys(result).length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPageList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/demos/landing-demos-get-site-list.md
+++ b/api-reference/landing/demos/landing-demos-get-site-list.md
@@ -92,27 +92,102 @@
       "https://**put.your-domain-here**/rest/landing.demos.getSiteList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.demos.getSiteList',
-    		{
-    			type: 'page',
-    			filter: {
-    				TYPE: 'page'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.info(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SiteListResult = Record<string, SiteTemplate>
+
+    type SiteTemplate = {
+      ID: string,
+      XML_ID: string,
+      TYPE: string[] | string,
+      TITLE: string,
+      ACTIVE: boolean,
+      PUBLICATION: boolean,
+      LOCK_DELETE: boolean,
+      AVAILABLE: boolean,
+      SINGLETON: boolean,
+      SECTION: string[],
+      DESCRIPTION: string,
+      PREVIEW: string,
+      PREVIEW2X: string,
+      PREVIEW3X: string,
+      APP_CODE: string,
+      REST: number,
+      DATA: Record<string, unknown>,
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SiteListResult>({
+        method: 'landing.demos.getSiteList',
+        params: {
+          type: 'page',
+          filter: {
+            TYPE: 'page',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Site demo templates:', Object.keys(result))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSiteList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.demos.getSiteList',
+            params: {
+              type: 'page',
+              filter: {
+                TYPE: 'page',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Site demo templates:', Object.keys(result))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSiteList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/demos/landing-demos-register.md
+++ b/api-reference/landing/demos/landing-demos-register.md
@@ -299,68 +299,157 @@
       "https://**put.your-domain-here**/rest/landing.demos.register.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const data = {
-    		charset: 'UTF-8',
-    		code: 'ftmlt',
-    		site_code: '/ftmlt/',
-    		name: 'Бизнес',
-    		description: null,
-    		type: 'page',
-    		fields: {
-    			TITLE: 'Бизнес',
-    			LANDING_ID_INDEX: '0',
-    			LANDING_ID_404: '0',
-    			ADDITIONAL_FIELDS: {}
-    		},
-    		folders: [],
-    		items: {
-    			ftmlt: {
-    				old_id: '16',
-    				code: 'ftmlt',
-    				name: 'Бизнес',
-    				description: null,
-    				preview: '',
-    				preview2x: '',
-    				preview3x: '',
-    				preview_url: '',
-    				show_in_list: 'Y',
-    				type: 'page',
-    				version: 3,
-    				fields: {
-    					TITLE: 'Бизнес'
-    				},
-    				layout: [],
-    				items: {}
-    			}
-    		},
-    		layout: [],
-    		preview: '',
-    		preview2x: '',
-    		preview3x: '',
-    		preview_url: '',
-    		show_in_list: 'Y',
-    		syspages: [],
-    		version: 3
-    	};
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const response = await $b24.callMethod(
-    		'landing.demos.register',
-    		{
-    			data
-    		}
-    	);
+    declare const $b24: B24Frame
 
-    	console.info(response.getData().result);
+    try {
+      const response = await $b24.actions.v2.call.make<number[]>({
+        method: 'landing.demos.register',
+        params: {
+          data: {
+            charset: 'UTF-8',
+            code: 'ftmlt',
+            site_code: '/ftmlt/',
+            name: 'Business',
+            description: null,
+            type: 'page',
+            fields: {
+              TITLE: 'Business',
+              LANDING_ID_INDEX: '0',
+              LANDING_ID_404: '0',
+              ADDITIONAL_FIELDS: {},
+            },
+            folders: [],
+            items: {
+              ftmlt: {
+                old_id: '16',
+                code: 'ftmlt',
+                name: 'Business',
+                description: null,
+                preview: '',
+                preview2x: '',
+                preview3x: '',
+                preview_url: '',
+                show_in_list: 'Y',
+                type: 'page',
+                version: 3,
+                fields: {
+                  TITLE: 'Business',
+                },
+                layout: [],
+                items: {},
+              },
+            },
+            layout: [],
+            preview: '',
+            preview2x: '',
+            preview3x: '',
+            preview_url: '',
+            show_in_list: 'Y',
+            syspages: [],
+            version: 3,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Registered template IDs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerDemo() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.demos.register',
+            params: {
+              data: {
+                charset: 'UTF-8',
+                code: 'ftmlt',
+                site_code: '/ftmlt/',
+                name: 'Business',
+                description: null,
+                type: 'page',
+                fields: {
+                  TITLE: 'Business',
+                  LANDING_ID_INDEX: '0',
+                  LANDING_ID_404: '0',
+                  ADDITIONAL_FIELDS: {},
+                },
+                folders: [],
+                items: {
+                  ftmlt: {
+                    old_id: '16',
+                    code: 'ftmlt',
+                    name: 'Business',
+                    description: null,
+                    preview: '',
+                    preview2x: '',
+                    preview3x: '',
+                    preview_url: '',
+                    show_in_list: 'Y',
+                    type: 'page',
+                    version: 3,
+                    fields: {
+                      TITLE: 'Business',
+                    },
+                    layout: [],
+                    items: {},
+                  },
+                },
+                layout: [],
+                preview: '',
+                preview2x: '',
+                preview3x: '',
+                preview_url: '',
+                show_in_list: 'Y',
+                syspages: [],
+                version: 3,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Registered template IDs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerDemo)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/demos/landing-demos-unregister.md
+++ b/api-reference/landing/demos/landing-demos-unregister.md
@@ -60,25 +60,73 @@
       "https://**put.your-domain-here**/rest/landing.demos.unregister.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.demos.unregister',
-    		{
-    			code: 'ftmlt'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.demos.unregister',
+        params: {
+          code: 'ftmlt',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unregister result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unregisterLandingDemo() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.demos.unregister',
+            params: {
+              code: 'ftmlt',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unregister result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unregisterLandingDemo)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/block.md
+++ b/api-reference/landing/embedding/block.md
@@ -111,32 +111,81 @@ Array
       https://**put_your_bitrix24_address**/rest/landing.repo.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.repo.bind',
-            {
-                fields: {
-                    PLACEMENT: 'LANDING_BLOCK_04.1.one_col_fix_with_title',
-                    PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-block-handler.php',
-                    TITLE: 'Мой виджет для блока'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        if (result.error())
-            console.error(result.error());
-        else
-            console.info(result.data());
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repo.bind',
+        params: {
+          fields: {
+            PLACEMENT: 'LANDING_BLOCK_04.1.one_col_fix_with_title',
+            PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-block-handler.php',
+            TITLE: 'My widget for block',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Binding result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindLandingBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.bind',
+            params: {
+              fields: {
+                PLACEMENT: 'LANDING_BLOCK_04.1.one_col_fix_with_title',
+                PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-block-handler.php',
+                TITLE: 'My widget for block',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Binding result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindLandingBlock)
+    </script>
     ```
 
 - PHP
@@ -237,32 +286,81 @@ Array
       https://**put_your_bitrix24_address**/rest/landing.repo.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.repo.bind',
-            {
-                fields: {
-                    PLACEMENT: 'LANDING_BLOCK_*',
-                    PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-block-handler.php',
-                    TITLE: 'Мой виджет для блока'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        if (result.error())
-            console.error(result.error());
-        else
-            console.info(result.data());
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repo.bind',
+        params: {
+          fields: {
+            PLACEMENT: 'LANDING_BLOCK_*',
+            PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-block-handler.php',
+            TITLE: 'My widget for block',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Binding result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindAllLandingBlocks() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.bind',
+            params: {
+              fields: {
+                PLACEMENT: 'LANDING_BLOCK_*',
+                PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-block-handler.php',
+                TITLE: 'My widget for block',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Binding result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindAllLandingBlocks)
+    </script>
     ```
 
 - PHP
@@ -356,27 +454,79 @@ Array
       "https://**put_your_bitrix24_address**/rest/placement.call?auth=**put_access_token_here**"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        await $b24.callMethod(
-            'placement.call',
-            {
-                type: 'refreshBlock',
-                params: {
-                    id: 123
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        console.log('Блок успешно обновлен');
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'placement.call',
+        params: {
+          type: 'refreshBlock',
+          params: {
+            id: 123,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block refreshed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function refreshBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'placement.call',
+            params: {
+              type: 'refreshBlock',
+              params: {
+                id: 123,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block refreshed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', refreshBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/knowledge-base/landing-site-binding-to-group.md
+++ b/api-reference/landing/embedding/knowledge-base/landing-site-binding-to-group.md
@@ -71,26 +71,75 @@
       "https://**put.your-domain-here**/rest/landing.site.bindingToGroup.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.bindingToGroup',
-    		{
-    			id: 32,
-    			groupId: 174
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.bindingToGroup',
+        params: {
+          id: 32,
+          groupId: 174,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Binding result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindKnowledgeBaseToGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.bindingToGroup',
+            params: {
+              id: 32,
+              groupId: 174,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Binding result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindKnowledgeBaseToGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/knowledge-base/landing-site-binding-to-menu.md
+++ b/api-reference/landing/embedding/knowledge-base/landing-site-binding-to-menu.md
@@ -69,26 +69,75 @@
       "https://**put.your-domain-here**/rest/landing.site.bindingToMenu.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.bindingToMenu',
-    		{
-    			id: 31,
-    			menuCode: 'crm_switcher:deal'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.bindingToMenu',
+        params: {
+          id: 31,
+          menuCode: 'crm_switcher:deal',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Binding result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindSiteToMenu() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.bindingToMenu',
+            params: {
+              id: 31,
+              menuCode: 'crm_switcher:deal',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Binding result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindSiteToMenu)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/knowledge-base/landing-site-get-group-bindings.md
+++ b/api-reference/landing/embedding/knowledge-base/landing-site-get-group-bindings.md
@@ -62,25 +62,82 @@
       "https://**put.your-domain-here**/rest/landing.site.getGroupBindings.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getGroupBindings',
-    		{
-    			groupId: 174
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each GroupBindingItem returned in result[]
+    type GroupBindingItem = {
+      ENTITY_ID: string
+      ENTITY_TYPE: string
+      BINDING_ID: string
+      TITLE: string
+      PUBLIC_URL: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GroupBindingItem[]>({
+        method: 'landing.site.getGroupBindings',
+        params: {
+          groupId: 174,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Group bindings count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getGroupBindings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getGroupBindings',
+            params: {
+              groupId: 174,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Group bindings count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getGroupBindings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/knowledge-base/landing-site-get-menu-bindings.md
+++ b/api-reference/landing/embedding/knowledge-base/landing-site-get-menu-bindings.md
@@ -64,25 +64,82 @@
       "https://**put.your-domain-here**/rest/landing.site.getMenuBindings.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getMenuBindings',
-    		{
-    			menuCode: 'crm_switcher:deal'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each MenuBinding returned in result[]
+    type MenuBinding = {
+      ENTITY_ID: string | number
+      ENTITY_TYPE: string
+      BINDING_ID: string
+      TITLE: string
+      PUBLIC_URL: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MenuBinding[]>({
+        method: 'landing.site.getMenuBindings',
+        params: {
+          menuCode: 'crm_switcher:deal',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Menu bindings count:', result.length, 'First binding:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMenuBindings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getMenuBindings',
+            params: {
+              menuCode: 'crm_switcher:deal',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Menu bindings count:', result.length, 'First binding:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMenuBindings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/knowledge-base/landing-site-unbinding-from-group.md
+++ b/api-reference/landing/embedding/knowledge-base/landing-site-unbinding-from-group.md
@@ -71,26 +71,75 @@
       "https://**put.your-domain-here**/rest/landing.site.unbindingFromGroup.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.unbindingFromGroup',
-    		{
-    			id: 32,
-    			groupId: 174
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.unbindingFromGroup',
+        params: {
+          id: 32,
+          groupId: 174,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unbinding result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unbindSiteFromGroup() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.unbindingFromGroup',
+            params: {
+              id: 32,
+              groupId: 174,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unbinding result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unbindSiteFromGroup)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/knowledge-base/landing-site-unbinding-from-menu.md
+++ b/api-reference/landing/embedding/knowledge-base/landing-site-unbinding-from-menu.md
@@ -69,26 +69,75 @@
       "https://**put.your-domain-here**/rest/landing.site.unbindingFromMenu.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.unbindingFromMenu',
-    		{
-    			id: 31,
-    			menuCode: 'crm_switcher:deal'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.unbindingFromMenu',
+        params: {
+          id: 31,
+          menuCode: 'crm_switcher:deal',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unbindSiteFromMenu() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.unbindingFromMenu',
+            params: {
+              id: 31,
+              menuCode: 'crm_switcher:deal',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unbindSiteFromMenu)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/landing-repo-unbind.md
+++ b/api-reference/landing/embedding/landing-repo-unbind.md
@@ -61,26 +61,75 @@
       "https://**put.your-domain-here**/rest/landing.repo.unbind.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.repo.unbind',
-            {
-                code: 'LANDING_SETTINGS',
-                handler: 'https://your-domain.com/widgets/landing-settings-handler.php'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repo.unbind',
+        params: {
+          code: 'LANDING_SETTINGS',
+          handler: 'https://your-domain.com/widgets/landing-settings-handler.php',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unbind result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unbindLandingRepo() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.unbind',
+            params: {
+              code: 'LANDING_SETTINGS',
+              handler: 'https://your-domain.com/widgets/landing-settings-handler.php',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unbind result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unbindLandingRepo)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/embedding/settings.md
+++ b/api-reference/landing/embedding/settings.md
@@ -105,32 +105,81 @@ Array
       https://**put_your_bitrix24_address**/rest/landing.repo.bind
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.repo.bind',
-            {
-                fields: {
-                    PLACEMENT: 'LANDING_SETTINGS',
-                    PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-settings-handler.php',
-                    TITLE: 'Мои настройки'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        if (result.error())
-            console.error(result.error());
-        else
-            console.info(result.data());
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repo.bind',
+        params: {
+          fields: {
+            PLACEMENT: 'LANDING_SETTINGS',
+            PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-settings-handler.php',
+            TITLE: 'My Settings',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Landing settings bound:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function bindLandingSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.bind',
+            params: {
+              fields: {
+                PLACEMENT: 'LANDING_SETTINGS',
+                PLACEMENT_HANDLER: 'https://your-domain.com/widgets/landing-settings-handler.php',
+                TITLE: 'My Settings',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Landing settings bound:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', bindLandingSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-add-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-add-block.md
@@ -115,30 +115,83 @@
       "https://**put.your-domain-here**/rest/landing.landing.addblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.addblock',
-    		{
-    			lid: 351,
-    			fields: {
-    				CODE: '02.three_cols_big_1',
-    				AFTER_ID: 6428,
-    				ACTIVE: 'Y'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.addblock',
+        params: {
+          lid: 351,
+          fields: {
+            CODE: '02.three_cols_big_1',
+            AFTER_ID: 6428,
+            ACTIVE: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New block ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.addblock',
+            params: {
+              lid: 351,
+              fields: {
+                CODE: '02.three_cols_big_1',
+                AFTER_ID: 6428,
+                ACTIVE: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New block ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-copy-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-copy-block.md
@@ -92,30 +92,106 @@
       "https://**put.your-domain-here**/rest/landing.landing.copyblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.copyblock',
-            {
-                lid: 351,
-                block: 6428,
-                params: {
-                    AFTER_ID: 6429,
-                    RETURN_CONTENT: 'Y'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CopyBlockResult = {
+      result: boolean
+      content: {
+        id: number
+        sections: string
+        active: boolean
+        access: string
+        anchor: string
+        php: boolean
+        designed: boolean
+        repoId: number | null
+        content: string
+        content_ext: string
+        css: string[]
+        js: string[]
+        assetStrings: string[]
+        lang: string[] | Record<string, string>
+        manifest: Record<string, unknown>
+        dynamicParams: unknown[]
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CopyBlockResult>({
+        method: 'landing.landing.copyblock',
+        params: {
+          lid: 351,
+          block: 6428,
+          params: {
+            AFTER_ID: 6429,
+            RETURN_CONTENT: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.result, result.content.id, result.content.anchor)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function copyBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.copyblock',
+            params: {
+              lid: 351,
+              block: 6428,
+              params: {
+                AFTER_ID: 6429,
+                RETURN_CONTENT: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.result, result.content.id, result.content.anchor)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', copyBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-delete-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-delete-block.md
@@ -75,26 +75,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.deleteblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.deleteblock',
-            {
-                lid: 351,
-                block: 6428
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.deleteblock',
+        params: {
+          lid: 351,
+          block: 6428,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.deleteblock',
+            params: {
+              lid: 351,
+              block: 6428,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-down-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-down-block.md
@@ -71,26 +71,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.downblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.downblock',
-            {
-                lid: 351,
-                block: 6428
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.downblock',
+        params: {
+          lid: 351,
+          block: 6428,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block moved down:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveBlockDown() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.downblock',
+            params: {
+              lid: 351,
+              block: 6428,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block moved down:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveBlockDown)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-favorite-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-favorite-block.md
@@ -110,32 +110,87 @@
       "https://**put.your-domain-here**/rest/landing.landing.favoriteBlock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.favoriteBlock',
-            {
-                lid: 351,
-                block: 6428,
-                meta: {
-                    name: 'Блок с преимуществами',
-                    section: ['text', 'features'],
-                    preview: 918273,
-                    tpl_code: 'bitrix24'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info('ID сохраненной копии:', result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.favoriteBlock',
+        params: {
+          lid: 351,
+          block: 6428,
+          meta: {
+            name: 'Block with advantages',
+            section: ['text', 'features'],
+            preview: 918273,
+            tpl_code: 'bitrix24',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Saved block copy ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function saveFavoriteBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.favoriteBlock',
+            params: {
+              lid: 351,
+              block: 6428,
+              meta: {
+                name: 'Block with advantages',
+                section: ['text', 'features'],
+                preview: 918273,
+                tpl_code: 'bitrix24',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Saved block copy ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', saveFavoriteBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-hide-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-hide-block.md
@@ -69,26 +69,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.hideblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.hideblock',
-            {
-                lid: 351,
-                block: 6428
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.hideblock',
+        params: {
+          lid: 351,
+          block: 6428,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block hidden:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function hideBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.hideblock',
+            params: {
+              lid: 351,
+              block: 6428,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block hidden:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', hideBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-mark-deleted-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-mark-deleted-block.md
@@ -75,26 +75,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.markdeletedblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.markdeletedblock',
-            {
-                lid: 351,
-                block: 6428
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.markdeletedblock',
+        params: {
+          lid: 351,
+          block: 6428,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block marked as deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markDeletedBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.markdeletedblock',
+            params: {
+              lid: 351,
+              block: 6428,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block marked as deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markDeletedBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-mark-undeleted-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-mark-undeleted-block.md
@@ -73,26 +73,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.markundeletedblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.markundeletedblock',
-            {
-                lid: 627,
-                block: 11923
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.markundeletedblock',
+        params: {
+          lid: 627,
+          block: 11923,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Mark undeleted block result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markUndeletedBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.markundeletedblock',
+            params: {
+              lid: 627,
+              block: 11923,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Mark undeleted block result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markUndeletedBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-move-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-move-block.md
@@ -94,30 +94,107 @@
       "https://**put.your-domain-here**/rest/landing.landing.moveblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.moveblock',
-            {
-                lid: 351,
-                block: 26723,
-                params: {
-                    AFTER_ID: 6429,
-                    RETURN_CONTENT: 'Y'
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveBlockResult = {
+      result: boolean
+      content: {
+        id: number
+        sections: string
+        active: boolean
+        access: string
+        anchor: string
+        php: boolean
+        designed: boolean
+        repoId: number | null
+        content: string
+        content_ext: string
+        css: string[]
+        js: string[]
+        assetStrings: string[]
+        lang: Record<string, string> | string[]
+        manifest: Record<string, unknown>
+        dynamicParams: unknown[]
+        requiredUserAction?: unknown[]
+      }
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MoveBlockResult>({
+        method: 'landing.landing.moveblock',
+        params: {
+          lid: 351,
+          block: 26723,
+          params: {
+            AFTER_ID: 6429,
+            RETURN_CONTENT: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Moved block id:', result.content.id, 'success:', result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.moveblock',
+            params: {
+              lid: 351,
+              block: 26723,
+              params: {
+                AFTER_ID: 6429,
+                RETURN_CONTENT: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Moved block id:', result.content.id, 'success:', result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-show-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-show-block.md
@@ -73,26 +73,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.showblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.showblock',
-            {
-                lid: 351,
-                block: 6428
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.showblock',
+        params: {
+          lid: 351,
+          block: 6428,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block shown successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function showBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.showblock',
+            params: {
+              lid: 351,
+              block: 6428,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block shown successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', showBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-unfavorite-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-unfavorite-block.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.unFavoriteBlock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.unFavoriteBlock',
-            {
-                blockId: 28619
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.unFavoriteBlock',
+        params: {
+          blockId: 28619,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unfavorited block, success:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unfavoriteBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.unFavoriteBlock',
+            params: {
+              blockId: 28619,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unfavorited block, success:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unfavoriteBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/block-methods/landing-landing-up-block.md
+++ b/api-reference/landing/page/block-methods/landing-landing-up-block.md
@@ -69,26 +69,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.upblock.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.upblock',
-            {
-                lid: 351,
-                block: 6428
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.upblock',
+        params: {
+          lid: 351,
+          block: 6428,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block moved up successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveBlockUp() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.upblock',
+            params: {
+              lid: 351,
+              block: 6428,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block moved up successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveBlockUp)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-add-by-template.md
+++ b/api-reference/landing/page/methods/landing-landing-add-by-template.md
@@ -179,31 +179,85 @@
       "https://**put.your-domain-here**/rest/landing.landing.addByTemplate.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.addByTemplate',
-    		{
-    			siteId: 157,
-    			code: 'krayt.monotovar@KraytPetShop',
-    			fields: {
-    				TITLE: 'Весенняя акция',
-    				DESCRIPTION: 'SEO-описание страницы акции',
-    				FOLDER_ID: 95
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.addByTemplate',
+        params: {
+          siteId: 157,
+          code: 'krayt.monotovar@KraytPetShop',
+          fields: {
+            TITLE: 'Spring sale',
+            DESCRIPTION: 'SEO page description',
+            FOLDER_ID: 95,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created page ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addLandingByTemplate() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.addByTemplate',
+            params: {
+              siteId: 157,
+              code: 'krayt.monotovar@KraytPetShop',
+              fields: {
+                TITLE: 'Spring sale',
+                DESCRIPTION: 'SEO page description',
+                FOLDER_ID: 95,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created page ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addLandingByTemplate)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-add.md
+++ b/api-reference/landing/page/methods/landing-landing-add.md
@@ -120,33 +120,89 @@
       "https://**put.your-domain-here**/rest/landing.landing.add.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.add',
-    		{
-    			fields: {
-    				TITLE: 'Весенняя акция',
-    				SITE_ID: 292,
-    				CODE: 'spring-sale',
-    				DESCRIPTION: 'Страница для сезонной акции',
-    				ADDITIONAL_FIELDS: {
-    					THEME_CODE: 'wedding'
-    				}
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.add',
+        params: {
+          fields: {
+            TITLE: 'Spring Sale',
+            SITE_ID: 292,
+            CODE: 'spring-sale',
+            DESCRIPTION: 'Page for seasonal promotion',
+            ADDITIONAL_FIELDS: {
+              THEME_CODE: 'wedding',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created landing page ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addLandingPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.add',
+            params: {
+              fields: {
+                TITLE: 'Spring Sale',
+                SITE_ID: 292,
+                CODE: 'spring-sale',
+                DESCRIPTION: 'Page for seasonal promotion',
+                ADDITIONAL_FIELDS: {
+                  THEME_CODE: 'wedding',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created landing page ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addLandingPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-copy.md
+++ b/api-reference/landing/page/methods/landing-landing-copy.md
@@ -80,27 +80,77 @@
       "https://**put.your-domain-here**/rest/landing.landing.copy.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.copy',
-    		{
-    			lid: 1688,
-    			toSiteId: 305,
-    			toFolderId: 95
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.copy',
+        params: {
+          lid: 1688,
+          toSiteId: 305,
+          toFolderId: 95,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('New page ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function copyLandingPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.copy',
+            params: {
+              lid: 1688,
+              toSiteId: 305,
+              toFolderId: 95,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('New page ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', copyLandingPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-delete.md
+++ b/api-reference/landing/page/methods/landing-landing-delete.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.delete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.delete',
-    		{
-    			lid: 350
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.delete',
+        params: {
+          lid: 350,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Page deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteLanding() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.delete',
+            params: {
+              lid: 350,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Page deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteLanding)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-get-additional-fields.md
+++ b/api-reference/landing/page/methods/landing-landing-get-additional-fields.md
@@ -61,25 +61,76 @@
       "https://**put.your-domain-here**/rest/landing.landing.getadditionalfields.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.getadditionalfields',
-            {
-                lid: 349
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AdditionalFieldsResult = Record<string, string | number | boolean | string[]>
+
+    try {
+      const response = await $b24.actions.v2.call.make<AdditionalFieldsResult>({
+        method: 'landing.landing.getadditionalfields',
+        params: {
+          lid: 349,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Additional fields:', Object.keys(result).length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAdditionalFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.getadditionalfields',
+            params: {
+              lid: 349,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Additional fields:', Object.keys(result).length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAdditionalFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-get-list.md
+++ b/api-reference/landing/page/methods/landing-landing-get-list.md
@@ -130,42 +130,131 @@
       "https://**put.your-domain-here**/rest/landing.landing.getList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.getList',
-    		{
-    			params: {
-    				select: [
-    					'ID',
-    					'TITLE',
-    					'SITE_ID',
-    					'DATE_MODIFY'
-    				],
-    				filter: {
-    					SITE_ID: 205,
-    					'=DELETED': 'N'
-    				},
-    				order: {
-    					ID: 'DESC'
-    				},
-    				get_urls: true,
-    				get_preview: true,
-    				check_area: true
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData();
-    	console.info(result.result);
+    declare const $b24: B24Frame
+
+    // Shape of each LandingItem returned in result[]
+    type LandingItem = {
+      ID: string
+      TITLE: string
+      SITE_ID: string
+      DATE_MODIFY: string
+      DOMAIN_ID: string | null
+      PUBLIC_URL?: string | null
+      PREVIEW?: string | null
+      IS_AREA?: boolean
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // landing.landing.getList returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<LandingItem[]>({
+        method: 'landing.landing.getList',
+        params: {
+          params: {
+            select: [
+              'ID',
+              'TITLE',
+              'SITE_ID',
+              'DATE_MODIFY',
+            ],
+            filter: {
+              SITE_ID: 205,
+              '=DELETED': 'N',
+            },
+            order: {
+              ID: 'DESC',
+            },
+            get_urls: true,
+            get_preview: true,
+            check_area: true,
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pages count:', result.length, 'First page:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLandingList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.landing.getList returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.getList',
+            params: {
+              params: {
+                select: [
+                  'ID',
+                  'TITLE',
+                  'SITE_ID',
+                  'DATE_MODIFY',
+                ],
+                filter: {
+                  SITE_ID: 205,
+                  '=DELETED': 'N',
+                },
+                order: {
+                  ID: 'DESC',
+                },
+                get_urls: true,
+                get_preview: true,
+                check_area: true,
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pages count:', result.length, 'First page:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLandingList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-get-preview.md
+++ b/api-reference/landing/page/methods/landing-landing-get-preview.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.getpreview.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.getpreview',
-    		{
-    			lid: 351
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'landing.landing.getpreview',
+        params: {
+          lid: 351,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Preview URL:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLandingPreview() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.getpreview',
+            params: {
+              lid: 351,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Preview URL:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLandingPreview)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-get-public-url.md
+++ b/api-reference/landing/page/methods/landing-landing-get-public-url.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.getpublicurl.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.landing.getpublicurl',
-            {
-                lid: 351
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'landing.landing.getpublicurl',
+        params: {
+          lid: 351,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLandingPublicUrl() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.getpublicurl',
+            params: {
+              lid: 351,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLandingPublicUrl)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-mark-delete.md
+++ b/api-reference/landing/page/methods/landing-landing-mark-delete.md
@@ -57,25 +57,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.markDelete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.markDelete',
-    		{
-    			lid: 350
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.markDelete',
+        params: {
+          lid: 350,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Marked page ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markLandingDelete() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.markDelete',
+            params: {
+              lid: 350,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Marked page ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markLandingDelete)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-mark-undelete.md
+++ b/api-reference/landing/page/methods/landing-landing-mark-undelete.md
@@ -58,25 +58,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.markUnDelete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.markUnDelete',
-    		{
-    			lid: 2227
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.landing.markUnDelete',
+        params: {
+          lid: 2227,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Restored landing page ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function restoreLandingPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.markUnDelete',
+            params: {
+              lid: 2227,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Restored landing page ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', restoreLandingPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-move.md
+++ b/api-reference/landing/page/methods/landing-landing-move.md
@@ -79,27 +79,77 @@
       "https://**put.your-domain-here**/rest/landing.landing.move.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.move',
-    		{
-    			lid: 2227,
-    			toSiteId: 157,
-    			toFolderId: 95
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.move',
+        params: {
+          lid: 2227,
+          toSiteId: 157,
+          toFolderId: 95,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Page moved successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveLandingPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.move',
+            params: {
+              lid: 2227,
+              toSiteId: 157,
+              toFolderId: 95,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Page moved successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveLandingPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-publication.md
+++ b/api-reference/landing/page/methods/landing-landing-publication.md
@@ -65,25 +65,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.publication.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.publication',
-    		{
-    			lid: 351
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.publication',
+        params: {
+          lid: 351,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Publication result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function publishLandingPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.publication',
+            params: {
+              lid: 351,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Publication result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', publishLandingPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-remove-entities.md
+++ b/api-reference/landing/page/methods/landing-landing-remove-entities.md
@@ -126,38 +126,99 @@
       "https://**put.your-domain-here**/rest/landing.landing.removeEntities.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.removeEntities',
-    		{
-    			lid: 648,
-    			data: {
-    				blocks: [12167, 123],
-    				images: [
-    					{
-    						block: 12269,
-    						image: 6866
-    					},
-    					{
-    						block: 12268,
-    						image: 6861
-    					}
-    				]
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.removeEntities',
+        params: {
+          lid: 648,
+          data: {
+            blocks: [12167, 123],
+            images: [
+              {
+                block: 12269,
+                image: 6866,
+              },
+              {
+                block: 12268,
+                image: 6861,
+              },
+            ],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('removeEntities result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function removeEntities() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.removeEntities',
+            params: {
+              lid: 648,
+              data: {
+                blocks: [12167, 123],
+                images: [
+                  {
+                    block: 12269,
+                    image: 6866,
+                  },
+                  {
+                    block: 12268,
+                    image: 6861,
+                  },
+                ],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('removeEntities result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', removeEntities)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-resolve-id-by-public-url.md
+++ b/api-reference/landing/page/methods/landing-landing-resolve-id-by-public-url.md
@@ -67,26 +67,75 @@
       "https://**put.your-domain-here**/rest/landing.landing.resolveIdByPublicUrl.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.resolveIdByPublicUrl',
-    		{
-    			landingUrl: '/catalog/sale/',
-    			siteId: 1817
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number | null>({
+        method: 'landing.landing.resolveIdByPublicUrl',
+        params: {
+          landingUrl: '/catalog/sale/',
+          siteId: 1817,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Resolved page ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function resolveLandingId() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.resolveIdByPublicUrl',
+            params: {
+              landingUrl: '/catalog/sale/',
+              siteId: 1817,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Resolved page ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', resolveLandingId)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-unpublic.md
+++ b/api-reference/landing/page/methods/landing-landing-unpublic.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.landing.unpublic.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.unpublic',
-    		{
-    			lid: 351
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.unpublic',
+        params: {
+          lid: 351,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Page unpublished:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unpublicLanding() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.unpublic',
+            params: {
+              lid: 351,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Page unpublished:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unpublicLanding)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/methods/landing-landing-update.md
+++ b/api-reference/landing/page/methods/landing-landing-update.md
@@ -121,31 +121,85 @@
       "https://**put.your-domain-here**/rest/landing.landing.update.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.landing.update',
-    		{
-    			lid: 349,
-    			fields: {
-    				TITLE: 'Весенняя акция 2026',
-    				CODE: 'spring-sale-2026',
-    				DESCRIPTION: 'Обновленное описание страницы акции',
-    				XML_ID: 'promo-2026-landing'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.landing.update',
+        params: {
+          lid: 349,
+          fields: {
+            TITLE: 'Spring Promo 2026',
+            CODE: 'spring-sale-2026',
+            DESCRIPTION: 'Updated promo page description',
+            XML_ID: 'promo-2026-landing',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Page updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateLanding() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.landing.update',
+            params: {
+              lid: 349,
+              fields: {
+                TITLE: 'Spring Promo 2026',
+                CODE: 'spring-sale-2026',
+                DESCRIPTION: 'Updated promo page description',
+                XML_ID: 'promo-2026-landing',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Page updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateLanding)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/special-pages/landing-syspage-delete-for-landing.md
+++ b/api-reference/landing/page/special-pages/landing-syspage-delete-for-landing.md
@@ -59,25 +59,73 @@
       "https://**put.your-domain-here**/rest/landing.syspage.deleteForLanding.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.syspage.deleteForLanding',
-    		{
-    			id: 8593
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.syspage.deleteForLanding',
+        params: {
+          id: 8593,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bindings deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteForLanding() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.syspage.deleteForLanding',
+            params: {
+              id: 8593,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bindings deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteForLanding)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/special-pages/landing-syspage-delete-for-site.md
+++ b/api-reference/landing/page/special-pages/landing-syspage-delete-for-site.md
@@ -59,25 +59,73 @@
       "https://**put.your-domain-here**/rest/landing.syspage.deleteForSite.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.syspage.deleteForSite',
-    		{
-    			id: 1390
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.syspage.deleteForSite',
+        params: {
+          id: 1390,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Bindings deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSyspageForSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.syspage.deleteForSite',
+            params: {
+              id: 1390,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Bindings deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSyspageForSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/special-pages/landing-syspage-get-special-page.md
+++ b/api-reference/landing/page/special-pages/landing-syspage-get-special-page.md
@@ -112,29 +112,81 @@ https://b24-test.bitrix24.shop/personalnyyrazdel/?SECTION=private&utm_source=new
       "https://**put.your-domain-here**/rest/landing.syspage.getSpecialPage.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.syspage.getSpecialPage',
-    		{
-    			siteId: 1390,
-    			type: 'personal',
-    			additional: {
-    				SECTION: 'private'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string | null>({
+        method: 'landing.syspage.getSpecialPage',
+        params: {
+          siteId: 1390,
+          type: 'personal',
+          additional: {
+            SECTION: 'private',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSpecialPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.syspage.getSpecialPage',
+            params: {
+              siteId: 1390,
+              type: 'personal',
+              additional: {
+                SECTION: 'private',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSpecialPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/special-pages/landing-syspage-get.md
+++ b/api-reference/landing/page/special-pages/landing-syspage-get.md
@@ -63,26 +63,86 @@
       "https://**put.your-domain-here**/rest/landing.syspage.get.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.syspage.get',
-    		{
-    			id: 1390,
-    			active: true
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    type SyspageItem = {
+      TYPE: string,
+      LANDING_ID: string,
+      TITLE: string,
+      DELETED: string,
+      ACTIVE: string,
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SyspageGetResult = Record<string, SyspageItem>
+
+    try {
+      const response = await $b24.actions.v2.call.make<SyspageGetResult>({
+        method: 'landing.syspage.get',
+        params: {
+          id: 1390,
+          active: true,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result).map(key => result[key]))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSyspages() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.syspage.get',
+            params: {
+              id: 1390,
+              active: true,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result).map(key => result[key]))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSyspages)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/page/special-pages/landing-syspage-set.md
+++ b/api-reference/landing/page/special-pages/landing-syspage-set.md
@@ -84,27 +84,77 @@
       "https://**put.your-domain-here**/rest/landing.syspage.set.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.syspage.set',
-    		{
-    			id: 1390,
-    			type: 'personal',
-    			lid: 8593
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.syspage.set',
+        params: {
+          id: 1390,
+          type: 'personal',
+          lid: 8593,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('landing.syspage.set result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setSysPage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.syspage.set',
+            params: {
+              id: 1390,
+              type: 'personal',
+              lid: 8593,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('landing.syspage.set result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setSysPage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/extended-model/landing-site-get-rights.md
+++ b/api-reference/landing/rights/extended-model/landing-site-get-rights.md
@@ -58,25 +58,73 @@
       "https://**put.your-domain-here**/rest/landing.site.getRights.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.site.getRights',
-            {
-                id: 645
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'landing.site.getRights',
+        params: {
+          id: 645,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Site rights:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSiteRights() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getRights',
+            params: {
+              id: 645,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Site rights:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSiteRights)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/extended-model/landing-site-set-rights.md
+++ b/api-reference/landing/rights/extended-model/landing-site-set-rights.md
@@ -118,29 +118,81 @@
       "https://**put.your-domain-here**/rest/landing.site.setRights.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.site.setRights',
-            {
-                id: 645,
-                rights: {
-                    AU: ['read'],
-                    U3: ['read', 'edit', 'sett', 'public']
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.setRights',
+        params: {
+          id: 645,
+          rights: {
+            AU: ['read'],
+            U3: ['read', 'edit', 'sett', 'public'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Rights saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setSiteRights() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.setRights',
+            params: {
+              id: 645,
+              rights: {
+                AU: ['read'],
+                U3: ['read', 'edit', 'sett', 'public'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Rights saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setSiteRights)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/landing-role-enable.md
+++ b/api-reference/landing/rights/landing-role-enable.md
@@ -57,25 +57,73 @@
       "https://**put.your-domain-here**/rest/landing.role.enable.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.role.enable',
-            {
-                mode: 1
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.role.enable',
+        params: {
+          mode: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Role model enabled:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function enableLandingRole() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.role.enable',
+            params: {
+              mode: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Role model enabled:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', enableLandingRole)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/landing-role-is-enabled.md
+++ b/api-reference/landing/rights/landing-role-is-enabled.md
@@ -45,23 +45,69 @@
       "https://**put.your-domain-here**/rest/landing.role.isEnabled.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.role.isEnabled',
-            {}
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.role.isEnabled',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Role model enabled:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkRoleIsEnabled() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.role.isEnabled',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Role model enabled:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkRoleIsEnabled)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/role-model/landing-role-get-list.md
+++ b/api-reference/landing/rights/role-model/landing-role-get-list.md
@@ -62,25 +62,92 @@
       "https://**put.your-domain-here**/rest/landing.role.getList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.role.getList',
-            {
-                scope: 'KNOWLEDGE'
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each role returned in result[]
+    type RoleItem = {
+      ID: string,
+      TITLE: string,
+      XML_ID: string,
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      // landing.role.getList returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<RoleItem[]>({
+        method: 'landing.role.getList',
+        params: {
+          scope: 'KNOWLEDGE',
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Roles:', result, 'Count:', result.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRoleList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.role.getList returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.role.getList',
+            params: {
+              scope: 'KNOWLEDGE',
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Roles:', result, 'Count:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRoleList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/role-model/landing-role-get-rights.md
+++ b/api-reference/landing/rights/role-model/landing-role-get-rights.md
@@ -55,25 +55,76 @@
       "https://**put.your-domain-here**/rest/landing.role.getRights.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.role.getRights',
-            {
-                id: 2
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetRightsResult = Record<string, string[]>
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetRightsResult>({
+        method: 'landing.role.getRights',
+        params: {
+          id: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Role rights by site:', Object.keys(result).map(siteId => `site ${siteId}: ${result[siteId].join(', ')}`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRoleRights() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.role.getRights',
+            params: {
+              id: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Role rights by site:', Object.keys(result).map(siteId => `site ${siteId}: ${result[siteId].join(', ')}`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRoleRights)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/role-model/landing-role-set-access-codes.md
+++ b/api-reference/landing/rights/role-model/landing-role-set-access-codes.md
@@ -88,30 +88,83 @@
       "https://**put.your-domain-here**/rest/landing.role.setAccessCodes.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.role.setAccessCodes',
-            {
-                id: 11,
-                codes: [
-                    'U45',
-                    'DR7',
-                    'SG3_A'
-                ]
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.role.setAccessCodes',
+        params: {
+          id: 11,
+          codes: [
+            'U45',
+            'DR7',
+            'SG3_A',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Access codes updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setRoleAccessCodes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.role.setAccessCodes',
+            params: {
+              id: 11,
+              codes: [
+                'U45',
+                'DR7',
+                'SG3_A',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Access codes updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setRoleAccessCodes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/rights/role-model/landing-role-set-rights.md
+++ b/api-reference/landing/rights/role-model/landing-role-set-rights.md
@@ -128,31 +128,85 @@
       "https://**put.your-domain-here**/rest/landing.role.setRights.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.role.setRights',
-            {
-                id: 11,
-                rights: {
-                    0: ['read'],
-                    66: ['read', 'edit', 'sett'],
-                    71: ['denied']
-                },
-                additional: ['menu24', 'create']
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.role.setRights',
+        params: {
+          id: 11,
+          rights: {
+            0: ['read'],
+            66: ['read', 'edit', 'sett'],
+            71: ['denied'],
+          },
+          additional: ['menu24', 'create'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Rights set successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setRoleRights() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.role.setRights',
+            params: {
+              id: 11,
+              rights: {
+                0: ['read'],
+                66: ['read', 'edit', 'sett'],
+                71: ['denied'],
+              },
+              additional: ['menu24', 'create'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Rights set successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setRoleRights)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-add-folder.md
+++ b/api-reference/landing/site/landing-site-add-folder.md
@@ -94,31 +94,85 @@
       "https://**put.your-domain-here**/rest/landing.site.addFolder.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.addFolder',
-    		{
-    			siteId: 1817,
-    			fields: {
-    				TITLE: 'Новая папка',
-    				CODE: 'new-folder',
-    				ACTIVE: 'Y',
-    				PARENT_ID: 736
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.site.addFolder',
+        params: {
+          siteId: 1817,
+          fields: {
+            TITLE: 'New folder',
+            CODE: 'new-folder',
+            ACTIVE: 'Y',
+            PARENT_ID: 736,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created folder ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.addFolder',
+            params: {
+              siteId: 1817,
+              fields: {
+                TITLE: 'New folder',
+                CODE: 'new-folder',
+                ACTIVE: 'Y',
+                PARENT_ID: 736,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created folder ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-add.md
+++ b/api-reference/landing/site/landing-site-add.md
@@ -113,31 +113,85 @@
       "https://**put.your-domain-here**/rest/landing.site.add.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.add',
-    		{
-                scope: 'KNOWLEDGE',
-    			fields: {
-    				TITLE: 'База знаний компании',
-    				CODE: '',
-    				TYPE: 'KNOWLEDGE',
-    				DESCRIPTION: 'Сайт базы знаний'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.site.add',
+        params: {
+          scope: 'KNOWLEDGE',
+          fields: {
+            TITLE: 'Company knowledge base',
+            CODE: '',
+            TYPE: 'KNOWLEDGE',
+            DESCRIPTION: 'Knowledge base site',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created site ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.add',
+            params: {
+              scope: 'KNOWLEDGE',
+              fields: {
+                TITLE: 'Company knowledge base',
+                CODE: '',
+                TYPE: 'KNOWLEDGE',
+                DESCRIPTION: 'Knowledge base site',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created site ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-delete.md
+++ b/api-reference/landing/site/landing-site-delete.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.site.delete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.delete',
-    		{
-    			id: 206
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.delete',
+        params: {
+          id: 206,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Site deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.delete',
+            params: {
+              id: 206,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Site deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-full-export.md
+++ b/api-reference/landing/site/landing-site-full-export.md
@@ -112,32 +112,113 @@
       "https://**put.your-domain-here**/rest/landing.site.fullExport.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.fullExport',
-    		{
-    			id: 326,
-    			params: {
-    				edit_mode: 'Y',
-    				code: 'myfirstsite2026',
-    				name: 'Сайт автомастерской',
-    				description: 'Сайт для автосервиса',
-    				preview_url: 'https://example.com/previews/myfirstsite2026'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FullExportResult = {
+      charset: string
+      code: string
+      site_code: string
+      name: string
+      description: string
+      preview: string
+      preview2x: string
+      preview3x: string
+      preview_url: string
+      show_in_list: string
+      type: string
+      version: number
+      fields: {
+        ADDITIONAL_FIELDS: Record<string, unknown> | unknown[]
+        TITLE: string
+        LANDING_ID_INDEX: string | number
+        LANDING_ID_404: string | number
+      }
+      layout: Record<string, unknown> | unknown[]
+      folders: Record<string, unknown> | unknown[]
+      syspages: Record<string, unknown> | unknown[]
+      items: Record<string, unknown>
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FullExportResult>({
+        method: 'landing.site.fullExport',
+        params: {
+          id: 326,
+          params: {
+            edit_mode: 'Y',
+            code: 'myfirstsite2026',
+            name: 'Car workshop site',
+            description: 'Site for car service',
+            preview_url: 'https://example.com/previews/myfirstsite2026',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.code, result.name, Object.keys(result.items))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function exportSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.fullExport',
+            params: {
+              id: 326,
+              params: {
+                edit_mode: 'Y',
+                code: 'myfirstsite2026',
+                name: 'Car workshop site',
+                description: 'Site for car service',
+                preview_url: 'https://example.com/previews/myfirstsite2026',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.code, result.name, Object.keys(result.items))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', exportSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-get-additional-fields.md
+++ b/api-reference/landing/site/landing-site-get-additional-fields.md
@@ -61,25 +61,76 @@
       "https://**put.your-domain-here**/rest/landing.site.getadditionalfields.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getadditionalfields',
-    		{
-    			id: 205
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AdditionalFieldsResult = Record<string, string | number | string[]> | null
+
+    try {
+      const response = await $b24.actions.v2.call.make<AdditionalFieldsResult>({
+        method: 'landing.site.getadditionalfields',
+        params: {
+          id: 205,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Additional fields:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAdditionalFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getadditionalfields',
+            params: {
+              id: 205,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Additional fields:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAdditionalFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-get-folders.md
+++ b/api-reference/landing/site/landing-site-get-folders.md
@@ -104,30 +104,111 @@
       "https://**put.your-domain-here**/rest/landing.site.getFolders.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getFolders',
-    		{
-    			siteId: 1817,
-    			filter: {
-    				PARENT_ID: 0,
-    				'=DELETED': 'N',
-    				ACTIVE: 'Y'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each Folder returned in result[]
+    type Folder = {
+      ID: string
+      PARENT_ID: string | null
+      SITE_ID: string
+      INDEX_ID: string | null
+      ACTIVE: string
+      DELETED: string
+      TITLE: string
+      CODE: string
+      CREATED_BY_ID: string
+      MODIFIED_BY_ID: string
+      DATE_CREATE: string
+      DATE_MODIFY: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // landing.site.getFolders returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<Folder[]>({
+        method: 'landing.site.getFolders',
+        params: {
+          siteId: 1817,
+          filter: {
+            PARENT_ID: 0,
+            '=DELETED': 'N',
+            ACTIVE: 'Y',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folders count:', result.length, 'First folder:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSiteFolders() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.site.getFolders returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getFolders',
+            params: {
+              siteId: 1817,
+              filter: {
+                PARENT_ID: 0,
+                '=DELETED': 'N',
+                ACTIVE: 'Y',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folders count:', result.length, 'First folder:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSiteFolders)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-get-list.md
+++ b/api-reference/landing/site/landing-site-get-list.md
@@ -125,37 +125,116 @@
       "https://**put.your-domain-here**/rest/landing.site.getList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getList',
-    		{
-    			params: {
-    				select: [
-    					'ID',
-    					'TITLE',
-    					'TYPE'
-    				],
-    				filter: {
-    					'=DELETED': 'N'
-    				},
-    				order: {
-    					ID: 'DESC'
-    				}
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData();
-    	console.info(result.result);
+    declare const $b24: B24Frame
+
+    // Shape of each site item returned in result[]
+    type SiteItem = {
+      ID: string
+      TITLE: string
+      TYPE: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // landing.site.getList returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SiteItem[]>({
+        method: 'landing.site.getList',
+        params: {
+          params: {
+            select: [
+              'ID',
+              'TITLE',
+              'TYPE',
+            ],
+            filter: {
+              '=DELETED': 'N',
+            },
+            order: {
+              ID: 'DESC',
+            },
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Sites fetched:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSiteList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.site.getList returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getList',
+            params: {
+              params: {
+                select: [
+                  'ID',
+                  'TITLE',
+                  'TYPE',
+                ],
+                filter: {
+                  '=DELETED': 'N',
+                },
+                order: {
+                  ID: 'DESC',
+                },
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Sites fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSiteList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-get-preview.md
+++ b/api-reference/landing/site/landing-site-get-preview.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.site.getPreview.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getPreview',
-    		{
-    			id: 1817
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'landing.site.getPreview',
+        params: {
+          id: 1817,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSitePreview() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getPreview',
+            params: {
+              id: 1817,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSitePreview)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-get-public-url.md
+++ b/api-reference/landing/site/landing-site-get-public-url.md
@@ -63,25 +63,76 @@
       "https://**put.your-domain-here**/rest/landing.site.getPublicUrl.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.getPublicUrl',
-    		{
-    			id: [3, 135]
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetPublicUrlResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetPublicUrlResult>({
+        method: 'landing.site.getPublicUrl',
+        params: {
+          id: [3, 135],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Public URLs by site ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPublicUrl() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.getPublicUrl',
+            params: {
+              id: [3, 135],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Public URLs by site ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPublicUrl)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-mark-delete.md
+++ b/api-reference/landing/site/landing-site-mark-delete.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.site.markDelete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.markDelete',
-    		{
-    			id: 143
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.site.markDelete',
+        params: {
+          id: 143,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Marked as deleted, site id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markSiteDeleted() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.markDelete',
+            params: {
+              id: 143,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Marked as deleted, site id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markSiteDeleted)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-mark-folder-delete.md
+++ b/api-reference/landing/site/landing-site-mark-folder-delete.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.site.markFolderDelete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.markFolderDelete',
-    		{
-    			id: 737
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.markFolderDelete',
+        params: {
+          id: 737,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder marked as deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markFolderDelete() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.markFolderDelete',
+            params: {
+              id: 737,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder marked as deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markFolderDelete)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-mark-folder-undelete.md
+++ b/api-reference/landing/site/landing-site-mark-folder-undelete.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.site.markFolderUnDelete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.markFolderUnDelete',
-    		{
-    			id: 737
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.markFolderUnDelete',
+        params: {
+          id: 737,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder restored from trash:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function markFolderUnDelete() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.markFolderUnDelete',
+            params: {
+              id: 737,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder restored from trash:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', markFolderUnDelete)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-mark-undelete.md
+++ b/api-reference/landing/site/landing-site-mark-undelete.md
@@ -62,25 +62,73 @@
       "https://**put.your-domain-here**/rest/landing.site.markUnDelete.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.markUnDelete',
-    		{
-    			id: 157
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.site.markUnDelete',
+        params: {
+          id: 157,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Restored site ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function restoreSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.markUnDelete',
+            params: {
+              id: 157,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Restored site ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', restoreSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-publication-folder.md
+++ b/api-reference/landing/site/landing-site-publication-folder.md
@@ -67,26 +67,75 @@
       "https://**put.your-domain-here**/rest/landing.site.publicationFolder.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.publicationFolder',
-    		{
-    			folderId: 737,
-    			mark: true
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.publicationFolder',
+        params: {
+          folderId: 737,
+          mark: true,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder published:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function publishFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.publicationFolder',
+            params: {
+              folderId: 737,
+              mark: true,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder published:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', publishFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-publication.md
+++ b/api-reference/landing/site/landing-site-publication.md
@@ -64,25 +64,73 @@
       "https://**put.your-domain-here**/rest/landing.site.publication.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.publication',
-    		{
-    			id: 1688
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.site.publication',
+        params: {
+          id: 1688,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Published site ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function publishSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.publication',
+            params: {
+              id: 1688,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Published site ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', publishSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-unpublic-folder.md
+++ b/api-reference/landing/site/landing-site-unpublic-folder.md
@@ -61,25 +61,73 @@
       "https://**put.your-domain-here**/rest/landing.site.unPublicFolder.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.unPublicFolder',
-    		{
-    			folderId: 737
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.unPublicFolder',
+        params: {
+          folderId: 737,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder unpublished:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unpublicFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.unPublicFolder',
+            params: {
+              folderId: 737,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder unpublished:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unpublicFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-unpublic.md
+++ b/api-reference/landing/site/landing-site-unpublic.md
@@ -64,25 +64,73 @@
       "https://**put.your-domain-here**/rest/landing.site.unpublic.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.unpublic',
-    		{
-    			id: 1688
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.site.unpublic',
+        params: {
+          id: 1688,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Unpublished site ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unpublicSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.unpublic',
+            params: {
+              id: 1688,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Unpublished site ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unpublicSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-update-folder.md
+++ b/api-reference/landing/site/landing-site-update-folder.md
@@ -106,33 +106,89 @@
       "https://**put.your-domain-here**/rest/landing.site.updateFolder.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.updateFolder',
-    		{
-    			siteId: 1817,
-    			folderId: 736,
-    			fields: {
-    				TITLE: 'Каталог услуг',
-    				CODE: 'services-catalog',
-    				PARENT_ID: 0,
-    				INDEX_ID: 987,
-    				ACTIVE: 'Y'
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.updateFolder',
+        params: {
+          siteId: 1817,
+          folderId: 736,
+          fields: {
+            TITLE: 'Services Catalog',
+            CODE: 'services-catalog',
+            PARENT_ID: 0,
+            INDEX_ID: 987,
+            ACTIVE: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Folder updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.updateFolder',
+            params: {
+              siteId: 1817,
+              folderId: 736,
+              fields: {
+                TITLE: 'Services Catalog',
+                CODE: 'services-catalog',
+                PARENT_ID: 0,
+                INDEX_ID: 987,
+                ACTIVE: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Folder updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/site/landing-site-update.md
+++ b/api-reference/landing/site/landing-site-update.md
@@ -110,31 +110,85 @@
       "https://**put.your-domain-here**/rest/landing.site.update.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.site.update',
-    		{
-    			id: 206,
-    			fields: {
-    				TITLE: 'Support portal',
-    				CODE: 'support-portal',
-    				DESCRIPTION: 'Обновленное описание сайта',
-    				LANDING_ID_INDEX: 987
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.site.update',
+        params: {
+          id: 206,
+          fields: {
+            TITLE: 'Support portal',
+            CODE: 'support-portal',
+            DESCRIPTION: 'Updated site description',
+            LANDING_ID_INDEX: 987,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Site updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSite() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.site.update',
+            params: {
+              id: 206,
+              fields: {
+                TITLE: 'Support portal',
+                CODE: 'support-portal',
+                DESCRIPTION: 'Updated site description',
+                LANDING_ID_INDEX: 987,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Site updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSite)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/template/landing-template-get-landing-ref.md
+++ b/api-reference/landing/template/landing-template-get-landing-ref.md
@@ -59,25 +59,84 @@
       "https://**put.your-domain-here**/rest/landing.template.getLandingRef.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.template.getLandingRef',
-            {
-                id: 557
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type LandingRefResult = Record<string, number> | true
+
+    try {
+      const response = await $b24.actions.v2.call.make<LandingRefResult>({
+        method: 'landing.template.getLandingRef',
+        params: {
+          id: 557,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        if (result === true) {
+          console.info('No landing refs configured')
+        } else {
+          console.info('Landing refs:', result, 'Area count:', Object.keys(result).length)
+        }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getLandingRef() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.template.getLandingRef',
+            params: {
+              id: 557,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          if (result === true) {
+            console.info('No landing refs configured')
+          } else {
+            console.info('Landing refs:', result, 'Area count:', Object.keys(result).length)
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getLandingRef)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/template/landing-template-get-list.md
+++ b/api-reference/landing/template/landing-template-get-list.md
@@ -141,43 +141,129 @@
       "https://**put.your-domain-here**/rest/landing.template.getlist.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.template.getlist',
-            {
-                params: {
-                    select: [
-                        'ID',
-                        'TITLE',
-                        'XML_ID',
-                        'SORT',
-                        'ACTIVE',
-                        'DATE_MODIFY'
-                    ],
-                    filter: {
-                        '=ACTIVE': 'Y'
-                    },
-                    order: {
-                        SORT: 'ASC',
-                        ID: 'ASC'
-                    },
-                    limit: 2,
-                    offset: 0
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each template item returned in result[]
+    type TemplateItem = {
+      ID: string
+      TITLE: string
+      XML_ID: string
+      SORT: string
+      ACTIVE: string
+      DATE_MODIFY: string
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      // landing.template.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<TemplateItem[]>({
+        method: 'landing.template.getlist',
+        params: {
+          params: {
+            select: [
+              'ID',
+              'TITLE',
+              'XML_ID',
+              'SORT',
+              'ACTIVE',
+              'DATE_MODIFY',
+            ],
+            filter: {
+              '=ACTIVE': 'Y',
+            },
+            order: {
+              SORT: 'ASC',
+              ID: 'ASC',
+            },
+            limit: 2,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Templates count:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTemplateList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.template.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.template.getlist',
+            params: {
+              params: {
+                select: [
+                  'ID',
+                  'TITLE',
+                  'XML_ID',
+                  'SORT',
+                  'ACTIVE',
+                  'DATE_MODIFY',
+                ],
+                filter: {
+                  '=ACTIVE': 'Y',
+                },
+                order: {
+                  SORT: 'ASC',
+                  ID: 'ASC',
+                },
+                limit: 2,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Templates count:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTemplateList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/template/landing-template-get-site-ref.md
+++ b/api-reference/landing/template/landing-template-get-site-ref.md
@@ -59,25 +59,76 @@
       "https://**put.your-domain-here**/rest/landing.template.getSiteRef.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.template.getSiteRef',
-            {
-                id: 157
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SiteRefResult = Record<string, number> | true
+
+    try {
+      const response = await $b24.actions.v2.call.make<SiteRefResult>({
+        method: 'landing.template.getSiteRef',
+        params: {
+          id: 157,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Site refs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSiteRef() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.template.getSiteRef',
+            params: {
+              id: 157,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Site refs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSiteRef)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/template/landing-template-set-landing-ref.md
+++ b/api-reference/landing/template/landing-template-set-landing-ref.md
@@ -94,30 +94,83 @@
       "https://**put.your-domain-here**/rest/landing.template.setLandingRef.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.template.setLandingRef',
-            {
-                id: 557,
-                data: {
-                    1: 614,
-                    2: 615,
-                    3: 616
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.template.setLandingRef',
+        params: {
+          id: 557,
+          data: {
+            1: 614,
+            2: 615,
+            3: 616,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Landing refs updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setLandingRef() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.template.setLandingRef',
+            params: {
+              id: 557,
+              data: {
+                1: 614,
+                2: 615,
+                3: 616,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Landing refs updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setLandingRef)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/template/landing-template-set-site-ref.md
+++ b/api-reference/landing/template/landing-template-set-site-ref.md
@@ -86,30 +86,83 @@
       "https://**put.your-domain-here**/rest/landing.template.setSiteRef.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'landing.template.setSiteRef',
-            {
-                id: 157,
-                data: {
-                    1: 614,
-                    2: 615,
-                    3: 616
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.template.setSiteRef',
+        params: {
+          id: 157,
+          data: {
+            1: 614,
+            2: 615,
+            3: 616,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Site refs saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setSiteRef() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.template.setSiteRef',
+            params: {
+              id: 157,
+              data: {
+                1: 614,
+                2: 615,
+                3: 616,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Site refs saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setSiteRef)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/user-blocks/landing-repo-check-content.md
+++ b/api-reference/landing/user-blocks/landing-repo-check-content.md
@@ -65,26 +65,81 @@
       "https://**put.your-domain-here**/rest/landing.repo.checkContent.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repo.checkContent',
-    		{
-    			content: '<div style="color:red" onclick="alert(1)"><iframe src="//evil.com"></iframe></div>',
-    			splitter: '#AAA#'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CheckContentResult = {
+      is_bad: boolean
+      content: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<CheckContentResult>({
+        method: 'landing.repo.checkContent',
+        params: {
+          content: '<div style="color:red" onclick="alert(1)"><iframe src="//evil.com"></iframe></div>',
+          splitter: '#AAA#',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Is bad content:', result.is_bad, '| Sanitized content:', result.content)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkContent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.checkContent',
+            params: {
+              content: '<div style="color:red" onclick="alert(1)"><iframe src="//evil.com"></iframe></div>',
+              splitter: '#AAA#',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Is bad content:', result.is_bad, '| Sanitized content:', result.content)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkContent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/user-blocks/landing-repo-get-list.md
+++ b/api-reference/landing/user-blocks/landing-repo-get-list.md
@@ -183,29 +183,114 @@
       "https://**put.your-domain-here**/rest/landing.repo.getList.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repo.getList',
-    		{
-    			params: {
-    				select: ['ID', 'NAME', 'DATE_MODIFY'],
-    				filter: { ACTIVE: 'Y' },
-    				order: { ID: 'DESC' },
-    				group: ['ACTIVE']
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.info(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of each RepoBlockItem returned in result[]
+    type RepoBlockItem = {
+      ID: string
+      XML_ID: string
+      APP_CODE: string | null
+      ACTIVE: string
+      NAME: string
+      DESCRIPTION: string
+      SECTIONS: string
+      SITE_TEMPLATE_ID: string | null
+      PREVIEW: string
+      MANIFEST: object | boolean
+      CONTENT: string
+      CREATED_BY_ID: string
+      MODIFIED_BY_ID: string
+      DATE_CREATE: string
+      DATE_MODIFY: string
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // landing.repo.getList returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<RepoBlockItem[]>({
+        method: 'landing.repo.getList',
+        params: {
+          params: {
+            select: ['ID', 'NAME', 'DATE_MODIFY'],
+            filter: { ACTIVE: 'Y' },
+            order: { ID: 'DESC' },
+            group: ['ACTIVE'],
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Blocks fetched:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRepoBlockList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.repo.getList returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.getList',
+            params: {
+              params: {
+                select: ['ID', 'NAME', 'DATE_MODIFY'],
+                filter: { ACTIVE: 'Y' },
+                order: { ID: 'DESC' },
+                group: ['ACTIVE'],
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Blocks fetched:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRepoBlockList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/user-blocks/landing-repo-register.md
+++ b/api-reference/landing/user-blocks/landing-repo-register.md
@@ -115,37 +115,99 @@
       "https://**put.your-domain-here**/rest/landing.repo.register.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repo.register',
-    		{
-    			code: 'myblockx',
-    			fields: {
-    				NAME: 'Test block',
-    				DESCRIPTION: 'Just try!',
-    				SECTIONS: 'cover,about',
-    				PREVIEW: 'https://www.bitrix24.ru/images/b24_screen.png',
-    				CONTENT: '<section class="landing-block"><div class="container">Test</div></section>'
-    			},
-    			manifest: {
-    				block: { name: 'Test block' },
-    				nodes: {
-    					'.landing-block-node-text': { name: 'Text', type: 'text' }
-    				}
-    			}
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.info(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.repo.register',
+        params: {
+          code: 'myblockx',
+          fields: {
+            NAME: 'Test block',
+            DESCRIPTION: 'Just try!',
+            SECTIONS: 'cover,about',
+            PREVIEW: 'https://www.bitrix24.ru/images/b24_screen.png',
+            CONTENT: '<section class="landing-block"><div class="container">Test</div></section>',
+          },
+          manifest: {
+            block: { name: 'Test block' },
+            nodes: {
+              '.landing-block-node-text': { name: 'Text', type: 'text' },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Registered block id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.register',
+            params: {
+              code: 'myblockx',
+              fields: {
+                NAME: 'Test block',
+                DESCRIPTION: 'Just try!',
+                SECTIONS: 'cover,about',
+                PREVIEW: 'https://www.bitrix24.ru/images/b24_screen.png',
+                CONTENT: '<section class="landing-block"><div class="container">Test</div></section>',
+              },
+              manifest: {
+                block: { name: 'Test block' },
+                nodes: {
+                  '.landing-block-node-text': { name: 'Text', type: 'text' },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Registered block id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerBlock)
+    </script>
     ```
 
 - PHP

--- a/api-reference/landing/user-blocks/landing-repo-unregister.md
+++ b/api-reference/landing/user-blocks/landing-repo-unregister.md
@@ -60,25 +60,73 @@
       "https://**put.your-domain-here**/rest/landing.repo.unregister.json"
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repo.unregister',
-    		{
-    			code: 'myblockx'
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repo.unregister',
+        params: {
+          code: 'myblockx',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Block unregistered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unregisterBlock() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repo.unregister',
+            params: {
+              code: 'myblockx',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Block unregistered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unregisterBlock)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.