### PR TITLE
docs(lists): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/lists/elements/lists-element-add.md
+++ b/api-reference/lists/elements/lists-element-add.md
@@ -111,31 +111,89 @@
     https://**put_your_bitrix24_address**/rest/lists.element.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'lists.element.add',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 47,
-                ELEMENT_CODE: 'test_element',
-                LIST_ELEMENT_URL: '#list_id#/element/#section_id#/#element_id#/',
-                FIELDS: {
-                    NAME: 'Тестовый элемент',
-                    PROPERTY_951: ["1269", "1271"],
-                    PROPERTY_1003: "2024-12-31 23:59:59"
-                }
-            }
-        );
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'lists.element.add',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 47,
+          ELEMENT_CODE: 'test_element',
+          LIST_ELEMENT_URL: '#list_id#/element/#section_id#/#element_id#/',
+          FIELDS: {
+            NAME: 'Test element',
+            PROPERTY_951: ['1269', '1271'],
+            PROPERTY_1003: '2024-12-31 23:59:59',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        processResult(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created element ID:', result)
+      }
     } catch (error) {
-        console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addListElement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.element.add',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 47,
+              ELEMENT_CODE: 'test_element',
+              LIST_ELEMENT_URL: '#list_id#/element/#section_id#/#element_id#/',
+              FIELDS: {
+                NAME: 'Test element',
+                PROPERTY_951: ['1269', '1271'],
+                PROPERTY_1003: '2024-12-31 23:59:59',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created element ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addListElement)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/elements/lists-element-delete.md
+++ b/api-reference/lists/elements/lists-element-delete.md
@@ -89,29 +89,77 @@
     https://**put_your_bitrix24_address**/rest/lists.element.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.element.delete',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 47,
-                ELEMENT_ID: 6999,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted element with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.element.delete',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 47,
+          ELEMENT_ID: 6999,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Element deleted successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteElement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.element.delete',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 47,
+              ELEMENT_ID: 6999,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Element deleted successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteElement)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/elements/lists-element-get-file-url.md
+++ b/api-reference/lists/elements/lists-element-get-file-url.md
@@ -87,30 +87,79 @@
     https://**put_your_bitrix24_address**/rest/lists.element.get.file.url
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.element.get.file.url',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 37,
-                ELEMENT_ID: 231,
-                FIELD_ID: 423
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('URL файла:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string[]>({
+        method: 'lists.element.get.file.url',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 37,
+          ELEMENT_ID: 231,
+          FIELD_ID: 423,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('File URLs:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFileUrl() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.element.get.file.url',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 37,
+              ELEMENT_ID: 231,
+              FIELD_ID: 423,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('File URLs:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFileUrl)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/elements/lists-element-get.md
+++ b/api-reference/lists/elements/lists-element-get.md
@@ -174,43 +174,134 @@
     https://**put_your_bitrix24_address**/rest/lists.element.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'lists.element.get',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 47,
-                ELEMENT_ID: 6999,
-                SELECT: [
-                    'ID',
-                    'CODE',
-                    'NAME',
-                    'IBLOCK_SECTION_ID',
-                    'DATE_CREATE',
-                    'PROPERTY_951',
-                    'PROPERTY_1003'
-                ],
-                FILTER: {
-                    NAME: '%Тестовый%',
-                    '>=DATE_CREATE': '2025-01-01',
-                    '<=DATE_CREATE': '2025-12-31'
-                },
-                ELEMENT_ORDER: {
-                    NAME: 'asc'
-                },
-                start: 0
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Fetched elements:', result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of each element returned in result[]
+    type ElementData = {
+      ID: string
+      NAME: string
+      CODE: string
+      IBLOCK_SECTION_ID: string | null
+      CREATED_BY: string
+      PROPERTY_951: Record<string, string>
+      PROPERTY_1003: Record<string, string>
     }
+
+    try {
+      // lists.element.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ElementData[]>({
+        method: 'lists.element.get',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 47,
+          ELEMENT_ID: 6999,
+          SELECT: [
+            'ID',
+            'CODE',
+            'NAME',
+            'IBLOCK_SECTION_ID',
+            'DATE_CREATE',
+            'PROPERTY_951',
+            'PROPERTY_1003',
+          ],
+          FILTER: {
+            NAME: '%Test%',
+            '>=DATE_CREATE': '2025-01-01',
+            '<=DATE_CREATE': '2025-12-31',
+          },
+          ELEMENT_ORDER: {
+            NAME: 'asc',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fetched elements:', result.length, result[0]?.ID, result[0]?.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getListElements() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // lists.element.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.element.get',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 47,
+              ELEMENT_ID: 6999,
+              SELECT: [
+                'ID',
+                'CODE',
+                'NAME',
+                'IBLOCK_SECTION_ID',
+                'DATE_CREATE',
+                'PROPERTY_951',
+                'PROPERTY_1003',
+              ],
+              FILTER: {
+                NAME: '%Test%',
+                '>=DATE_CREATE': '2025-01-01',
+                '<=DATE_CREATE': '2025-12-31',
+              },
+              ELEMENT_ORDER: {
+                NAME: 'asc',
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fetched elements:', result.length, result[0]?.ID, result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getListElements)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/elements/lists-element-update.md
+++ b/api-reference/lists/elements/lists-element-update.md
@@ -121,32 +121,85 @@
     https://**put_your_bitrix24_address**/rest/lists.element.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.element.update',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 47,
-                ELEMENT_ID: 6999,
-                FIELDS: {
-                    NAME: 'Тестовый элемент (обновлен)',
-                    PROPERTY_951: ["1269"]
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated element with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.element.update',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 47,
+          ELEMENT_ID: 6999,
+          FIELDS: {
+            NAME: 'Test element (updated)',
+            PROPERTY_951: ['1269'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Element updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateElement() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.element.update',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 47,
+              ELEMENT_ID: 6999,
+              FIELDS: {
+                NAME: 'Test element (updated)',
+                PROPERTY_951: ['1269'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Element updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateElement)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/fields/lists-field-add.md
+++ b/api-reference/lists/fields/lists-field-add.md
@@ -199,44 +199,115 @@
     https://**put_your_bitrix24_address**/rest/lists.field.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'lists.field.add',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: '123',
-                FIELDS: {
-                    NAME: 'Проект',
-                    IS_REQUIRED: 'Y',
-                    MULTIPLE: 'N',
-                    TYPE: 'L',
-                    SORT: '10',
-                    CODE: 'PROJECT',
-                    LIST: {
-                        '10': { VALUE: 'Планирование', SORT: 10, DEF: 'Y' },
-                        '20': { VALUE: 'В разработке', SORT: 20, DEF: 'N' }
-                    },
-                    LIST_TEXT_VALUES: 'Тестирование\nЗавершен\nОтложен',
-                    SETTINGS: {
-                        SHOW_ADD_FORM: 'Y',
-                        SHOW_EDIT_FORM: 'Y',
-                        ADD_READ_ONLY_FIELD: 'N',
-                        EDIT_READ_ONLY_FIELD: 'N',
-                        SHOW_FIELD_PREVIEW: 'N'
-                    }
-                }
-            }
-        );
+      const response = await $b24.actions.v2.call.make<string>({
+        method: 'lists.field.add',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: '123',
+          FIELDS: {
+            NAME: 'Project',
+            IS_REQUIRED: 'Y',
+            MULTIPLE: 'N',
+            TYPE: 'L',
+            SORT: '10',
+            CODE: 'PROJECT',
+            LIST: {
+              '10': { VALUE: 'Planning', SORT: 10, DEF: 'Y' },
+              '20': { VALUE: 'In progress', SORT: 20, DEF: 'N' },
+            },
+            LIST_TEXT_VALUES: 'Testing\nCompleted\nPostponed',
+            SETTINGS: {
+              SHOW_ADD_FORM: 'Y',
+              SHOW_EDIT_FORM: 'Y',
+              ADD_READ_ONLY_FIELD: 'N',
+              EDIT_READ_ONLY_FIELD: 'N',
+              SHOW_FIELD_PREVIEW: 'N',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const result = response.getData().result;
-        console.log('Created field with ID:', result);
-        processResult(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created field ID:', result)
+      }
     } catch (error) {
-        console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addListField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.field.add',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: '123',
+              FIELDS: {
+                NAME: 'Project',
+                IS_REQUIRED: 'Y',
+                MULTIPLE: 'N',
+                TYPE: 'L',
+                SORT: '10',
+                CODE: 'PROJECT',
+                LIST: {
+                  '10': { VALUE: 'Planning', SORT: 10, DEF: 'Y' },
+                  '20': { VALUE: 'In progress', SORT: 20, DEF: 'N' },
+                },
+                LIST_TEXT_VALUES: 'Testing\nCompleted\nPostponed',
+                SETTINGS: {
+                  SHOW_ADD_FORM: 'Y',
+                  SHOW_EDIT_FORM: 'Y',
+                  ADD_READ_ONLY_FIELD: 'N',
+                  EDIT_READ_ONLY_FIELD: 'N',
+                  SHOW_FIELD_PREVIEW: 'N',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created field ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addListField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/fields/lists-field-delete.md
+++ b/api-reference/lists/fields/lists-field-delete.md
@@ -75,29 +75,77 @@
     https://**put_your_bitrix24_address**/rest/lists.field.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.field.delete',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: '123',
-                FIELD_ID: 'PROPERTY_1151',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted field with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.field.delete',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: '123',
+          FIELD_ID: 'PROPERTY_1151',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field deleted successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteListField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.field.delete',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: '123',
+              FIELD_ID: 'PROPERTY_1151',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field deleted successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteListField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/fields/lists-field-get.md
+++ b/api-reference/lists/fields/lists-field-get.md
@@ -75,29 +75,100 @@
     https://**put_your_bitrix24_address**/rest/lists.field.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.field.get',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: '123',
-                FIELD_ID: 'PROPERTY_1151',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Fetched field data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldsGetResult = Record<string, FieldItem>
+
+    type FieldItem = {
+      FIELD_ID: string
+      SORT: number
+      NAME: string
+      IS_REQUIRED: string
+      MULTIPLE: string
+      DEFAULT_VALUE: string
+      TYPE: string
+      PROPERTY_TYPE: string
+      PROPERTY_USER_TYPE: boolean | null
+      CODE: string
+      ID: string
+      LINK_IBLOCK_ID: string | null
+      ROW_COUNT: string
+      COL_COUNT: string
+      USER_TYPE_SETTINGS: unknown | null
+      SETTINGS: Record<string, string>
+      DISPLAY_VALUES_FORM: Record<string, string>
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<FieldsGetResult>({
+        method: 'lists.field.get',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: '123',
+          FIELD_ID: 'PROPERTY_1151',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(Object.keys(result).map(key => `${key}: ${result[key].NAME}`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchFieldData() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.field.get',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: '123',
+              FIELD_ID: 'PROPERTY_1151',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(Object.keys(result).map(key => `${key}: ${result[key].NAME}`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchFieldData)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/fields/lists-field-type-get.md
+++ b/api-reference/lists/fields/lists-field-type-get.md
@@ -75,27 +75,78 @@
     https://**put_your_bitrix24_address**/rest/lists.field.type.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.field.type.get',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: '123',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldTypeGetResult = Record<string, string>
+
+    try {
+      const response = await $b24.actions.v2.call.make<FieldTypeGetResult>({
+        method: 'lists.field.type.get',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: '123',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available field types:', Object.keys(result).length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFieldTypes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.field.type.get',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: '123',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available field types:', Object.keys(result).length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFieldTypes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/fields/lists-field-update.md
+++ b/api-reference/lists/fields/lists-field-update.md
@@ -184,48 +184,123 @@
     https://**put_your_bitrix24_address**/rest/lists.field.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-            'lists.field.update',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: '123',
-                FIELD_ID: 'PROPERTY_1151',
-                FIELDS: {
-                    NAME: 'Статус задачи',
-                    SORT: '50',
-                    IS_REQUIRED: 'N',
-                    MULTIPLE: 'N',
-                    TYPE: 'L',
-                    LIST: {
-                        '1669': { VALUE: 'Планирование', SORT: 10 },
-                        '1671': { VALUE: 'В активной работе', SORT: 20 },
-                        '1673': { VALUE: 'Тестирование', SORT: 30 },
-                        '1675': { VALUE: 'Завершен', SORT: 40 },
-                        '1677': { VALUE: 'Отложен', SORT: 50 }
-                    },
-                    LIST_TEXT_VALUES: 'Архив',
-                    LIST_DEF: ['1671'],
-                    SETTINGS: {
-                        SHOW_ADD_FORM: 'Y',
-                        SHOW_EDIT_FORM: 'Y',
-                        ADD_READ_ONLY_FIELD: 'N',
-                        EDIT_READ_ONLY_FIELD: 'Y',
-                        SHOW_FIELD_PREVIEW: 'N'
-                    }
-                }
-            }
-        );
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.field.update',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: '123',
+          FIELD_ID: 'PROPERTY_1151',
+          FIELDS: {
+            NAME: 'Task status',
+            SORT: '50',
+            IS_REQUIRED: 'N',
+            MULTIPLE: 'N',
+            TYPE: 'L',
+            LIST: {
+              '1669': { VALUE: 'Planning', SORT: 10 },
+              '1671': { VALUE: 'In progress', SORT: 20 },
+              '1673': { VALUE: 'Testing', SORT: 30 },
+              '1675': { VALUE: 'Done', SORT: 40 },
+              '1677': { VALUE: 'On hold', SORT: 50 },
+            },
+            LIST_TEXT_VALUES: 'Archive',
+            LIST_DEF: ['1671'],
+            SETTINGS: {
+              SHOW_ADD_FORM: 'Y',
+              SHOW_EDIT_FORM: 'Y',
+              ADD_READ_ONLY_FIELD: 'N',
+              EDIT_READ_ONLY_FIELD: 'Y',
+              SHOW_FIELD_PREVIEW: 'N',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-        const result = response.getData().result;
-        console.log('Updated field:', result);
-        processResult(result);
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field updated successfully:', result)
+      }
     } catch (error) {
-        console.error('Error:', error);
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateListField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.field.update',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: '123',
+              FIELD_ID: 'PROPERTY_1151',
+              FIELDS: {
+                NAME: 'Task status',
+                SORT: '50',
+                IS_REQUIRED: 'N',
+                MULTIPLE: 'N',
+                TYPE: 'L',
+                LIST: {
+                  '1669': { VALUE: 'Planning', SORT: 10 },
+                  '1671': { VALUE: 'In progress', SORT: 20 },
+                  '1673': { VALUE: 'Testing', SORT: 30 },
+                  '1675': { VALUE: 'Done', SORT: 40 },
+                  '1677': { VALUE: 'On hold', SORT: 50 },
+                },
+                LIST_TEXT_VALUES: 'Archive',
+                LIST_DEF: ['1671'],
+                SETTINGS: {
+                  SHOW_ADD_FORM: 'Y',
+                  SHOW_EDIT_FORM: 'Y',
+                  ADD_READ_ONLY_FIELD: 'N',
+                  EDIT_READ_ONLY_FIELD: 'Y',
+                  SHOW_FIELD_PREVIEW: 'N',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateListField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/lists/lists-add.md
+++ b/api-reference/lists/lists/lists-add.md
@@ -135,45 +135,117 @@ RIGHTS: {
     https://**put_your_bitrix24_address**/rest/lists.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-        const response = await $b24.callMethod(
-          'lists.add',
-          {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'lists.add',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_CODE: 'my_custom_list',
+          FIELDS: {
+            NAME: 'My new list',
+            DESCRIPTION: 'List for tracking project tasks',
+            SORT: 500,
+            BIZPROC: 'Y',
+          },
+          MESSAGES: {
+            ELEMENTS_NAME: 'Tasks',
+            ELEMENT_NAME: 'Task',
+            ELEMENT_ADD: 'Add task',
+            ELEMENT_EDIT: 'Edit task',
+            ELEMENT_DELETE: 'Delete task',
+            SECTIONS_NAME: 'Sections',
+            SECTION_NAME: 'Section',
+            SECTION_ADD: 'Add section',
+            SECTION_EDIT: 'Edit section',
+            SECTION_DELETE: 'Delete section',
+          },
+          RIGHTS: {
+            'U1271': 'X',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created list with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.add',
+            params: {
               IBLOCK_TYPE_ID: 'lists',
               IBLOCK_CODE: 'my_custom_list',
               FIELDS: {
-                NAME: 'Мой новый список',
-                DESCRIPTION: 'Список для отслеживания задач в проекте',
+                NAME: 'My new list',
+                DESCRIPTION: 'List for tracking project tasks',
                 SORT: 500,
-                BIZPROC: 'Y'
+                BIZPROC: 'Y',
               },
               MESSAGES: {
-                ELEMENTS_NAME: 'Задачи',
-                ELEMENT_NAME: 'Задача',
-                ELEMENT_ADD: 'Добавить задачу',
-                ELEMENT_EDIT: 'Изменить задачу',
-                ELEMENT_DELETE: 'Удалить задачу',
-                SECTIONS_NAME: 'Разделы',
-                SECTION_NAME: 'Раздел',
-                SECTION_ADD: 'Добавить раздел',
-                SECTION_EDIT: 'Изменить раздел',
-                SECTION_DELETE: 'Удалить раздел'
+                ELEMENTS_NAME: 'Tasks',
+                ELEMENT_NAME: 'Task',
+                ELEMENT_ADD: 'Add task',
+                ELEMENT_EDIT: 'Edit task',
+                ELEMENT_DELETE: 'Delete task',
+                SECTIONS_NAME: 'Sections',
+                SECTION_NAME: 'Section',
+                SECTION_ADD: 'Add section',
+                SECTION_EDIT: 'Edit section',
+                SECTION_DELETE: 'Delete section',
               },
               RIGHTS: {
-                'U1271': 'X'
-              }
-          }
-      );
+                'U1271': 'X',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        const result = response.getData().result;
-        console.log('Created list with ID:', result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created list with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/lists/lists-delete.md
+++ b/api-reference/lists/lists/lists-delete.md
@@ -71,25 +71,75 @@
     https://**put_your_bitrix24_address**/rest/lists.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod(
-          'lists.delete',
-          {
-            IBLOCK_TYPE_ID: 'lists',
-            IBLOCK_ID: 109,
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.delete',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 109,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('List deleted successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.delete',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 109,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
-      );
-    
-      const result = response.getData().result;
-      console.log('Deleted list with ID:', result);
-    
-      processResult(result);
-  } catch( error ) {
-      console.error('Error:', error);
-  }
+
+          const result = response.getData().result
+          console.info('List deleted successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/lists/lists-get-iblock-type-id.md
+++ b/api-reference/lists/lists/lists-get-iblock-type-id.md
@@ -64,27 +64,73 @@
     https://**put_your_bitrix24_address**/rest/lists.get.iblock.type.id
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.get.iblock.type.id',
-            {
-                IBLOCK_ID: 87,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Data:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<string | null>({
+        method: 'lists.get.iblock.type.id',
+        params: {
+          IBLOCK_ID: 87,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Iblock type id:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getIblockTypeId() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.get.iblock.type.id',
+            params: {
+              IBLOCK_ID: 87,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Iblock type id:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getIblockTypeId)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/lists/lists-get.md
+++ b/api-reference/lists/lists/lists-get.md
@@ -99,29 +99,109 @@
     https://**put_your_bitrix24_address**/rest/lists.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each list item returned in result[]
+    type ListItem = {
+      ID: string
+      TIMESTAMP_X: string
+      IBLOCK_TYPE_ID: string
+      LID: string
+      CODE: string | null
+      API_CODE: string | null
+      NAME: string
+      ACTIVE: string
+      SORT: string
+      SOCNET_GROUP_ID: string | null
+    }
+
     try {
-      const response = await $b24.callMethod(
-          'lists.get',
-          {
+      // lists.get returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ListItem[]>({
+        method: 'lists.get',
+        params: {
+          IBLOCK_TYPE_ID: 'lists_socnet',
+          SOCNET_GROUP_ID: 33,
+          IBLOCK_ORDER: {
+            SORT: 'asc',
+            NAME: 'asc',
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fetched lists:', result.length, result[0]?.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchLists() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // lists.get returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.get',
+            params: {
               IBLOCK_TYPE_ID: 'lists_socnet',
               SOCNET_GROUP_ID: 33,
               IBLOCK_ORDER: {
                 SORT: 'asc',
-                NAME: 'asc'
+                NAME: 'asc',
               },
-              start: 0
-          }
-      );
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log('Fetched lists:', result);
-      processResult(result);
-  } catch (error) {
-      console.error('Error:', error);
-  }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fetched lists:', result.length, result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchLists)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/lists/lists-update.md
+++ b/api-reference/lists/lists/lists-update.md
@@ -149,45 +149,117 @@ RIGHTS: {
     https://**put_your_bitrix24_address**/rest/lists.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
     try {
-      const response = await $b24.callMethod(
-          'lists.update',
-          {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.update',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 109,
+          FIELDS: {
+            NAME: 'Updated task list',
+            DESCRIPTION: 'Updated description: list for managing daily tasks',
+            SORT: 600,
+            BIZPROC: 'N',
+          },
+          MESSAGES: {
+            ELEMENTS_NAME: 'Items',
+            ELEMENT_NAME: 'Item',
+            ELEMENT_ADD: 'Create item',
+            ELEMENT_EDIT: 'Edit item',
+            ELEMENT_DELETE: 'Delete item',
+            SECTIONS_NAME: 'Categories',
+            SECTION_NAME: 'Category',
+            SECTION_ADD: 'Add category',
+            SECTION_EDIT: 'Edit category',
+            SECTION_DELETE: 'Delete category',
+          },
+          RIGHTS: {
+            'D15': 'W',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('List updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.update',
+            params: {
               IBLOCK_TYPE_ID: 'lists',
               IBLOCK_ID: 109,
               FIELDS: {
-                NAME: 'Обновленный список задач',
-                DESCRIPTION: 'Обновленное описание: список для управления ежедневными задачами',
+                NAME: 'Updated task list',
+                DESCRIPTION: 'Updated description: list for managing daily tasks',
                 SORT: 600,
-                BIZPROC: 'N'
+                BIZPROC: 'N',
               },
               MESSAGES: {
-                ELEMENTS_NAME: 'Пункты',
-                ELEMENT_NAME: 'Пункт',
-                ELEMENT_ADD: 'Создать пункт',
-                ELEMENT_EDIT: 'Редактировать пункт',
-                ELEMENT_DELETE: 'Удалить пункт',
-                SECTIONS_NAME: 'Категории',
-                SECTION_NAME: 'Категория',
-                SECTION_ADD: 'Добавить категорию',
-                SECTION_EDIT: 'Редактировать категорию',
-                SECTION_DELETE: 'Удалить категорию'
+                ELEMENTS_NAME: 'Items',
+                ELEMENT_NAME: 'Item',
+                ELEMENT_ADD: 'Create item',
+                ELEMENT_EDIT: 'Edit item',
+                ELEMENT_DELETE: 'Delete item',
+                SECTIONS_NAME: 'Categories',
+                SECTION_NAME: 'Category',
+                SECTION_ADD: 'Add category',
+                SECTION_EDIT: 'Edit category',
+                SECTION_DELETE: 'Delete category',
               },
               RIGHTS: {
-                'D15': 'W'
-              }
-          }
-      );
+                'D15': 'W',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-      const result = response.getData().result;
-      console.log('Updated list with ID:', result);
-      processResult(result);
-  } catch (error) {
-      console.error('Error:', error);
-  }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('List updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/sections/lists-section-add.md
+++ b/api-reference/lists/sections/lists-section-add.md
@@ -130,36 +130,93 @@
     https://**put_your_bitrix24_address**/rest/lists.section.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.section.add',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 95,
-                IBLOCK_SECTION_ID: 0,
-                SECTION_CODE: 'marketing_documents',
-                FIELDS: {
-                    NAME: 'Документы отдела маркетинга',
-                    EXTERNAL_ID: 'ext_marketing_docs_001',
-                    XML_ID: 'xml_marketing_docs_001',
-                    SORT: 500,
-                    ACTIVE: 'Y',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created section with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'lists.section.add',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 95,
+          IBLOCK_SECTION_ID: 0,
+          SECTION_CODE: 'marketing_documents',
+          FIELDS: {
+            NAME: 'Marketing department documents',
+            EXTERNAL_ID: 'ext_marketing_docs_001',
+            XML_ID: 'xml_marketing_docs_001',
+            SORT: 500,
+            ACTIVE: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created section ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addListsSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.section.add',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 95,
+              IBLOCK_SECTION_ID: 0,
+              SECTION_CODE: 'marketing_documents',
+              FIELDS: {
+                NAME: 'Marketing department documents',
+                EXTERNAL_ID: 'ext_marketing_docs_001',
+                XML_ID: 'xml_marketing_docs_001',
+                SORT: 500,
+                ACTIVE: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created section ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addListsSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/sections/lists-section-delete.md
+++ b/api-reference/lists/sections/lists-section-delete.md
@@ -83,28 +83,77 @@
     https://**put_your_bitrix24_address**/rest/lists.section.delete
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.section.delete',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 95,
-                SECTION_ID: 169,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted section:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.section.delete',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 95,
+          SECTION_ID: 169,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Section deleted:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.section.delete',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 95,
+              SECTION_ID: 169,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Section deleted:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteSection)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/sections/lists-section-get.md
+++ b/api-reference/lists/sections/lists-section-get.md
@@ -135,53 +135,148 @@
     https://**put_your_bitrix24_address**/rest/lists.section.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.section.get',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 95,
-                FILTER: {
-                    ID: 169,
-                    ACTIVE: 'Y',
-                    NAME: '%маркетинг%',
-                    '>=DATE_CREATE': '2025-01-01',
-                    '<=DATE_CREATE': '2025-12-31'
-                },
-                SELECT: [
-                    'ID',
-                    'CODE',
-                    'XML_ID',
-                    'EXTERNAL_ID',
-                    'IBLOCK_SECTION_ID',
-                    'TIMESTAMP_X',
-                    'SORT',
-                    'NAME',
-                    'ACTIVE',
-                    'GLOBAL_ACTIVE',
-                    'LEFT_MARGIN',
-                    'RIGHT_MARGIN',
-                    'DEPTH_LEVEL',
-                    'SEARCHABLE_CONTENT',
-                    'MODIFIED_BY',
-                    'DATE_CREATE',
-                    'CREATED_BY',
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Retrieved sections:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each SectionItem returned in result[]
+    type SectionItem = {
+      ID: string
+      CODE: string
+      XML_ID: string
+      EXTERNAL_ID: string
+      IBLOCK_SECTION_ID: string | null
+      TIMESTAMP_X: string
+      SORT: string
+      NAME: string
+      ACTIVE: string
+      GLOBAL_ACTIVE: string
+      LEFT_MARGIN: string
+      RIGHT_MARGIN: string
+      DEPTH_LEVEL: string
+      SEARCHABLE_CONTENT: string
+      MODIFIED_BY: string
+      DATE_CREATE: string
+      CREATED_BY: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SectionItem[]>({
+        method: 'lists.section.get',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 95,
+          FILTER: {
+            ID: 169,
+            ACTIVE: 'Y',
+            NAME: '%marketing%',
+            '>=DATE_CREATE': '2025-01-01',
+            '<=DATE_CREATE': '2025-12-31',
+          },
+          SELECT: [
+            'ID',
+            'CODE',
+            'XML_ID',
+            'EXTERNAL_ID',
+            'IBLOCK_SECTION_ID',
+            'TIMESTAMP_X',
+            'SORT',
+            'NAME',
+            'ACTIVE',
+            'GLOBAL_ACTIVE',
+            'LEFT_MARGIN',
+            'RIGHT_MARGIN',
+            'DEPTH_LEVEL',
+            'SEARCHABLE_CONTENT',
+            'MODIFIED_BY',
+            'DATE_CREATE',
+            'CREATED_BY',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Retrieved sections:', result.length, result[0]?.NAME)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getListSections() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.section.get',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 95,
+              FILTER: {
+                ID: 169,
+                ACTIVE: 'Y',
+                NAME: '%marketing%',
+                '>=DATE_CREATE': '2025-01-01',
+                '<=DATE_CREATE': '2025-12-31',
+              },
+              SELECT: [
+                'ID',
+                'CODE',
+                'XML_ID',
+                'EXTERNAL_ID',
+                'IBLOCK_SECTION_ID',
+                'TIMESTAMP_X',
+                'SORT',
+                'NAME',
+                'ACTIVE',
+                'GLOBAL_ACTIVE',
+                'LEFT_MARGIN',
+                'RIGHT_MARGIN',
+                'DEPTH_LEVEL',
+                'SEARCHABLE_CONTENT',
+                'MODIFIED_BY',
+                'DATE_CREATE',
+                'CREATED_BY',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Retrieved sections:', result.length, result[0]?.NAME)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getListSections)
+    </script>
     ```
 
 - PHP

--- a/api-reference/lists/sections/lists-section-update.md
+++ b/api-reference/lists/sections/lists-section-update.md
@@ -136,35 +136,91 @@
     https://**put_your_bitrix24_address**/rest/lists.section.update
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'lists.section.update',
-            {
-                IBLOCK_TYPE_ID: 'lists',
-                IBLOCK_ID: 95,
-                SECTION_ID: 169,
-                FIELDS: {
-                    NAME: 'Обновленные документы маркетинга',
-                    EXTERNAL_ID: 'ext_marketing_docs_002',
-                    XML_ID: 'xml_marketing_docs_002',
-                    SORT: 600,
-                    ACTIVE: 'Y',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Updated section with ID:', result);
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'lists.section.update',
+        params: {
+          IBLOCK_TYPE_ID: 'lists',
+          IBLOCK_ID: 95,
+          SECTION_ID: 169,
+          FIELDS: {
+            NAME: 'Updated marketing documents',
+            EXTERNAL_ID: 'ext_marketing_docs_002',
+            XML_ID: 'xml_marketing_docs_002',
+            SORT: 600,
+            ACTIVE: 'Y',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Section updated successfully:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateSection() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'lists.section.update',
+            params: {
+              IBLOCK_TYPE_ID: 'lists',
+              IBLOCK_ID: 95,
+              SECTION_ID: 169,
+              FIELDS: {
+                NAME: 'Updated marketing documents',
+                EXTERNAL_ID: 'ext_marketing_docs_002',
+                XML_ID: 'xml_marketing_docs_002',
+                SORT: 600,
+                ACTIVE: 'Y',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Section updated successfully:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateSection)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.