### PR TITLE
docs(mailservice): actualize JS examples to TS + UMD

### DIFF
--- a/api-reference/mailservice/mailservice-add.md
+++ b/api-reference/mailservice/mailservice-add.md
@@ -91,30 +91,85 @@
       https://**put_your_bitrix24_address**/rest/mailservice.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'mailservice.add',
-    		{
-    			NAME: 'Мой почтовый сервис',
-    			ACTIVE: 'Y',
-    			SERVER: 'imap.my-mail.ru',
-    			PORT: 993,
-    			ENCRYPTION: 'Y',
-    			LINK: 'https://mail.my-mail.ru/',
-    			SORT: 500
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'mailservice.add',
+        params: {
+          NAME: 'My mail service',
+          ACTIVE: 'Y',
+          SERVER: 'imap.my-mail.ru',
+          PORT: 993,
+          ENCRYPTION: 'Y',
+          LINK: 'https://mail.my-mail.ru/',
+          SORT: 500,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created mail service ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addMailService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'mailservice.add',
+            params: {
+              NAME: 'My mail service',
+              ACTIVE: 'Y',
+              SERVER: 'imap.my-mail.ru',
+              PORT: 993,
+              ENCRYPTION: 'Y',
+              LINK: 'https://mail.my-mail.ru/',
+              SORT: 500,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created mail service ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addMailService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/mailservice/mailservice-delete.md
+++ b/api-reference/mailservice/mailservice-delete.md
@@ -54,22 +54,73 @@
       https://**put_your_bitrix24_address**/rest/mailservice.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'mailservice.delete',
-    		{ ID: 31 }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'mailservice.delete',
+        params: {
+          ID: 31,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Mail service deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteMailService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'mailservice.delete',
+            params: {
+              ID: 31,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Mail service deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteMailService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/mailservice/mailservice-fields.md
+++ b/api-reference/mailservice/mailservice-fields.md
@@ -44,18 +44,72 @@
       https://**put_your_bitrix24_address**/rest/mailservice.fields
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod('mailservice.fields', {});
-    	console.log(response.getData().result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailserviceFieldsResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<MailserviceFieldsResult>({
+        method: 'mailservice.fields',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field labels:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailserviceFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'mailservice.fields',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field labels:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailserviceFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/mailservice/mailservice-get.md
+++ b/api-reference/mailservice/mailservice-get.md
@@ -54,22 +54,93 @@
       https://**put_your_bitrix24_address**/rest/mailservice.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'mailservice.get',
-    		{ ID: 31 }
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailServiceGetResult = {
+      ID: string
+      SITE_ID: string
+      ACTIVE: string
+      SORT: string
+      NAME: string
+      SERVER: string
+      PORT: string
+      ENCRYPTION: string
+      LINK: string
+      ICON: string | null
+      SMTP_SERVER: string | null
+      SMTP_PORT: string | null
+      SMTP_LOGIN_AS_IMAP: string
+      SMTP_PASSWORD_AS_IMAP: string
+      SMTP_ENCRYPTION: string | null
+      UPLOAD_OUTGOING: string | null
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<MailServiceGetResult>({
+        method: 'mailservice.get',
+        params: {
+          ID: 31,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.ID, result.NAME, result.SERVER)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'mailservice.get',
+            params: {
+              ID: 31,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.ID, result.NAME, result.SERVER)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailService)
+    </script>
     ```
 
 - PHP

--- a/api-reference/mailservice/mailservice-list.md
+++ b/api-reference/mailservice/mailservice-list.md
@@ -44,18 +44,103 @@
       https://**put_your_bitrix24_address**/rest/mailservice.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod('mailservice.list', {});
-    	console.log(response.getData().result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each mail service item returned in result[]
+    type MailServiceItem = {
+      ID: string
+      SITE_ID: string
+      ACTIVE: string
+      SORT: string
+      NAME: string
+      SERVER: string
+      PORT: string
+      ENCRYPTION: string
+      LINK: string
+      ICON: string
+      SMTP_SERVER: string | null
+      SMTP_PORT: string | null
+      SMTP_LOGIN_AS_IMAP: string
+      SMTP_PASSWORD_AS_IMAP: string
+      SMTP_ENCRYPTION: string | null
+      UPLOAD_OUTGOING: string | null
     }
-    catch (error)
-    {
-    	console.error(error);
+
+    try {
+      // mailservice.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<MailServiceItem[]>({
+        method: 'mailservice.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Mail services:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listMailServices() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // mailservice.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'mailservice.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Mail services:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listMailServices)
+    </script>
     ```
 
 - PHP

--- a/api-reference/mailservice/mailservice-update.md
+++ b/api-reference/mailservice/mailservice-update.md
@@ -95,31 +95,87 @@
       https://**put_your_bitrix24_address**/rest/mailservice.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'mailservice.update',
-    		{
-    			ID: 31,
-    			NAME: 'Обновленный почтовый сервис',
-    			ACTIVE: 'N',
-    			SERVER: 'imap.my2-mail.ru',
-    			PORT: 993,
-    			ENCRYPTION: 'Y',
-    			LINK: 'https://mail.my2-mail.ru/',
-    			SORT: 600
-    		}
-    	);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    	console.log(response.getData().result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'mailservice.update',
+        params: {
+          ID: 31,
+          NAME: 'Updated mail service',
+          ACTIVE: 'N',
+          SERVER: 'imap.my2-mail.ru',
+          PORT: 993,
+          ENCRYPTION: 'Y',
+          LINK: 'https://mail.my2-mail.ru/',
+          SORT: 600,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Mail service updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch (error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateMailService() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'mailservice.update',
+            params: {
+              ID: 31,
+              NAME: 'Updated mail service',
+              ACTIVE: 'N',
+              SERVER: 'imap.my2-mail.ru',
+              PORT: 993,
+              ENCRYPTION: 'Y',
+              LINK: 'https://mail.my2-mail.ru/',
+              SORT: 600,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Mail service updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateMailService)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.