### PR TITLE
docs(pay-system): actualize JS examples to TS + UMD

### DIFF
--- a/api-reference/pay-system/outdated/sale-pay-system-pay-invoice.md
+++ b/api-reference/pay-system/outdated/sale-pay-system-pay-invoice.md
@@ -65,27 +65,75 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.pay.invoice
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.pay.invoice',
-    		{
-    			"INVOICE_ID": 2,
-    			"PAY_SYSTEM_ID": 31,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.pay.invoice',
+        params: {
+          INVOICE_ID: 2,
+          PAY_SYSTEM_ID: 31,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Invoice paid successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function payInvoice() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.pay.invoice',
+            params: {
+              INVOICE_ID: 2,
+              PAY_SYSTEM_ID: 31,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Invoice paid successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', payInvoice)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/outdated/sale-pay-system-settings-invoice-get.md
+++ b/api-reference/pay-system/outdated/sale-pay-system-settings-invoice-get.md
@@ -65,27 +65,78 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.settings.invoice.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.settings.invoice.get',
-    		{
-    			"INVOICE_ID": 10,
-    			"PAY_SYSTEM_ID": 11
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PaySystemSettingsResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<PaySystemSettingsResult>({
+        method: 'sale.paysystem.settings.invoice.get',
+        params: {
+          INVOICE_ID: 10,
+          PAY_SYSTEM_ID: 11,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pay system settings:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getInvoicePaySystemSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.settings.invoice.get',
+            params: {
+              INVOICE_ID: 10,
+              PAY_SYSTEM_ID: 11,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pay system settings:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getInvoicePaySystemSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-add.md
+++ b/api-reference/pay-system/sale-pay-system-add.md
@@ -174,48 +174,117 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"sale.paysystem.add",
-    		{
-    			'NAME' : 'Оплата картой',
-    			'DESCRIPTION': 'Легко оплачивайте покупки картой.',
-    			'XML_ID': 'my_ps_id',
-    			'PERSON_TYPE_ID' : 1,
-    			'BX_REST_HANDLER' : 'resthandlercode',
-    			'ACTIVE' : 'Y',
-    			'ENTITY_REGISTRY_TYPE': 'ORDER',
-    			'LOGOTYPE': '/* base64 image */',
-    			'NEW_WINDOW': 'N',
-    			'SETTINGS' : {
-    				'REST_SERVICE_ID' : {
-    					'TYPE' : 'VALUE',
-    					'VALUE' : 'SERVICE ID VALUE'
-    				},
-    				'REST_SERVICE_KEY' : {
-    					'TYPE' : 'VALUE',
-    					'VALUE' : 'KEY ID VALUE'
-    				},
-    				'PAYMENT_ID': {
-    					'TYPE': 'PAYMENT',
-    					'VALUE': 'ACCOUNT_NUMBER',
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'sale.paysystem.add',
+        params: {
+          NAME: 'Card payment',
+          DESCRIPTION: 'Pay for your purchases easily by card.',
+          XML_ID: 'my_ps_id',
+          PERSON_TYPE_ID: 1,
+          BX_REST_HANDLER: 'resthandlercode',
+          ACTIVE: 'Y',
+          ENTITY_REGISTRY_TYPE: 'ORDER',
+          LOGOTYPE: '/* base64 image */',
+          NEW_WINDOW: 'N',
+          SETTINGS: {
+            REST_SERVICE_ID: {
+              TYPE: 'VALUE',
+              VALUE: 'SERVICE ID VALUE',
+            },
+            REST_SERVICE_KEY: {
+              TYPE: 'VALUE',
+              VALUE: 'KEY ID VALUE',
+            },
+            PAYMENT_ID: {
+              TYPE: 'PAYMENT',
+              VALUE: 'ACCOUNT_NUMBER',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Added payment system ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPaySystem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.add',
+            params: {
+              NAME: 'Card payment',
+              DESCRIPTION: 'Pay for your purchases easily by card.',
+              XML_ID: 'my_ps_id',
+              PERSON_TYPE_ID: 1,
+              BX_REST_HANDLER: 'resthandlercode',
+              ACTIVE: 'Y',
+              ENTITY_REGISTRY_TYPE: 'ORDER',
+              LOGOTYPE: '/* base64 image */',
+              NEW_WINDOW: 'N',
+              SETTINGS: {
+                REST_SERVICE_ID: {
+                  TYPE: 'VALUE',
+                  VALUE: 'SERVICE ID VALUE',
+                },
+                REST_SERVICE_KEY: {
+                  TYPE: 'VALUE',
+                  VALUE: 'KEY ID VALUE',
+                },
+                PAYMENT_ID: {
+                  TYPE: 'PAYMENT',
+                  VALUE: 'ACCOUNT_NUMBER',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Added payment system ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPaySystem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-delete.md
+++ b/api-reference/pay-system/sale-pay-system-delete.md
@@ -52,26 +52,73 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.delete',
-    		{
-    			"ID": 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.delete',
+        params: {
+          ID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment system deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePaysystem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.delete',
+            params: {
+              ID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment system deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePaysystem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-handler-add.md
+++ b/api-reference/pay-system/sale-pay-system-handler-add.md
@@ -290,120 +290,257 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.handler.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"sale.paysystem.handler.add",
-    		{
-    			"NAME": "Обработчик.Rest FORM",
-    			"CODE": "resthandlerform",
-    			"SORT": 100,
-    			"SETTINGS": {
-    				"CURRENCY": [
-    					"RUB"
-    				],
-    				"CLIENT_TYPE": "b2c",
-    				"FORM_DATA": {
-    					"ACTION_URI": "http://example.com/payment_form.php",
-    					"METHOD": "POST",
-    					"FIELDS": {
-    						"phone": {
-    							"VISIBLE": "Y",
-    							"CODE": {
-    								"NAME": "Номер телефона",
-    								"TYPE": "STRING"
-    							}
-    						},
-    						"selection": {
-    							"VISIBLE": "Y",
-    							"CODE": {
-    								"NAME": "Иллюзия выбора",
-    								"INPUT": {
-    									"TYPE": "Y/N"
-    								}
-    							}
-    						},
-    						"paymentId": {
-    							"CODE": "PAYMENT_ID",
-    							"VISIBLE": "Y"
-    						},
-    						"serviceid": {
-    							"CODE": "REST_SERVICE_ID"
-    						}
-    					}
-    				},
-    				"CODES": {
-    					"REST_SERVICE_ID": {
-    						"NAME": "Номер магазина",
-    						"DESCRIPTION": "Номер магазина",
-    						"SORT": "100"
-    					},
-    					"REST_SERVICE_KEY": {
-    						"NAME": "Секретный ключ",
-    						"DESCRIPTION": "Секретный ключ",
-    						"SORT": "300"
-    					},
-    					"PAYMENT_ID": {
-    						"NAME": "Номер оплаты",
-    						"SORT": "400",
-    						"GROUP": "PAYMENT",
-    						"DEFAULT": {
-    							"PROVIDER_KEY": "PAYMENT",
-    							"PROVIDER_VALUE": "ACCOUNT_NUMBER"
-    						}
-    					},
-    					"PAYMENT_SHOULD_PAY": {
-    						"NAME": "Сумма оплаты",
-    						"SORT": "600",
-    						"GROUP": "PAYMENT",
-    						"DEFAULT": {
-    							"PROVIDER_KEY": "PAYMENT",
-    							"PROVIDER_VALUE": "SUM"
-    						}
-    					},
-    					"PS_CHANGE_STATUS_PAY": {
-    						"NAME": "Автоматическая смена статуса оплаты",
-    						"SORT": "700",
-    						"INPUT": {
-    							"TYPE": "Y/N"
-    						}
-    					},
-    					"PAYMENT_BUYER_ID": {
-    						"NAME": "Код покупателя",
-    						"SORT": "1000",
-    						"GROUP": "PAYMENT",
-    						"DEFAULT": {
-    							"PROVIDER_KEY": "ORDER",
-    							"PROVIDER_VALUE": "USER_ID"
-    						}
-    					},
-    					"PS_WORK_MODE": {
-    						"NAME": "Режим работы платёжной системы",
-    						"SORT": "1100",
-    						"INPUT": {
-    							"TYPE": "ENUM",
-    							"OPTIONS": {
-    								"TEST": "Тестовый",
-    								"REGULAR": "Рабочий"
-    							}
-    						}
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'sale.paysystem.handler.add',
+        params: {
+          NAME: 'Rest handler FORM',
+          CODE: 'resthandlerform',
+          SORT: 100,
+          SETTINGS: {
+            CURRENCY: ['RUB'],
+            CLIENT_TYPE: 'b2c',
+            FORM_DATA: {
+              ACTION_URI: 'http://example.com/payment_form.php',
+              METHOD: 'POST',
+              FIELDS: {
+                phone: {
+                  VISIBLE: 'Y',
+                  CODE: {
+                    NAME: 'Phone number',
+                    TYPE: 'STRING',
+                  },
+                },
+                selection: {
+                  VISIBLE: 'Y',
+                  CODE: {
+                    NAME: 'Illusion of choice',
+                    INPUT: {
+                      TYPE: 'Y/N',
+                    },
+                  },
+                },
+                paymentId: {
+                  CODE: 'PAYMENT_ID',
+                  VISIBLE: 'Y',
+                },
+                serviceid: {
+                  CODE: 'REST_SERVICE_ID',
+                },
+              },
+            },
+            CODES: {
+              REST_SERVICE_ID: {
+                NAME: 'Shop ID',
+                DESCRIPTION: 'Shop ID',
+                SORT: '100',
+              },
+              REST_SERVICE_KEY: {
+                NAME: 'Secret key',
+                DESCRIPTION: 'Secret key',
+                SORT: '300',
+              },
+              PAYMENT_ID: {
+                NAME: 'Payment number',
+                SORT: '400',
+                GROUP: 'PAYMENT',
+                DEFAULT: {
+                  PROVIDER_KEY: 'PAYMENT',
+                  PROVIDER_VALUE: 'ACCOUNT_NUMBER',
+                },
+              },
+              PAYMENT_SHOULD_PAY: {
+                NAME: 'Payment amount',
+                SORT: '600',
+                GROUP: 'PAYMENT',
+                DEFAULT: {
+                  PROVIDER_KEY: 'PAYMENT',
+                  PROVIDER_VALUE: 'SUM',
+                },
+              },
+              PS_CHANGE_STATUS_PAY: {
+                NAME: 'Automatic payment status change',
+                SORT: '700',
+                INPUT: {
+                  TYPE: 'Y/N',
+                },
+              },
+              PAYMENT_BUYER_ID: {
+                NAME: 'Buyer ID',
+                SORT: '1000',
+                GROUP: 'PAYMENT',
+                DEFAULT: {
+                  PROVIDER_KEY: 'ORDER',
+                  PROVIDER_VALUE: 'USER_ID',
+                },
+              },
+              PS_WORK_MODE: {
+                NAME: 'Payment system work mode',
+                SORT: '1100',
+                INPUT: {
+                  TYPE: 'ENUM',
+                  OPTIONS: {
+                    TEST: 'Test',
+                    REGULAR: 'Live',
+                  },
+                },
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handler added with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPaySystemHandlerForm() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.handler.add',
+            params: {
+              NAME: 'Rest handler FORM',
+              CODE: 'resthandlerform',
+              SORT: 100,
+              SETTINGS: {
+                CURRENCY: ['RUB'],
+                CLIENT_TYPE: 'b2c',
+                FORM_DATA: {
+                  ACTION_URI: 'http://example.com/payment_form.php',
+                  METHOD: 'POST',
+                  FIELDS: {
+                    phone: {
+                      VISIBLE: 'Y',
+                      CODE: {
+                        NAME: 'Phone number',
+                        TYPE: 'STRING',
+                      },
+                    },
+                    selection: {
+                      VISIBLE: 'Y',
+                      CODE: {
+                        NAME: 'Illusion of choice',
+                        INPUT: {
+                          TYPE: 'Y/N',
+                        },
+                      },
+                    },
+                    paymentId: {
+                      CODE: 'PAYMENT_ID',
+                      VISIBLE: 'Y',
+                    },
+                    serviceid: {
+                      CODE: 'REST_SERVICE_ID',
+                    },
+                  },
+                },
+                CODES: {
+                  REST_SERVICE_ID: {
+                    NAME: 'Shop ID',
+                    DESCRIPTION: 'Shop ID',
+                    SORT: '100',
+                  },
+                  REST_SERVICE_KEY: {
+                    NAME: 'Secret key',
+                    DESCRIPTION: 'Secret key',
+                    SORT: '300',
+                  },
+                  PAYMENT_ID: {
+                    NAME: 'Payment number',
+                    SORT: '400',
+                    GROUP: 'PAYMENT',
+                    DEFAULT: {
+                      PROVIDER_KEY: 'PAYMENT',
+                      PROVIDER_VALUE: 'ACCOUNT_NUMBER',
+                    },
+                  },
+                  PAYMENT_SHOULD_PAY: {
+                    NAME: 'Payment amount',
+                    SORT: '600',
+                    GROUP: 'PAYMENT',
+                    DEFAULT: {
+                      PROVIDER_KEY: 'PAYMENT',
+                      PROVIDER_VALUE: 'SUM',
+                    },
+                  },
+                  PS_CHANGE_STATUS_PAY: {
+                    NAME: 'Automatic payment status change',
+                    SORT: '700',
+                    INPUT: {
+                      TYPE: 'Y/N',
+                    },
+                  },
+                  PAYMENT_BUYER_ID: {
+                    NAME: 'Buyer ID',
+                    SORT: '1000',
+                    GROUP: 'PAYMENT',
+                    DEFAULT: {
+                      PROVIDER_KEY: 'ORDER',
+                      PROVIDER_VALUE: 'USER_ID',
+                    },
+                  },
+                  PS_WORK_MODE: {
+                    NAME: 'Payment system work mode',
+                    SORT: '1100',
+                    INPUT: {
+                      TYPE: 'ENUM',
+                      OPTIONS: {
+                        TEST: 'Test',
+                        REGULAR: 'Live',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handler added with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPaySystemHandlerForm)
+    </script>
     ```
 
 - PHP
@@ -841,68 +978,153 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.handler.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"sale.paysystem.handler.add",
-    		{
-    			"NAME": "Обработчик.Rest CHECKOUT",
-    			"CODE": "resthandlercheckout",
-    			"SORT": 100,
-    			"SETTINGS": {
-    				"CURRENCY": [
-    					"RUB"
-    				],
-    				"CLIENT_TYPE": "b2c",
-    				"CHECKOUT_DATA": {
-    					"ACTION_URI": "http://example.com/payment_checkout.php",
-    					"FIELDS": {
-    						"serviceKey": {
-    							"CODE": "REST_SERVICE_KEY_CHECKOUT",
-    						},
-    						"serviceid": {
-    							"CODE": "REST_SERVICE_ID_CHECKOUT"
-    						}
-    					}
-    				},
-    				"CODES": {
-    					"REST_SERVICE_ID_CHECKOUT": {
-    						"NAME": "Номер магазина",
-    						"DESCRIPTION": "Номер магазина",
-    						"SORT": "100"
-    					},
-    					"REST_SERVICE_KEY_CHECKOUT": {
-    						"NAME": "Секретный ключ",
-    						"DESCRIPTION": "Секретный ключ",
-    						"SORT": "300"
-    					},
-    					"PS_WORK_MODE_CHECKOUT": {
-    						"NAME": "Режим работы платёжной системы",
-    						"SORT": "1100",
-    						"INPUT": {
-    							"TYPE": "ENUM",
-    							"OPTIONS": {
-    								"TEST": "Тестовый",
-    								"REGULAR": "Рабочий"
-    							}
-    						}
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info("Обработчик добавлен с ID " + result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'sale.paysystem.handler.add',
+        params: {
+          NAME: 'Rest handler CHECKOUT',
+          CODE: 'resthandlercheckout',
+          SORT: 100,
+          SETTINGS: {
+            CURRENCY: ['RUB'],
+            CLIENT_TYPE: 'b2c',
+            CHECKOUT_DATA: {
+              ACTION_URI: 'http://example.com/payment_checkout.php',
+              FIELDS: {
+                serviceKey: {
+                  CODE: 'REST_SERVICE_KEY_CHECKOUT',
+                },
+                serviceid: {
+                  CODE: 'REST_SERVICE_ID_CHECKOUT',
+                },
+              },
+            },
+            CODES: {
+              REST_SERVICE_ID_CHECKOUT: {
+                NAME: 'Shop ID',
+                DESCRIPTION: 'Shop ID',
+                SORT: '100',
+              },
+              REST_SERVICE_KEY_CHECKOUT: {
+                NAME: 'Secret key',
+                DESCRIPTION: 'Secret key',
+                SORT: '300',
+              },
+              PS_WORK_MODE_CHECKOUT: {
+                NAME: 'Payment system work mode',
+                SORT: '1100',
+                INPUT: {
+                  TYPE: 'ENUM',
+                  OPTIONS: {
+                    TEST: 'Test',
+                    REGULAR: 'Live',
+                  },
+                },
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handler added with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPaySystemHandlerCheckout() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.handler.add',
+            params: {
+              NAME: 'Rest handler CHECKOUT',
+              CODE: 'resthandlercheckout',
+              SORT: 100,
+              SETTINGS: {
+                CURRENCY: ['RUB'],
+                CLIENT_TYPE: 'b2c',
+                CHECKOUT_DATA: {
+                  ACTION_URI: 'http://example.com/payment_checkout.php',
+                  FIELDS: {
+                    serviceKey: {
+                      CODE: 'REST_SERVICE_KEY_CHECKOUT',
+                    },
+                    serviceid: {
+                      CODE: 'REST_SERVICE_ID_CHECKOUT',
+                    },
+                  },
+                },
+                CODES: {
+                  REST_SERVICE_ID_CHECKOUT: {
+                    NAME: 'Shop ID',
+                    DESCRIPTION: 'Shop ID',
+                    SORT: '100',
+                  },
+                  REST_SERVICE_KEY_CHECKOUT: {
+                    NAME: 'Secret key',
+                    DESCRIPTION: 'Secret key',
+                    SORT: '300',
+                  },
+                  PS_WORK_MODE_CHECKOUT: {
+                    NAME: 'Payment system work mode',
+                    SORT: '1100',
+                    INPUT: {
+                      TYPE: 'ENUM',
+                      OPTIONS: {
+                        TEST: 'Test',
+                        REGULAR: 'Live',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handler added with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPaySystemHandlerCheckout)
+    </script>
     ```
 
 - PHP
@@ -1205,68 +1427,153 @@ document.addEventListener("DOMContentLoaded", function() {
     https://**put_your_bitrix24_address**/rest/sale.paysystem.handler.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"sale.paysystem.handler.add",
-    		{
-    			"NAME": "Обработчик.Rest IFrame",
-    			"CODE": "resthandleriframe",
-    			"SORT": 100,
-    			"SETTINGS": {
-    				"CURRENCY": [
-    					"RUB"
-    				],
-    				"CLIENT_TYPE": "b2c",
-    				"IFRAME_DATA": {
-    					"ACTION_URI": "http://example.com/payment_iframe.php",
-    					"FIELDS": {
-    						"serviceKey": {
-    							"CODE": "REST_SERVICE_KEY_IFRAME",
-    						},
-    						"serviceid": {
-    							"CODE": "REST_SERVICE_ID_IFRAME"
-    						}
-    					}
-    				},
-    				"CODES": {
-    					"REST_SERVICE_ID_IFRAME": {
-    						"NAME": "Номер магазина",
-    						"DESCRIPTION": "Номер магазина",
-    						"SORT": "100"
-    					},
-    					"REST_SERVICE_KEY_IFRAME": {
-    						"NAME": "Секретный ключ",
-    						"DESCRIPTION": "Секретный ключ",
-    						"SORT": "300"
-    					},
-    					"PS_WORK_MODE_IFRAME": {
-    						"NAME": "Режим работы платёжной системы",
-    						"SORT": "1100",
-    						"INPUT": {
-    							"TYPE": "ENUM",
-    							"OPTIONS": {
-    								"TEST": "Тестовый",
-    								"REGULAR": "Рабочий"
-    							}
-    						}
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'sale.paysystem.handler.add',
+        params: {
+          NAME: 'Rest handler IFrame',
+          CODE: 'resthandleriframe',
+          SORT: 100,
+          SETTINGS: {
+            CURRENCY: ['RUB'],
+            CLIENT_TYPE: 'b2c',
+            IFRAME_DATA: {
+              ACTION_URI: 'http://example.com/payment_iframe.php',
+              FIELDS: {
+                serviceKey: {
+                  CODE: 'REST_SERVICE_KEY_IFRAME',
+                },
+                serviceid: {
+                  CODE: 'REST_SERVICE_ID_IFRAME',
+                },
+              },
+            },
+            CODES: {
+              REST_SERVICE_ID_IFRAME: {
+                NAME: 'Shop ID',
+                DESCRIPTION: 'Shop ID',
+                SORT: '100',
+              },
+              REST_SERVICE_KEY_IFRAME: {
+                NAME: 'Secret key',
+                DESCRIPTION: 'Secret key',
+                SORT: '300',
+              },
+              PS_WORK_MODE_IFRAME: {
+                NAME: 'Payment system work mode',
+                SORT: '1100',
+                INPUT: {
+                  TYPE: 'ENUM',
+                  OPTIONS: {
+                    TEST: 'Test',
+                    REGULAR: 'Live',
+                  },
+                },
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handler added with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addPaySystemHandlerIframe() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.handler.add',
+            params: {
+              NAME: 'Rest handler IFrame',
+              CODE: 'resthandleriframe',
+              SORT: 100,
+              SETTINGS: {
+                CURRENCY: ['RUB'],
+                CLIENT_TYPE: 'b2c',
+                IFRAME_DATA: {
+                  ACTION_URI: 'http://example.com/payment_iframe.php',
+                  FIELDS: {
+                    serviceKey: {
+                      CODE: 'REST_SERVICE_KEY_IFRAME',
+                    },
+                    serviceid: {
+                      CODE: 'REST_SERVICE_ID_IFRAME',
+                    },
+                  },
+                },
+                CODES: {
+                  REST_SERVICE_ID_IFRAME: {
+                    NAME: 'Shop ID',
+                    DESCRIPTION: 'Shop ID',
+                    SORT: '100',
+                  },
+                  REST_SERVICE_KEY_IFRAME: {
+                    NAME: 'Secret key',
+                    DESCRIPTION: 'Secret key',
+                    SORT: '300',
+                  },
+                  PS_WORK_MODE_IFRAME: {
+                    NAME: 'Payment system work mode',
+                    SORT: '1100',
+                    INPUT: {
+                      TYPE: 'ENUM',
+                      OPTIONS: {
+                        TEST: 'Test',
+                        REGULAR: 'Live',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handler added with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addPaySystemHandlerIframe)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-handler-delete.md
+++ b/api-reference/pay-system/sale-pay-system-handler-delete.md
@@ -52,26 +52,73 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.handler.delete
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"sale.paysystem.handler.delete",
-    		{
-    			'ID': 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.handler.delete',
+        params: {
+          ID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handler deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deletePaySystemHandler() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.handler.delete',
+            params: {
+              ID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handler deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deletePaySystemHandler)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-handler-list.md
+++ b/api-reference/pay-system/sale-pay-system-handler-list.md
@@ -43,44 +43,92 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.handler.list?auth=**put_access_token_here**
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'sale.paysystem.handler.list',
-        {},
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each HandlerItem returned in result[]
+    type HandlerItem = {
+      ID: string
+      NAME: string
+      CODE: string
+      SORT: string
+      SETTINGS: Record<string, unknown>
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('sale.paysystem.handler.list', {}, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+      // sale.paysystem.handler.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<HandlerItem[]>({
+        method: 'sale.paysystem.handler.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handlers count:', result.length, 'First handler:', result[0])
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('sale.paysystem.handler.list', {}, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listPaySystemHandlers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // sale.paysystem.handler.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.handler.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handlers count:', result.length, 'First handler:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listPaySystemHandlers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-handler-update.md
+++ b/api-reference/pay-system/sale-pay-system-handler-update.md
@@ -69,92 +69,201 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.handler.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"sale.paysystem.handler.update",
-    		{
-    			'ID': 3,
-    			'FIELDS': {
-    				'CODE': 'newresthandlercode',
-    				'NAME': 'Новое название обработчика',
-    				'SORT': 200,
-    				'SETTINGS': {
-    					"CURRENCY": [
-    						"RUB", "BYN"
-    					],
-    					"FORM_DATA": {
-    						"ACTION_URI": "http://example.com/payment_form.php",
-    						"METHOD": "POST",
-    						"PARAMS": {
-    							"serviceid": "REST_SERVICE_ID_2",
-    							"invoiceNumber": "PAYMENT_ID_2",
-    							"Sum": "PAYMENT_SHOULD_PAY_2",
-    							"customer": "PAYMENT_BUYER_ID_2"
-    						}
-    					},
-    					"CODES": {
-    						"REST_SERVICE_ID_2": {
-    							"NAME": "Номер магазина",
-    							"DESCRIPTION": "Номер магазина",
-    							"SORT": "100"
-    						},
-    						"REST_SERVICE_KEY_2": {
-    							"NAME": "Секретный ключ",
-    							"DESCRIPTION": "Секретный ключ",
-    							"SORT": "300"
-    						},
-    						"PAYMENT_ID_2": {
-    							"NAME": "Номер оплаты",
-    							"SORT": "400",
-    							"GROUP": "PAYMENT",
-    							"DEFAULT": {
-    								"PROVIDER_KEY": "PAYMENT",
-    								"PROVIDER_VALUE": "ACCOUNT_NUMBER"
-    							}
-    						},
-    						"PAYMENT_SHOULD_PAY_2": {
-    							"NAME": "Сумма оплаты",
-    							"SORT": "600",
-    							"GROUP": "PAYMENT",
-    							"DEFAULT": {
-    								"PROVIDER_KEY": "PAYMENT",
-    								"PROVIDER_VALUE": "SUM"
-    							}
-    						},
-    						"PS_CHANGE_STATUS_PAY_2": {
-    							"NAME": "Автоматическая смена статуса оплаты",
-    							"SORT": "700",
-    							"INPUT": {
-    								"TYPE": "Y/N"
-    							}
-    						},
-    						"PAYMENT_BUYER_ID_2": {
-    							"NAME": "Код покупателя",
-    							"SORT": "1000",
-    							"GROUP": "PAYMENT",
-    							"DEFAULT": {
-    								"PROVIDER_KEY": "ORDER",
-    								"PROVIDER_VALUE": "USER_ID"
-    							}
-    						}
-    					}
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.handler.update',
+        params: {
+          ID: 3,
+          FIELDS: {
+            CODE: 'newresthandlercode',
+            NAME: 'New handler name',
+            SORT: 200,
+            SETTINGS: {
+              CURRENCY: ['RUB', 'BYN'],
+              FORM_DATA: {
+                ACTION_URI: 'http://example.com/payment_form.php',
+                METHOD: 'POST',
+                PARAMS: {
+                  serviceid: 'REST_SERVICE_ID_2',
+                  invoiceNumber: 'PAYMENT_ID_2',
+                  Sum: 'PAYMENT_SHOULD_PAY_2',
+                  customer: 'PAYMENT_BUYER_ID_2',
+                },
+              },
+              CODES: {
+                REST_SERVICE_ID_2: {
+                  NAME: 'Store number',
+                  DESCRIPTION: 'Store number',
+                  SORT: '100',
+                },
+                REST_SERVICE_KEY_2: {
+                  NAME: 'Secret key',
+                  DESCRIPTION: 'Secret key',
+                  SORT: '300',
+                },
+                PAYMENT_ID_2: {
+                  NAME: 'Payment number',
+                  SORT: '400',
+                  GROUP: 'PAYMENT',
+                  DEFAULT: {
+                    PROVIDER_KEY: 'PAYMENT',
+                    PROVIDER_VALUE: 'ACCOUNT_NUMBER',
+                  },
+                },
+                PAYMENT_SHOULD_PAY_2: {
+                  NAME: 'Payment amount',
+                  SORT: '600',
+                  GROUP: 'PAYMENT',
+                  DEFAULT: {
+                    PROVIDER_KEY: 'PAYMENT',
+                    PROVIDER_VALUE: 'SUM',
+                  },
+                },
+                PS_CHANGE_STATUS_PAY_2: {
+                  NAME: 'Automatic payment status change',
+                  SORT: '700',
+                  INPUT: {
+                    TYPE: 'Y/N',
+                  },
+                },
+                PAYMENT_BUYER_ID_2: {
+                  NAME: 'Customer code',
+                  SORT: '1000',
+                  GROUP: 'PAYMENT',
+                  DEFAULT: {
+                    PROVIDER_KEY: 'ORDER',
+                    PROVIDER_VALUE: 'USER_ID',
+                  },
+                },
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Handler updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePaySystemHandler() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.handler.update',
+            params: {
+              ID: 3,
+              FIELDS: {
+                CODE: 'newresthandlercode',
+                NAME: 'New handler name',
+                SORT: 200,
+                SETTINGS: {
+                  CURRENCY: ['RUB', 'BYN'],
+                  FORM_DATA: {
+                    ACTION_URI: 'http://example.com/payment_form.php',
+                    METHOD: 'POST',
+                    PARAMS: {
+                      serviceid: 'REST_SERVICE_ID_2',
+                      invoiceNumber: 'PAYMENT_ID_2',
+                      Sum: 'PAYMENT_SHOULD_PAY_2',
+                      customer: 'PAYMENT_BUYER_ID_2',
+                    },
+                  },
+                  CODES: {
+                    REST_SERVICE_ID_2: {
+                      NAME: 'Store number',
+                      DESCRIPTION: 'Store number',
+                      SORT: '100',
+                    },
+                    REST_SERVICE_KEY_2: {
+                      NAME: 'Secret key',
+                      DESCRIPTION: 'Secret key',
+                      SORT: '300',
+                    },
+                    PAYMENT_ID_2: {
+                      NAME: 'Payment number',
+                      SORT: '400',
+                      GROUP: 'PAYMENT',
+                      DEFAULT: {
+                        PROVIDER_KEY: 'PAYMENT',
+                        PROVIDER_VALUE: 'ACCOUNT_NUMBER',
+                      },
+                    },
+                    PAYMENT_SHOULD_PAY_2: {
+                      NAME: 'Payment amount',
+                      SORT: '600',
+                      GROUP: 'PAYMENT',
+                      DEFAULT: {
+                        PROVIDER_KEY: 'PAYMENT',
+                        PROVIDER_VALUE: 'SUM',
+                      },
+                    },
+                    PS_CHANGE_STATUS_PAY_2: {
+                      NAME: 'Automatic payment status change',
+                      SORT: '700',
+                      INPUT: {
+                        TYPE: 'Y/N',
+                      },
+                    },
+                    PAYMENT_BUYER_ID_2: {
+                      NAME: 'Customer code',
+                      SORT: '1000',
+                      GROUP: 'PAYMENT',
+                      DEFAULT: {
+                        PROVIDER_KEY: 'ORDER',
+                        PROVIDER_VALUE: 'USER_ID',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Handler updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePaySystemHandler)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-list.md
+++ b/api-reference/pay-system/sale-pay-system-list.md
@@ -90,149 +90,180 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.list
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
+    declare const $b24: B24Frame
+
+    // Shape of each PaySystemItem returned in result[]
+    type PaySystemItem = {
+      ID: number
+      PERSON_TYPE_ID: number
+      NAME: string
+      PSA_NAME: string
+      SORT: number
+      DESCRIPTION: string
+      ACTION_FILE: string
+      RESULT_FILE: string | null
+      NEW_WINDOW: string
+      TARIFF: string | null
+      PS_MODE: string | null
+      HAVE_PAYMENT: string
+      HAVE_ACTION: string
+      HAVE_RESULT: string
+      HAVE_PREPAY: string
+      HAVE_PRICE: string
+      HAVE_RESULT_RECEIVE: string
+      ENCODING: string | null
+      ACTIVE: string
+      ALLOW_EDIT_PAYMENT: string
+      IS_CASH: string
+      AUTO_CHANGE_1C: string
+      CAN_PRINT_CHECK: string
+      ENTITY_REGISTRY_TYPE: string
+      XML_ID: string
+    }
+
     try {
-      const response = await $b24.callListMethod(
-        'sale.paysystem.list',
-        {
+      // sale.paysystem.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<PaySystemItem[]>({
+        method: 'sale.paysystem.list',
+        params: {
           SELECT: [
-            "ID",
-            "PERSON_TYPE_ID",
-            "NAME",
-            "PSA_NAME",
-            "SORT",
-            "DESCRIPTION",
-            "ACTION_FILE",
-            "RESULT_FILE",
-            "NEW_WINDOW",
-            "TARIF",
-            "PS_MODE",
-            "HAVE_PAYMENT",
-            "HAVE_ACTION",
-            "HAVE_RESULT",
-            "HAVE_PREPAY",
-            "HAVE_PRICE",
-            "HAVE_RESULT_RECEIVE",
-            "ENCODING",
-            "ACTIVE",
-            "ALLOW_EDIT_PAYMENT",
-            "IS_CASH",
-            "AUTO_CHANGE_1C",
-            "CAN_PRINT_CHECK",
-            "ENTITY_REGISTRY_TYPE",
-            "XML_ID",
+            'ID',
+            'PERSON_TYPE_ID',
+            'NAME',
+            'PSA_NAME',
+            'SORT',
+            'DESCRIPTION',
+            'ACTION_FILE',
+            'RESULT_FILE',
+            'NEW_WINDOW',
+            'TARIF',
+            'PS_MODE',
+            'HAVE_PAYMENT',
+            'HAVE_ACTION',
+            'HAVE_RESULT',
+            'HAVE_PREPAY',
+            'HAVE_PRICE',
+            'HAVE_RESULT_RECEIVE',
+            'ENCODING',
+            'ACTIVE',
+            'ALLOW_EDIT_PAYMENT',
+            'IS_CASH',
+            'AUTO_CHANGE_1C',
+            'CAN_PRINT_CHECK',
+            'ENTITY_REGISTRY_TYPE',
+            'XML_ID',
           ],
           FILTER: {
-            "@ID": [117, 118],
+            '@ID': [117, 118],
           },
           ORDER: {
-            SORT: "ASC",
-            ID: "DESC",
+            SORT: 'ASC',
+            ID: 'DESC',
           },
+          start: 0,
         },
-        (progress) => { console.log('Progress:', progress) }
-      );
-      const items = response.getData() || [];
-      for (const entity of items) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
-    try {
-      const generator = $b24.fetchListMethod('sale.paysystem.list', {
-        SELECT: [
-          "ID",
-          "PERSON_TYPE_ID",
-          "NAME",
-          "PSA_NAME",
-          "SORT",
-          "DESCRIPTION",
-          "ACTION_FILE",
-          "RESULT_FILE",
-          "NEW_WINDOW",
-          "TARIF",
-          "PS_MODE",
-          "HAVE_PAYMENT",
-          "HAVE_ACTION",
-          "HAVE_RESULT",
-          "HAVE_PREPAY",
-          "HAVE_PRICE",
-          "HAVE_RESULT_RECEIVE",
-          "ENCODING",
-          "ACTIVE",
-          "ALLOW_EDIT_PAYMENT",
-          "IS_CASH",
-          "AUTO_CHANGE_1C",
-          "CAN_PRINT_CHECK",
-          "ENTITY_REGISTRY_TYPE",
-          "XML_ID",
-        ],
-        FILTER: {
-          "@ID": [117, 118],
-        },
-        ORDER: {
-          SORT: "ASC",
-          ID: "DESC",
-        },
-      }, 'ID');
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity); }
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pay systems fetched:', result.length, result[0]?.NAME)
       }
     } catch (error) {
-      console.error('Request failed', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('sale.paysystem.list', {
-        SELECT: [
-          "ID",
-          "PERSON_TYPE_ID",
-          "NAME",
-          "PSA_NAME",
-          "SORT",
-          "DESCRIPTION",
-          "ACTION_FILE",
-          "RESULT_FILE",
-          "NEW_WINDOW",
-          "TARIF",
-          "PS_MODE",
-          "HAVE_PAYMENT",
-          "HAVE_ACTION",
-          "HAVE_RESULT",
-          "HAVE_PREPAY",
-          "HAVE_PRICE",
-          "HAVE_RESULT_RECEIVE",
-          "ENCODING",
-          "ACTIVE",
-          "ALLOW_EDIT_PAYMENT",
-          "IS_CASH",
-          "AUTO_CHANGE_1C",
-          "CAN_PRINT_CHECK",
-          "ENTITY_REGISTRY_TYPE",
-          "XML_ID",
-        ],
-        FILTER: {
-          "@ID": [117, 118],
-        },
-        ORDER: {
-          SORT: "ASC",
-          ID: "DESC",
-        },
-      }, 0);
-      const result = response.getData().result || [];
-      for (const entity of result) { console.log('Entity:', entity); }
-    } catch (error) {
-      console.error('Request failed', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchPaySystemList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // sale.paysystem.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.list',
+            params: {
+              SELECT: [
+                'ID',
+                'PERSON_TYPE_ID',
+                'NAME',
+                'PSA_NAME',
+                'SORT',
+                'DESCRIPTION',
+                'ACTION_FILE',
+                'RESULT_FILE',
+                'NEW_WINDOW',
+                'TARIF',
+                'PS_MODE',
+                'HAVE_PAYMENT',
+                'HAVE_ACTION',
+                'HAVE_RESULT',
+                'HAVE_PREPAY',
+                'HAVE_PRICE',
+                'HAVE_RESULT_RECEIVE',
+                'ENCODING',
+                'ACTIVE',
+                'ALLOW_EDIT_PAYMENT',
+                'IS_CASH',
+                'AUTO_CHANGE_1C',
+                'CAN_PRINT_CHECK',
+                'ENTITY_REGISTRY_TYPE',
+                'XML_ID',
+              ],
+              FILTER: {
+                '@ID': [117, 118],
+              },
+              ORDER: {
+                SORT: 'ASC',
+                ID: 'DESC',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pay systems fetched:', result.length, result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchPaySystemList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-pay-payment.md
+++ b/api-reference/pay-system/sale-pay-system-pay-payment.md
@@ -58,27 +58,75 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.pay.payment
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.pay.payment',
-    		{
-    			"PAYMENT_ID": 1,
-    			"PAY_SYSTEM_ID": 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.pay.payment',
+        params: {
+          PAYMENT_ID: 1,
+          PAY_SYSTEM_ID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment processed:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function payPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.pay.payment',
+            params: {
+              PAYMENT_ID: 1,
+              PAY_SYSTEM_ID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment processed:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', payPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-settings-get.md
+++ b/api-reference/pay-system/sale-pay-system-settings-get.md
@@ -56,27 +56,78 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.settings.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.settings.get',
-    		{
-    			'ID': 11,
-    			'PERSON_TYPE_ID': 1,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PaySystemSettingsResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<PaySystemSettingsResult>({
+        method: 'sale.paysystem.settings.get',
+        params: {
+          ID: 11,
+          PERSON_TYPE_ID: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pay system settings retrieved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPaySystemSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.settings.get',
+            params: {
+              ID: 11,
+              PERSON_TYPE_ID: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pay system settings retrieved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPaySystemSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-settings-payment-get.md
+++ b/api-reference/pay-system/sale-pay-system-settings-payment-get.md
@@ -56,27 +56,78 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.settings.payment.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.settings.payment.get',
-    		{
-    			"PAYMENT_ID": 10,
-    			"PAY_SYSTEM_ID": 11
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type PaySystemSettingsResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<PaySystemSettingsResult>({
+        method: 'sale.paysystem.settings.payment.get',
+        params: {
+          PAYMENT_ID: 10,
+          PAY_SYSTEM_ID: 11,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Pay system settings:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getPaySystemSettingsForPayment() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.settings.payment.get',
+            params: {
+              PAYMENT_ID: 10,
+              PAY_SYSTEM_ID: 11,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Pay system settings:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getPaySystemSettingsForPayment)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-settings-update.md
+++ b/api-reference/pay-system/sale-pay-system-settings-update.md
@@ -70,33 +70,87 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.settings.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.settings.update',
-    		{
-    			'ID': 11,
-    			'PERSON_TYPE_ID': 1,
-    			'SETTINGS': {
-    				'REST_SERVICE_KEY_IFRAME': {
-    					'TYPE': 'VALUE',
-    					'VALUE': 'NEW_KEY',
-    				}
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.settings.update',
+        params: {
+          ID: 11,
+          PERSON_TYPE_ID: 1,
+          SETTINGS: {
+            REST_SERVICE_KEY_IFRAME: {
+              TYPE: 'VALUE',
+              VALUE: 'NEW_KEY',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Settings updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePaySystemSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.settings.update',
+            params: {
+              ID: 11,
+              PERSON_TYPE_ID: 1,
+              SETTINGS: {
+                REST_SERVICE_KEY_IFRAME: {
+                  TYPE: 'VALUE',
+                  VALUE: 'NEW_KEY',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Settings updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePaySystemSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/pay-system/sale-pay-system-update.md
+++ b/api-reference/pay-system/sale-pay-system-update.md
@@ -83,35 +83,91 @@
     https://**put_your_bitrix24_address**/rest/sale.paysystem.update
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sale.paysystem.update',
-    		{
-    			"ID": 12,
-    			"FIELDS": {
-    				"NAME": "Новое название платёжной системы",
-    				"DESCRIPTION": "Новое описание платёжной системы",
-    				"PERSON_TYPE_ID": 1,
-    				"BX_REST_HANDLER": 'resthandlercode',
-    				"ACTIVE": 'Y',
-    				'NEW_WINDOW': 'N',
-    				'LOGOTYPE': '/* base64 image */',
-    			}
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'sale.paysystem.update',
+        params: {
+          ID: 12,
+          FIELDS: {
+            NAME: 'New payment system name',
+            DESCRIPTION: 'New payment system description',
+            PERSON_TYPE_ID: 1,
+            BX_REST_HANDLER: 'resthandlercode',
+            ACTIVE: 'Y',
+            NEW_WINDOW: 'N',
+            LOGOTYPE: '/* base64 image */',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Payment system updated:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updatePaySystem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sale.paysystem.update',
+            params: {
+              ID: 12,
+              FIELDS: {
+                NAME: 'New payment system name',
+                DESCRIPTION: 'New payment system description',
+                PERSON_TYPE_ID: 1,
+                BX_REST_HANDLER: 'resthandlercode',
+                ACTIVE: 'Y',
+                NEW_WINDOW: 'N',
+                LOGOTYPE: '/* base64 image */',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Payment system updated:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updatePaySystem)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.