### PR TITLE
docs(log): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/log/_includes/log-recepients.md
+++ b/api-reference/log/_includes/log-recepients.md
@@ -1,5 +1,5 @@
 
-- `SG<X>` — [рабочие группы и проекты](/api-reference/sonet-group/sonet-group-create.html) с идентификатором `X`. Идентификатор можно получить методом [sonet_group.get](/api-reference/sonet-group/sonet-group-get.html)
-- `U<X>` — [пользователи](/api-reference/user/index.html) с идентификатором `X`. Идентификатор можно получить методом [user.get](/api-reference/user/user-get.html)
+- `SG<X>` — [рабочие группы и проекты](../../sonet-group/sonet-group-create.md) с идентификатором `X`. Идентификатор можно получить методом [sonet_group.get](../../sonet-group/sonet-group-get.md)
+- `U<X>` — [пользователи](../../user/index.md) с идентификатором `X`. Идентификатор можно получить методом [user.get](../../user/user-get.md)
 - `UA` — все авторизованные пользователи
-- `DR<X>` — подразделения компании с идентификатором `X`. Идентификатор можно получить методом [department.get](/api-reference/departments/department-get.html)
+- `DR<X>` — подразделения компании с идентификатором `X`. Идентификатор можно получить методом [department.get](../../departments/department-get.md)

--- a/api-reference/log/blogcomment/log-blogcomment-add.md
+++ b/api-reference/log/blogcomment/log-blogcomment-add.md
@@ -62,15 +62,22 @@
     https://**put_your_bitrix24_address**/rest/log.blogcomment.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod(
