### PR TITLE
docs(timeman): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/timeman/base/timeman-close.md
+++ b/api-reference/timeman/base/timeman-close.md
@@ -68,30 +68,99 @@
     https://**put_your_bitrix24_address**/rest/timeman.close
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.close',
-    		{
-    			'USER_ID' : 503,
-    			'TIME': '2025-03-27T17:00:01+00:00',
-    			'REPORT': 'Забыла закрыть рабочий день',
-    			'LAT': 53.548841, 
-    			'LON': 9.987274
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimemanCloseResult = {
+      STATUS: string,
+      TIME_START: ISODate,
+      TIME_FINISH: ISODate | null,
+      DURATION: string,
+      TIME_LEAKS: string,
+      ACTIVE: boolean,
+      IP_OPEN: string,
+      IP_CLOSE: string | null,
+      LAT_OPEN: number,
+      LON_OPEN: number,
+      LAT_CLOSE: number,
+      LON_CLOSE: number,
+      TZ_OFFSET: number,
+      TIME_FINISH_DEFAULT?: ISODate | null,
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimemanCloseResult>({
+        method: 'timeman.close',
+        params: {
+          USER_ID: 503,
+          TIME: '2025-03-27T17:00:01+00:00',
+          REPORT: 'Forgot to close the workday',
+          LAT: 53.548841,
+          LON: 9.987274,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.STATUS, result.TIME_START, result.TIME_FINISH, result.DURATION)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function closeWorkday() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.close',
+            params: {
+              USER_ID: 503,
+              TIME: '2025-03-27T17:00:01+00:00',
+              REPORT: 'Forgot to close the workday',
+              LAT: 53.548841,
+              LON: 9.987274,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.STATUS, result.TIME_START, result.TIME_FINISH, result.DURATION)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', closeWorkday)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/base/timeman-open.md
+++ b/api-reference/timeman/base/timeman-open.md
@@ -70,30 +70,99 @@
     https://**put_your_bitrix24_address**/rest/timeman.open
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.open',
-    		{
-    			'USER_ID' : 503,
-    			'TIME': '2025-03-27T08:00:01+00:00',
-    			'REPORT': 'Забыла открыть рабочий день',
-    			'LAT': 53.548841, 
-    			'LON': 9.987274
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimemanOpenResult = {
+      STATUS: string
+      TIME_START: ISODate
+      TIME_FINISH: ISODate | null
+      DURATION: string
+      TIME_LEAKS: string
+      ACTIVE: boolean
+      IP_OPEN: string
+      IP_CLOSE: string
+      LAT_OPEN: number
+      LON_OPEN: number
+      LAT_CLOSE: number
+      LON_CLOSE: number
+      TZ_OFFSET: number
+      TIME_FINISH_DEFAULT?: ISODate
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimemanOpenResult>({
+        method: 'timeman.open',
+        params: {
+          USER_ID: 503,
+          TIME: '2025-03-27T08:00:01+00:00',
+          REPORT: 'Forgot to open the working day',
+          LAT: 53.548841,
+          LON: 9.987274,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Status:', result.STATUS, '| Start:', result.TIME_START)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function openWorkday() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.open',
+            params: {
+              USER_ID: 503,
+              TIME: '2025-03-27T08:00:01+00:00',
+              REPORT: 'Forgot to open the working day',
+              LAT: 53.548841,
+              LON: 9.987274,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Status:', result.STATUS, '| Start:', result.TIME_START)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', openWorkday)
+    </script>
     ```
 
 - BX24.js

--- a/api-reference/timeman/base/timeman-pause.md
+++ b/api-reference/timeman/base/timeman-pause.md
@@ -54,26 +54,91 @@
     https://**put_your_bitrix24_address**/rest/timeman.pause
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.pause',
-    		{
-    			'USER_ID' : 503
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimemanPauseResult = {
+      STATUS: string
+      TIME_START: ISODate
+      TIME_FINISH: ISODate | null
+      DURATION: string
+      TIME_LEAKS: string
+      ACTIVE: boolean
+      IP_OPEN: string
+      IP_CLOSE: string
+      LAT_OPEN: number
+      LON_OPEN: number
+      LAT_CLOSE: number
+      LON_CLOSE: number
+      TZ_OFFSET: number
+      TIME_FINISH_DEFAULT?: ISODate
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimemanPauseResult>({
+        method: 'timeman.pause',
+        params: {
+          USER_ID: 503,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Status:', result.STATUS, 'Start:', result.TIME_START)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function pauseWorkday() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.pause',
+            params: {
+              USER_ID: 503,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Status:', result.STATUS, 'Start:', result.TIME_START)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', pauseWorkday)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/base/timeman-settings.md
+++ b/api-reference/timeman/base/timeman-settings.md
@@ -52,26 +52,84 @@
     https://**put_your_bitrix24_address**/rest/timeman.settings
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.settings',
-    		{
-    			'USER_ID' : 503
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimemanSettingsResult = {
+      UF_TIMEMAN: boolean
+      UF_TM_FREE: boolean
+      UF_TM_MAX_START: string
+      UF_TM_MIN_FINISH: string
+      UF_TM_MIN_DURATION: string
+      UF_TM_ALLOWED_DELTA: string
+      ADMIN: boolean
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimemanSettingsResult>({
+        method: 'timeman.settings',
+        params: {
+          USER_ID: 503,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Time tracking enabled:', result.UF_TIMEMAN, 'Free schedule:', result.UF_TM_FREE, 'Admin:', result.ADMIN)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTimemanSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.settings',
+            params: {
+              USER_ID: 503,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Time tracking enabled:', result.UF_TIMEMAN, 'Free schedule:', result.UF_TM_FREE, 'Admin:', result.ADMIN)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTimemanSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/base/timeman-status.md
+++ b/api-reference/timeman/base/timeman-status.md
@@ -52,26 +52,91 @@
     https://**put_your_bitrix24_address**/rest/timeman.status
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.status',
-    		{
-    			'USER_ID' : 503
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimemanStatusResult = {
+      STATUS: string
+      TIME_START: ISODate | null
+      TIME_FINISH: ISODate | null
+      DURATION: string
+      TIME_LEAKS: string
+      ACTIVE: boolean
+      IP_OPEN: string
+      IP_CLOSE: string | null
+      LAT_OPEN: number
+      LON_OPEN: number
+      LAT_CLOSE: number
+      LON_CLOSE: number
+      TZ_OFFSET: number
+      TIME_FINISH_DEFAULT: ISODate | null
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimemanStatusResult>({
+        method: 'timeman.status',
+        params: {
+          USER_ID: 503,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Status:', result.STATUS, 'Started:', result.TIME_START)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTimemanStatus() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.status',
+            params: {
+              USER_ID: 503,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Status:', result.STATUS, 'Started:', result.TIME_START)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTimemanStatus)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/networkrange/timeman-networkrange-check.md
+++ b/api-reference/timeman/networkrange/timeman-networkrange-check.md
@@ -54,26 +54,88 @@
     https://**put_your_bitrix24_address**/rest/timeman.networkrange.check
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.networkrange.check',
-    		{
-    			'IP': '10.10.255.255'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NetworkRangeCheckResult = {
+      ip: string
+      range: string
+      name: string
+    } | false
+
+    try {
+      const response = await $b24.actions.v2.call.make<NetworkRangeCheckResult>({
+        method: 'timeman.networkrange.check',
+        params: {
+          IP: '10.10.255.255',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        if (result) {
+          console.info(result.ip, result.range, result.name)
+        } else {
+          console.info('IP address is not in any network range')
+        }
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error.ex);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function checkNetworkRange() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.networkrange.check',
+            params: {
+              IP: '10.10.255.255',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          if (result) {
+            console.info(result.ip, result.range, result.name)
+          } else {
+            console.info('IP address is not in any network range')
+          }
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', checkNetworkRange)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/networkrange/timeman-networkrange-get.md
+++ b/api-reference/timeman/networkrange/timeman-networkrange-get.md
@@ -45,24 +45,75 @@
     https://**put_your_bitrix24_address**/rest/timeman.networkrange.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.networkrange.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of each NetworkRangeItem returned in result[]
+    type NetworkRangeItem = {
+      ip_range: string
+      name: string
     }
-    catch( error )
-    {
-    	console.error('Error:', error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<NetworkRangeItem[]>({
+        method: 'timeman.networkrange.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Network ranges:', result.map(r => `${r.name}: ${r.ip_range}`))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNetworkRanges() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.networkrange.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Network ranges:', result.map(r => `${r.name}: ${r.ip_range}`))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNetworkRanges)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/networkrange/timeman-networkrange-set.md
+++ b/api-reference/timeman/networkrange/timeman-networkrange-set.md
@@ -70,39 +70,108 @@ ranges: [
     https://**put_your_bitrix24_address**/rest/timeman.networkrange.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.networkrange.set',
-    		{
-    			ranges: [
-    				{
-    					"ip_range": "10.0.0.0-10.255.255.255",
-    					"name": "Офисная сеть 10.x.x.x"
-    				},
-    				{
-    					"ip_range": "172.16.0.0-172.31.255.255",
-    					"name": "Офисная сеть 172.x.x.x"
-    				},
-    				{
-    					"ip_range": "192.168.0.0-192.168.255.255",
-    					"name": "Офисная сеть 192.168.x.x"
-    				}
-    			]
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.log(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NetworkRangeSetResult = {
+      result: boolean
+      error_ranges?: Array<{
+        ip_range: string
+        name: string
+      }>
     }
-    catch( error )
-    {
-    	console.error(error.ex);
+
+    try {
+      const response = await $b24.actions.v2.call.make<NetworkRangeSetResult>({
+        method: 'timeman.networkrange.set',
+        params: {
+          ranges: [
+            {
+              ip_range: '10.0.0.0-10.255.255.255',
+              name: 'Office network 10.x.x.x',
+            },
+            {
+              ip_range: '172.16.0.0-172.31.255.255',
+              name: 'Office network 172.x.x.x',
+            },
+            {
+              ip_range: '192.168.0.0-192.168.255.255',
+              name: 'Office network 192.168.x.x',
+            },
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Set result:', result.result, 'Error ranges:', result.error_ranges)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setNetworkRanges() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.networkrange.set',
+            params: {
+              ranges: [
+                {
+                  ip_range: '10.0.0.0-10.255.255.255',
+                  name: 'Office network 10.x.x.x',
+                },
+                {
+                  ip_range: '172.16.0.0-172.31.255.255',
+                  name: 'Office network 172.x.x.x',
+                },
+                {
+                  ip_range: '192.168.0.0-192.168.255.255',
+                  name: 'Office network 192.168.x.x',
+                },
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Set result:', result.result, 'Error ranges:', result.error_ranges)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setNetworkRanges)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/schedule/timeman-schedule-get.md
+++ b/api-reference/timeman/schedule/timeman-schedule-get.md
@@ -52,28 +52,141 @@
     https://**put_your_bitrix24_address**/rest/timeman.schedule.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		"timeman.schedule.get",
-    		{
-    			id: 1
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.dir(result);
-    	if(response.more())
-    		response.next();
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ScheduleGetResult = {
+      ID: number
+      NAME: string
+      SCHEDULE_TYPE: string
+      REPORT_PERIOD: string
+      REPORT_PERIOD_OPTIONS: {
+        START_WEEK_DAY: number
+      }
+      CALENDAR_ID: number
+      ALLOWED_DEVICES: {
+        browser: boolean
+      }
+      DELETED: string
+      IS_FOR_ALL_USERS: boolean
+      WORKTIME_RESTRICTIONS: string[]
+      CONTROLLED_ACTIONS: number
+      UPDATED_BY: number
+      DELETED_BY: number
+      DELETED_AT: string
+      CREATED_BY: number
+      CREATED_AT: ISODate
+      SHIFTS: {
+        ID: number
+        NAME: string
+        BREAK_DURATION: number
+        WORK_TIME_START: number
+        WORK_TIME_END: number
+        WORK_DAYS: string
+        SCHEDULE_ID: number
+        DELETED: boolean
+      }[]
+      CALENDAR: {
+        ID: number
+        NAME: string
+        PARENT_CALENDAR_ID: number
+        SYSTEM_CODE: string
+        EXCLUSIONS: string[]
+      }
+      SCHEDULE_VIOLATION_RULES: {
+        ID: number
+        SCHEDULE_ID: number
+        ENTITY_CODE: string
+        MAX_EXACT_START: number
+        MIN_EXACT_END: number
+        MAX_OFFSET_START: number
+        MIN_OFFSET_END: number
+        RELATIVE_START_FROM: number
+        RELATIVE_START_TO: number
+        RELATIVE_END_FROM: number
+        RELATIVE_END_TO: number
+        MIN_DAY_DURATION: number
+        MAX_ALLOWED_TO_EDIT_WORK_TIME: number
+        MAX_WORK_TIME_LACK_FOR_PERIOD: number
+        PERIOD_TIME_LACK_AGENT_ID: number
+        MAX_SHIFT_START_DELAY: number
+        MISSED_SHIFT_START: number
+        USERS_TO_NOTIFY: {
+          FIXED_START_END: string[]
+          FIXED_PER_RECORD: string[]
+          FIXED_EDIT_WORKTIME: string[]
+          FIXED_PERIODIC: string[]
+          SHIFT_DELAY: string[]
+          SHIFT_MISSED_START: string[]
+        }
+      }
     }
-    catch(error)
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<ScheduleGetResult>({
+        method: 'timeman.schedule.get',
+        params: {
+          id: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Schedule:', result.ID, result.NAME, result.SCHEDULE_TYPE)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getSchedule() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.schedule.get',
+            params: {
+              id: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Schedule:', result.ID, result.NAME, result.SCHEDULE_TYPE)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getSchedule)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/timecontrol/timeman-timecontrol-report-add.md
+++ b/api-reference/timeman/timecontrol/timeman-timecontrol-report-add.md
@@ -74,29 +74,79 @@
     https://**put_your_bitrix24_address**/rest/timeman.timecontrol.report.add
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.timecontrol.report.add',
-    		{
-    			'REPORT_ID': 123,
-    			'TEXT': 'Работал над проектом',
-    			'TYPE': 'WORK',
-    			'CALENDAR': 'Y'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'timeman.timecontrol.report.add',
+        params: {
+          REPORT_ID: 123,
+          TEXT: 'Worked on project',
+          TYPE: 'WORK',
+          CALENDAR: 'Y',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Report added:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTimecontrolReport() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.timecontrol.report.add',
+            params: {
+              REPORT_ID: 123,
+              TEXT: 'Worked on project',
+              TYPE: 'WORK',
+              CALENDAR: 'Y',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Report added:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTimecontrolReport)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/timecontrol/timeman-timecontrol-reports-get.md
+++ b/api-reference/timeman/timecontrol/timeman-timecontrol-reports-get.md
@@ -68,30 +68,133 @@
     https://**put_your_bitrix24_address**/rest/timeman.timecontrol.reports.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.timecontrol.reports.get',
-    		{
-    			'USER_ID': 3,
-    			'MONTH': 5,
-    			'YEAR': 2025,
-    			'IDLE_MINUTES': 15,
-    			'WORKDAY_HOURS': 8
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimecontrolReportResult = {
+      report: {
+        month_title: string
+        date_start: ISODate
+        date_finish: ISODate
+        days: {
+          index: string
+          day_title: string
+          workday_date_start: ISODate
+          workday_date_finish: ISODate
+          workday_complete: boolean
+          workday_time_leaks_user: number
+          workday_time_leaks_final: number
+          workday_duration: number
+          workday_duration_final: number
+          workday_duration_config: number
+          reports: {
+            id: string
+            user_id: string
+            type: string
+            date_start: ISODate
+            date_finish: ISODate
+            duration: number
+            active: boolean
+            entry_id: string
+            report_type: string
+            report_text: string
+            system_text: string | null
+            source_start: string
+            source_finish: string
+            ip_start: string
+            ip_finish: string
+            ip_start_network: boolean | object
+            ip_finish_network: boolean | object
+          }[]
+          workday_time_leaks_real: number
+        }[]
+      }
+      user: {
+        id: number
+        active: boolean
+        name: string
+        first_name: string
+        last_name: string
+        work_position: string
+        avatar: string
+        personal_gender: string
+        last_activity_date: ISODate
+      }
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimecontrolReportResult>({
+        method: 'timeman.timecontrol.reports.get',
+        params: {
+          USER_ID: 3,
+          MONTH: 5,
+          YEAR: 2025,
+          IDLE_MINUTES: 15,
+          WORKDAY_HOURS: 8,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.report.month_title, result.report.days.length, result.user.name)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTimecontrolReport() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.timecontrol.reports.get',
+            params: {
+              USER_ID: 3,
+              MONTH: 5,
+              YEAR: 2025,
+              IDLE_MINUTES: 15,
+              WORKDAY_HOURS: 8,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.report.month_title, result.report.days.length, result.user.name)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTimecontrolReport)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/timecontrol/timeman-timecontrol-reports-settings-get.md
+++ b/api-reference/timeman/timecontrol/timeman-timecontrol-reports-settings-get.md
@@ -44,24 +44,90 @@
     https://**put_your_bitrix24_address**/rest/timeman.timecontrol.reports.settings.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.timecontrol.reports.settings.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimeControlReportsSettingsResult = {
+      active: boolean
+      user_id: number
+      user_admin: boolean
+      user_head: boolean
+      departments: { id: string; name: string }[]
+      minimum_idle_for_report: number
+      report_view_type: 'none' | 'head' | 'full' | 'simple'
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimeControlReportsSettingsResult>({
+        method: 'timeman.timecontrol.reports.settings.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          'active:', result.active,
+          'user_id:', result.user_id,
+          'report_view_type:', result.report_view_type,
+          'departments:', result.departments
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTimeControlReportsSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.timecontrol.reports.settings.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            'active:', result.active,
+            'user_id:', result.user_id,
+            'report_view_type:', result.report_view_type,
+            'departments:', result.departments
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTimeControlReportsSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/timecontrol/timeman-timecontrol-reports-users-get.md
+++ b/api-reference/timeman/timecontrol/timeman-timecontrol-reports-users-get.md
@@ -57,26 +57,85 @@
     https://**put_your_bitrix24_address**/rest/timeman.timecontrol.reports.users.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.timecontrol.reports.users.get',
-    		{
-    			'DEPARTMENT_ID': 15
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of each UserItem returned in result[]
+    type UserItem = {
+      id: number
+      name: string
+      first_name: string
+      last_name: string
+      work_position: string
+      avatar: string
+      personal_gender: string
+      last_activity_date: ISODate | null
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<UserItem[]>({
+        method: 'timeman.timecontrol.reports.users.get',
+        params: {
+          DEPARTMENT_ID: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Users count:', result.length, 'First user:', result[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getDepartmentUsers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.timecontrol.reports.users.get',
+            params: {
+              DEPARTMENT_ID: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Users count:', result.length, 'First user:', result[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getDepartmentUsers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/timecontrol/timeman-timecontrol-settings-get.md
+++ b/api-reference/timeman/timecontrol/timeman-timecontrol-settings-get.md
@@ -44,24 +44,84 @@
     https://**put_your_bitrix24_address**/rest/timeman.timecontrol.settings.get
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.timecontrol.settings.get',
-    		{}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimecontrolSettingsGetResult = {
+      active: boolean
+      minimum_idle_for_report: number
+      register_offline: boolean
+      register_idle: boolean
+      register_desktop: boolean
+      report_request_type: string
+      report_request_users: number[]
+      report_simple_type: string
+      report_simple_users: number[]
+      report_full_type: string
+      report_full_users: number[]
     }
-    catch( error )
-    {
-    	console.error(error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<TimecontrolSettingsGetResult>({
+        method: 'timeman.timecontrol.settings.get',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('active:', result.active, 'report_request_type:', result.report_request_type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTimecontrolSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.timecontrol.settings.get',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('active:', result.active, 'report_request_type:', result.report_request_type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTimecontrolSettings)
+    </script>
     ```
 
 - PHP

--- a/api-reference/timeman/timecontrol/timeman-timecontrol-settings-set.md
+++ b/api-reference/timeman/timecontrol/timeman-timecontrol-settings-set.md
@@ -94,33 +94,87 @@
     https://**put_your_bitrix24_address**/rest/timeman.timecontrol.settings.set
     ```
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'timeman.timecontrol.settings.set',
-    		{
-    			'ACTIVE': true,
-    			'MINIMUM_IDLE_FOR_REPORT': 15,
-    			'REGISTER_OFFLINE': true,
-    			'REGISTER_IDLE': true,
-    			'REGISTER_DESKTOP': true,
-    			'REPORT_REQUEST_TYPE': 'all',
-    			'REPORT_SIMPLE_TYPE': 'all',
-    			'REPORT_FULL_TYPE': 'all'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'timeman.timecontrol.settings.set',
+        params: {
+          ACTIVE: true,
+          MINIMUM_IDLE_FOR_REPORT: 15,
+          REGISTER_OFFLINE: true,
+          REGISTER_IDLE: true,
+          REGISTER_DESKTOP: true,
+          REPORT_REQUEST_TYPE: 'all',
+          REPORT_SIMPLE_TYPE: 'all',
+          REPORT_FULL_TYPE: 'all',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Settings saved:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error(error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setTimeControlSettings() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'timeman.timecontrol.settings.set',
+            params: {
+              ACTIVE: true,
+              MINIMUM_IDLE_FOR_REPORT: 15,
+              REGISTER_OFFLINE: true,
+              REGISTER_IDLE: true,
+              REGISTER_DESKTOP: true,
+              REPORT_REQUEST_TYPE: 'all',
+              REPORT_SIMPLE_TYPE: 'all',
+              REPORT_FULL_TYPE: 'all',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Settings saved:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setTimeControlSettings)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.