### PR TITLE
docs(user-consent): actualize JS examples to TS + UMD

### DIFF
--- a/api-reference/user-consent/user-consent-agreement-list.md
+++ b/api-reference/user-consent/user-consent-agreement-list.md
@@ -45,50 +45,93 @@
     https://**put_your_bitrix24_address**/rest/userconsent.agreement.list
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    // callListMethod: Получает все данные сразу.
-    // Используйте только для небольших выборок (< 1000 элементов) из-за высокой
-    // нагрузки на память.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    try {
-    const response = await $b24.callListMethod(
-        'userconsent.agreement.list',
-        {},
-        (progress: number) => { console.log('Progress:', progress) }
-    );
-    const items = response.getData() || [];
-    for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each AgreementItem returned in result[]
+    type AgreementItem = {
+      ID: string
+      NAME: string
+      ACTIVE: string
+      LANGUAGE_ID: string | null
     }
 
-    // fetchListMethod: Выбирает данные по частям с помощью итератора.
-    // Используйте для больших объемов данных для эффективного потребления памяти.
-
     try {
-    const generator = $b24.fetchListMethod('userconsent.agreement.list', {}, 'ID');
-    for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
-    }
-    } catch (error: any) {
-    console.error('Request failed', error)
-    }
+      // userconsent.agreement.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<AgreementItem[]>({
+        method: 'userconsent.agreement.list',
+        params: {
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
 
-    // callMethod: Ручное управление постраничной навигацией через параметр start.
-    // Используйте для точного контроля над пакетами запросов.
-    // Для больших данных менее эффективен, чем fetchListMethod.
-
-    try {
-    const response = await $b24.callMethod('userconsent.agreement.list', {}, 0);
-    const result = response.getData().result || [];
-    for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error: any) {
-    console.error('Request failed', error)
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Agreements:', result.length, result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
     ```
-    
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchAgreementList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // userconsent.agreement.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'userconsent.agreement.list',
+            params: {
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Agreements:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchAgreementList)
+    </script>
+    ```
+
 - PHP
 
     ```php

--- a/api-reference/user-consent/user-consent-agreement-text.md
+++ b/api-reference/user-consent/user-consent-agreement-text.md
@@ -84,33 +84,101 @@
     https://**put_your_bitrix24_address**/rest/userconsent.agreement.text
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try {
-        const response = await $b24.callMethod(
-            'userconsent.agreement.text',
-            {
-                id: 19,
-                replace: {
-                    button_caption: 'Я согласен',
-                    fields: {
-                        COMPANY_NAME: 'ООО Пример',
-                        COMPANY_ADDRESS: 'г. Москва, ул. Примерная, д. 1',
-                        PURPOSES: 'Обработка персональных данных для улучшения сервиса',
-                        THIRD_PARTIES: 'Партнеры компании для аналитики',
-                        EMAIL: 'info@example.com'
-                    }
-                }
-            }
-        );
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-        const result = response.getData().result;
-        console.log('Result:', result);
-        processResult(result);
-    } catch (error) {
-        console.error('Error:', error);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AgreementTextResult = {
+      LABEL: string
+      TEXT: string
     }
+
+    try {
+      const response = await $b24.actions.v2.call.make<AgreementTextResult>({
+        method: 'userconsent.agreement.text',
+        params: {
+          id: 19,
+          replace: {
+            button_caption: 'I agree',
+            fields: {
+              COMPANY_NAME: 'Example LLC',
+              COMPANY_ADDRESS: '1 Example St, New York, NY',
+              PURPOSES: 'Processing personal data to improve service',
+              THIRD_PARTIES: 'Company partners for analytics',
+              EMAIL: 'info@example.com',
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Agreement label:', result.LABEL)
+        console.info('Agreement text:', result.TEXT)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAgreementText() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userconsent.agreement.text',
+            params: {
+              id: 19,
+              replace: {
+                button_caption: 'I agree',
+                fields: {
+                  COMPANY_NAME: 'Example LLC',
+                  COMPANY_ADDRESS: '1 Example St, New York, NY',
+                  PURPOSES: 'Processing personal data to improve service',
+                  THIRD_PARTIES: 'Company partners for analytics',
+                  EMAIL: 'info@example.com',
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Agreement label:', result.LABEL)
+          console.info('Agreement text:', result.TEXT)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAgreementText)
+    </script>
     ```
 
 - PHP

--- a/api-reference/user-consent/user-consent-consent-add.md
+++ b/api-reference/user-consent/user-consent-consent-add.md
@@ -66,32 +66,83 @@
     https://**put_your_bitrix24_address**/rest/userconsent.consent.add
     ```
 
-- JS
+- JS (TS)
 
-    ```js
-    try
-    {
-        const response = await $b24.callMethod(
-            'userconsent.consent.add',
-            {
-                AGREEMENT_ID: 19,
-                USER_ID: 123,
-                IP: '192.168.1.100',
-                URL: 'https://example.com/contact-form',
-                ORIGIN_ID: 'my_contact_form',
-                ORIGINATOR_ID: 'user@example.com'
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'userconsent.consent.add',
+        params: {
+          AGREEMENT_ID: 19,
+          USER_ID: 123,
+          IP: '192.168.1.100',
+          URL: 'https://example.com/contact-form',
+          ORIGIN_ID: 'my_contact_form',
+          ORIGINATOR_ID: 'user@example.com',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created consent with ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addConsent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'userconsent.consent.add',
+            params: {
+              AGREEMENT_ID: 19,
+              USER_ID: 123,
+              IP: '192.168.1.100',
+              URL: 'https://example.com/contact-form',
+              ORIGIN_ID: 'my_contact_form',
+              ORIGINATOR_ID: 'user@example.com',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created consent with ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addConsent)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.