-        'log.blogcomment.add',
-        {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'log.blogcomment.add',
+        params: {
           POST_ID: 403,
-          TEXT: 'Комментарий к посту',
+          TEXT: 'Comment on the post',
           USER_ID: 27,
           FILES: [
             [
@@ -78,14 +85,66 @@
               'SXQncyBhIHRlc3QgZmlsZSBmb3IgQml0cml4IFJlc3QgQVBJLg==',
             ],
           ],
-        }
-      );
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Created comment:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created comment ID:', result)
+      }
     } catch (error) {
-      console.error('Error adding comment:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBlogComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogcomment.add',
+            params: {
+              POST_ID: 403,
+              TEXT: 'Comment on the post',
+              USER_ID: 27,
+              FILES: [
+                [
+                  'example.txt',
+                  'SXQncyBhIHRlc3QgZmlsZSBmb3IgQml0cml4IFJlc3QgQVBJLg==',
+                ],
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created comment ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBlogComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/blogcomment/log-blogcomment-delete.md
+++ b/api-reference/log/blogcomment/log-blogcomment-delete.md
@@ -58,25 +58,75 @@
     https://**put_your_bitrix24_address**/rest/log.blogcomment.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'log.blogcomment.delete',
-            {
-                COMMENT_ID: 197,
-                USER_ID: 503,
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'log.blogcomment.delete',
+        params: {
+          COMMENT_ID: 197,
+          USER_ID: 503,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const result = response.getData().result;
-        console.info(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteBlogComment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogcomment.delete',
+            params: {
+              COMMENT_ID: 197,
+              USER_ID: 503,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteBlogComment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/blogcomment/log-blogcomment-user-get.md
+++ b/api-reference/log/blogcomment/log-blogcomment-user-get.md
@@ -62,24 +62,105 @@
     https://**put_your_bitrix24_address**/rest/log.blogcomment.user.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type BlogCommentUserGetResult = {
+      comments: {
+        id: number
+        comment_id: number
+        log_id: number
+        date: ISODate
+        text: string
+        attach: number[]
+      }[]
+      files: Record<string, {
+        id: number
+        date: ISODate
+        type: string
+        name: string
+        size: number
+        image?: {
+          width: number
+          height: number
+        }
+        authorId: number
+        authorName: string
+        urlPreview: string
+        urlShow: string
+        urlDownload: string
+      }>
+    }
+
     try {
-      const response = await $b24.callMethod(
-        'log.blogcomment.user.get',
-        {
+      const response = await $b24.actions.v2.call.make<BlogCommentUserGetResult>({
+        method: 'log.blogcomment.user.get',
+        params: {
           USER_ID: 28,
           FIRST_ID: 215,
           LAST_ID: 216,
-        }
-      );
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-      const { result } = response.getData();
-      console.log('Comments:', result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Comments:', result.comments, 'Files:', result.files)
+      }
     } catch (error) {
-      console.error('Error getting comments:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlogCommentsForUser() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogcomment.user.get',
+            params: {
+              USER_ID: 28,
+              FIRST_ID: 215,
+              LAST_ID: 216,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Comments:', result.comments, 'Files:', result.files)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlogCommentsForUser)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/log-blogpost-add.md
+++ b/api-reference/log/log-blogpost-add.md
@@ -164,34 +164,89 @@ UF_BLOG_POST_VOTE: 'n<ID_опроса>',
     https://**put_your_bitrix24_address**/rest/log.blogpost.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'log.blogpost.add',
-            {
-                POST_TITLE: 'Новый регламент',
-                POST_MESSAGE: 'С 1 ноября обновляется процесс согласования.',
-                DEST: ['UA'],
-                TAGS: 'регламент,согласование,обновление',
-                IMPORTANT: 'Y',
-                FILES: [
-                    ['first-image.jpg', 'iVBORw0KGgoAAAANSUhEUgAAAAUA...'],
-                    ['second-image.jpg', 'iVBORw0KGgoAAAANSUhEUgAAAAUA...']
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'log.blogpost.add',
+        params: {
+          POST_TITLE: 'New regulation',
+          POST_MESSAGE: 'As of November 1, the approval process is being updated.',
+          DEST: ['UA'],
+          TAGS: 'regulation,approval,update',
+          IMPORTANT: 'Y',
+          FILES: [
+            ['first-image.jpg', 'iVBORw0KGgoAAAANSUhEUgAAAAUA...'],
+            ['second-image.jpg', 'iVBORw0KGgoAAAANSUhEUgAAAAUA...'],
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created blog post with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addBlogpost() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogpost.add',
+            params: {
+              POST_TITLE: 'New regulation',
+              POST_MESSAGE: 'As of November 1, the approval process is being updated.',
+              DEST: ['UA'],
+              TAGS: 'regulation,approval,update',
+              IMPORTANT: 'Y',
+              FILES: [
+                ['first-image.jpg', 'iVBORw0KGgoAAAANSUhEUgAAAAUA...'],
+                ['second-image.jpg', 'iVBORw0KGgoAAAANSUhEUgAAAAUA...'],
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created blog post with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addBlogpost)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/log-blogpost-delete.md
+++ b/api-reference/log/log-blogpost-delete.md
@@ -54,26 +54,73 @@
     https://**put_your_bitrix24_address**/rest/log.blogpost.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'log.blogpost.delete',
-            {
-                POST_ID: 211
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'log.blogpost.delete',
+        params: {
+          POST_ID: 211,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Post deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteBlogPost() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogpost.delete',
+            params: {
+              POST_ID: 211,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Post deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteBlogPost)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/log-blogpost-get.md
+++ b/api-reference/log/log-blogpost-get.md
@@ -77,26 +77,107 @@
     https://**put_your_bitrix24_address**/rest/log.blogpost.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'log.blogpost.get',
-            {
-                POST_ID: 217
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Blog post data:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each BlogPostItem returned in result[]
+    type BlogPostItem = {
+      ID: string
+      BLOG_ID: string
+      PUBLISH_STATUS: string
+      TITLE: string
+      AUTHOR_ID: string
+      ENABLE_COMMENTS: string
+      NUM_COMMENTS: string
+      CODE: string | null
+      MICRO: string
+      DETAIL_TEXT: string
+      DATE_PUBLISH: ISODate | null
+      CATEGORY_ID: string
+      HAS_SOCNET_ALL: string
+      HAS_TAGS: string
+      HAS_IMAGES: string
+      HAS_PROPS: string
+      HAS_COMMENT_IMAGES: string | null
+      FILES: number[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      // log.blogpost.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<BlogPostItem[]>({
+        method: 'log.blogpost.get',
+        params: {
+          POST_ID: 217,
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Blog posts count:', result.length, 'First post title:', result[0]?.TITLE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getBlogPosts() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // log.blogpost.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogpost.get',
+            params: {
+              POST_ID: 217,
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Blog posts count:', result.length, 'First post title:', result[0]?.TITLE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getBlogPosts)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/log-blogpost-getusers-important.md
+++ b/api-reference/log/log-blogpost-getusers-important.md
@@ -60,26 +60,73 @@
     https://**put_your_bitrix24_address**/rest/log.blogpost.getusers.important
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'log.blogpost.getusers.important',
-            {
-                POST_ID: 221
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'log.blogpost.getusers.important',
+        params: {
+          POST_ID: 221,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Users who read the important post:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getImportantPostUsers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogpost.getusers.important',
+            params: {
+              POST_ID: 221,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Users who read the important post:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getImportantPostUsers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/log-blogpost-share.md
+++ b/api-reference/log/log-blogpost-share.md
@@ -67,28 +67,75 @@
     https://**put_your_bitrix24_address**/rest/log.blogpost.share
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'log.blogpost.share',
-            {
-                POST_ID: 217,
-                DEST: ['SG69', 'DR4'],
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log(result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'log.blogpost.share',
+        params: {
+          POST_ID: 217,
+          DEST: ['SG69', 'DR4'],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recipients added:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function shareBlogPost() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogpost.share',
+            params: {
+              POST_ID: 217,
+              DEST: ['SG69', 'DR4'],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recipients added:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', shareBlogPost)
+    </script>
     ```
 
 - PHP

--- a/api-reference/log/log-blogpost-update.md
+++ b/api-reference/log/log-blogpost-update.md
@@ -160,31 +160,81 @@ UF_BLOG_POST_VOTE: 'n<ID_опроса>',
     https://**put_your_bitrix24_address**/rest/log.blogpost.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'log.blogpost.update',
-            {
-                POST_ID: 217,
-                POST_TITLE: 'Новый заголовок сообщения',
-                FILES: {
-                    505: 'del'
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated post with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'log.blogpost.update',
+        params: {
+          POST_ID: 217,
+          POST_TITLE: 'New post title',
+          FILES: {
+            505: 'del',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated post ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateBlogPost() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'log.blogpost.update',
+            params: {
+              POST_ID: 217,
+              POST_TITLE: 'New post title',
+              FILES: {
+                505: 'del',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated post ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateBlogPost)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.