### PR TITLE
docs(sign): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/sign/sign-b2e-company-provider-list.md
+++ b/api-reference/sign/sign-b2e-company-provider-list.md
@@ -68,33 +68,104 @@
     https://**put_your_bitrix24_address**/rest/sign.b2e.company.provider.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sign.b2e.company.provider.list',
-    		{
-    			// UUID компании в HCM Link или ID компании в CRM
-    			companyCrmId: 12,
-    
-    			// Язык локализации названий провайдеров
-    			language: 'ru',
-    
-    			// Параметры постраничной навигации
-    			limit: 2,
-    			offset: 0
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of each provider item returned in result[]
+    type ProviderItem = {
+      code: string
+      uid: string
+      name: string
+      date: ISODate | null
+      expires: ISODate | null
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      // sign.b2e.company.provider.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<ProviderItem[]>({
+        method: 'sign.b2e.company.provider.list',
+        params: {
+          // UUID of the company in HCM Link or its CRM company ID
+          companyCrmId: 12,
+          // Language for provider name localization
+          language: 'en',
+          // Pagination parameters
+          limit: 2,
+          offset: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.length, result[0]?.name, result[0]?.uid)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchCompanyProviders() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // sign.b2e.company.provider.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'sign.b2e.company.provider.list',
+            params: {
+              // UUID of the company in HCM Link or its CRM company ID
+              companyCrmId: 12,
+              // Language for provider name localization
+              language: 'en',
+              // Pagination parameters
+              limit: 2,
+              offset: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.length, result[0]?.name, result[0]?.uid)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchCompanyProviders)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sign/sign-b2e-document-get.md
+++ b/api-reference/sign/sign-b2e-document-get.md
@@ -48,26 +48,98 @@
     https://**put_your_bitrix24_address**/rest/sign.b2e.document.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sign.b2e.document.get',
-    		{
-    			uid: 'b6f5f1f1-9d20-4b6b-ae0f-2f0a8a0c2b3c',
-    			language: 'ru'
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DocumentGetResult = {
+      uid: string
+      state: {
+        code: string
+        name: string
+      }
+      members: {
+        uid: string
+        role: string
+        party: number
+        user: {
+          employeeCode: string
+          employeeId: number
+          userId: number
+        }
+        state: {
+          code: string
+          name: string
+        }
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<DocumentGetResult>({
+        method: 'sign.b2e.document.get',
+        params: {
+          uid: 'b6f5f1f1-9d20-4b6b-ae0f-2f0a8a0c2b3c',
+          language: 'ru',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.uid, result.state.code, result.members.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sign.b2e.document.get',
+            params: {
+              uid: 'b6f5f1f1-9d20-4b6b-ae0f-2f0a8a0c2b3c',
+              language: 'ru',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.uid, result.state.code, result.members.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sign/sign-b2e-document-send.md
+++ b/api-reference/sign/sign-b2e-document-send.md
@@ -170,45 +170,136 @@
     https://**put_your_bitrix24_address**/rest/sign.b2e.document.send
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sign.b2e.document.send',
-    		{
-    			fields: {
-    				company: { crmId: 12 },
-    				members: [
-    					{ userId: 25, role: 'signer' },
-    					{ userId: 42, role: 'assignee' }
-    				],
-    				responsible: { userId: 7 },
-    				companyProviderUid: 'd4f6b8a1-4c6d-4d8c-9c7c-2d1b1f6d0f2b',
-    				files: [
-    					{
-    						fileName: 'contract.pdf',
-    						fileType: 'application/pdf',
-    						fileContent: 'JVBERi0xLjQKJ...'
-    					}
-    				],
-    				regionDocumentType: '12.999',
-    				externalSettings: {
-    					externalId: 'EXT-123',
-    					externalDateCreate: '2025-02-18T09:19:34+03:00'
-    				}
-    			}
-    		}
-    	);
-    
-    	const result = response.getData().result;
-    	console.dir(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SendDocumentResult = {
+      uid: string
+      state: {
+        code: string
+        name: string
+      }
+      members: {
+        uid: string
+        role: string
+        party: number
+        user: {
+          employeeCode: string
+          employeeId: number
+          userId: number
+        }
+        state: {
+          code: string
+          name: string
+        }
+      }[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SendDocumentResult>({
+        method: 'sign.b2e.document.send',
+        params: {
+          fields: {
+            company: { crmId: 12 },
+            members: [
+              { userId: 25, role: 'signer' },
+              { userId: 42, role: 'assignee' },
+            ],
+            responsible: { userId: 7 },
+            companyProviderUid: 'd4f6b8a1-4c6d-4d8c-9c7c-2d1b1f6d0f2b',
+            files: [
+              {
+                fileName: 'contract.pdf',
+                fileType: 'application/pdf',
+                fileContent: 'JVBERi0xLjQKJ...',
+              },
+            ],
+            regionDocumentType: '12.999',
+            externalSettings: {
+              externalId: 'EXT-123',
+              externalDateCreate: '2025-02-18T09:19:34+03:00',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Document uid:', result.uid, 'state:', result.state.code, 'members:', result.members.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendDocument() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sign.b2e.document.send',
+            params: {
+              fields: {
+                company: { crmId: 12 },
+                members: [
+                  { userId: 25, role: 'signer' },
+                  { userId: 42, role: 'assignee' },
+                ],
+                responsible: { userId: 7 },
+                companyProviderUid: 'd4f6b8a1-4c6d-4d8c-9c7c-2d1b1f6d0f2b',
+                files: [
+                  {
+                    fileName: 'contract.pdf',
+                    fileType: 'application/pdf',
+                    fileContent: 'JVBERi0xLjQKJ...',
+                  },
+                ],
+                regionDocumentType: '12.999',
+                externalSettings: {
+                  externalId: 'EXT-123',
+                  externalDateCreate: '2025-02-18T09:19:34+03:00',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Document uid:', result.uid, 'state:', result.state.code, 'members:', result.members.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendDocument)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sign/sign-b2e-mysafe-tail.md
+++ b/api-reference/sign/sign-b2e-mysafe-tail.md
@@ -53,31 +53,97 @@
     https://**put_your_bitrix24_address**/rest/sign.b2e.mysafe.tail
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sign.b2e.mysafe.tail',
-    		{
-    			// Количество записей на странице. Значение от 1 до 50. По умолчанию 20.
-    			limit: 2,
-    			
-    			// Параметр для управления постраничной навигацией.
-    			// Используется для указания смещения от начала списка.
-    			offset: 0
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of each SafeDocument returned in result[]
+    type SafeDocument = {
+      id: number
+      title: string
+      create_date: ISODate | null
+      signed_date: ISODate | null
+      creator_id: number
+      member_id: number
+      role: string
+      file_url: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      // sign.b2e.mysafe.tail returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<SafeDocument[]>({
+        method: 'sign.b2e.mysafe.tail',
+        params: {
+          limit: 2,
+          offset: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fetched documents:', result.length, result.map(d => `[${d.id}] ${d.title}`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSafeDocuments() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // sign.b2e.mysafe.tail returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'sign.b2e.mysafe.tail',
+            params: {
+              limit: 2,
+              offset: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fetched documents:', result.length, result.map(d => `[${d.id}] ${d.title}`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSafeDocuments)
+    </script>
     ```
 
 - PHP

--- a/api-reference/sign/sign-b2e-personal-tail.md
+++ b/api-reference/sign/sign-b2e-personal-tail.md
@@ -53,31 +53,87 @@
     https://**put_your_bitrix24_address**/rest/sign.b2e.personal.tail
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'sign.b2e.personal.tail',
-    		{
-    			// Количество записей на странице. Значение от 1 до 50. По умолчанию 20.
-    			limit: 2,
-    			
-    			// Параметр для управления постраничной навигацией.
-    			// Используется для указания смещения от начала списка.
-    			offset: 0
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
+    declare const $b24: B24Frame
+
+    // Shape of each signed document returned in result[]
+    type SignedDocumentItem = {
+      id: number
+      title: string
+      signed_date: ISODate | null
+      file_url: string
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<SignedDocumentItem[]>({
+        method: 'sign.b2e.personal.tail',
+        params: {
+          // Number of records per page. Value from 1 to 50. Default is 20.
+          limit: 2,
+          // Offset for pagination (analogous to the standard start parameter).
+          offset: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Signed documents:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchSignedDocuments() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'sign.b2e.personal.tail',
+            params: {
+              // Number of records per page. Value from 1 to 50. Default is 20.
+              limit: 2,
+              // Offset for pagination (analogous to the standard start parameter).
+              offset: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Signed documents:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchSignedDocuments)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.