### PR TITLE
docs(vibe): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/vibe/landing-repowidget-debug.md
+++ b/api-reference/vibe/landing-repowidget-debug.md
@@ -32,28 +32,73 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repowidget.debug', {
-    			enable: true,
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repowidget.debug',
+        params: {
+          enable: true,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Debug mode enabled:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function enableDebugMode() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repowidget.debug',
+            params: {
+              enable: true,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Debug mode enabled:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', enableDebugMode)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vibe/landing-repowidget-get-list.md
+++ b/api-reference/vibe/landing-repowidget-get-list.md
@@ -132,71 +132,114 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    // callListMethod: Получает все данные сразу. Используйте только для небольших выборок (< 1000 элементов) из-за высокой нагрузки на память.
-    
-    try {
-      const response = await $b24.callListMethod(
-        'landing.repowidget.getlist',
-        {
-          params: {
-            select: [
-              'ID', 'NAME'
-            ],
-            filter: {
-              '>ID': '1'
-            }
-          }
-        },
-        (progress) => { console.log('Progress:', progress) }
-      )
-      const items = response.getData() || []
-      for (const entity of items) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
+    declare const $b24: B24Frame
+
+    // Shape of each widget returned in result[]
+    type RepoWidgetItem = {
+      ID: string
+      XML_ID: string
+      APP_CODE: string
+      ACTIVE: 'Y' | 'N'
+      NAME: string
+      DESCRIPTION: string | null
+      SECTIONS: string
+      SITE_TEMPLATE_ID: string | null
+      PREVIEW: string
+      MANIFEST: Record<string, unknown>
+      CONTENT: string
+      CREATED_BY_ID: string
+      MODIFIED_BY_ID: string
+      DATE_CREATE: string
+      DATE_MODIFY: string
     }
-    
-    // fetchListMethod: Выбирает данные по частям с помощью итератора. Используйте для больших объемов данных для эффективного потребления памяти.
-    
+
     try {
-      const generator = $b24.fetchListMethod('landing.repowidget.getlist', {
+      // landing.repowidget.getlist returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v2.call.make<RepoWidgetItem[]>({
+        method: 'landing.repowidget.getlist',
         params: {
-          select: [
-            'ID', 'NAME'
-          ],
-          filter: {
-            '>ID': '1'
-          }
-        }
-      }, 'ID')
-      for await (const page of generator) {
-        for (const entity of page) { console.log('Entity:', entity) }
+          params: {
+            select: ['ID', 'NAME'],
+            filter: {
+              '>ID': '1',
+            },
+          },
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Widgets count on this page:', result.length, result)
       }
     } catch (error) {
-      console.error('Request failed', error)
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    
-    // callMethod: Ручное управление постраничной навигацией через параметр start. Используйте для точного контроля над пакетами запросов. Для больших данных менее эффективен, чем fetchListMethod.
-    
-    try {
-      const response = await $b24.callMethod('landing.repowidget.getlist', {
-        params: {
-          select: [
-            'ID', 'NAME'
-          ],
-          filter: {
-            '>ID': '1'
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRepoWidgetList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // landing.repowidget.getlist returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repowidget.getlist',
+            params: {
+              params: {
+                select: ['ID', 'NAME'],
+                filter: {
+                  '>ID': '1',
+                },
+              },
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
           }
+
+          const result = response.getData().result
+          console.info('Widgets count on this page:', result.length, result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
         }
-      }, 0)
-      const result = response.getData().result || []
-      for (const entity of result) { console.log('Entity:', entity) }
-    } catch (error) {
-      console.error('Request failed', error)
-    }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRepoWidgetList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vibe/landing-repowidget-register.md
+++ b/api-reference/vibe/landing-repowidget-register.md
@@ -107,31 +107,137 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repowidget.register',
-    		data
-    	);
-    	
-    	const result = response.getData().result;
-    	
-    	if (result.error())
-    	{
-    		console.error(result.error());
-    		return;
-    	}
-    	
-    	console.info(result);
+    declare const $b24: B24Frame
+
+    const content = '<div class="my-app-w-container"><!-- Vue template --></div>'
+
+    try {
+      const response = await $b24.actions.v2.call.make<number>({
+        method: 'landing.repowidget.register',
+        params: {
+          code: 'my_widget',
+          fields: {
+            NAME: 'My widget',
+            PREVIEW: 'https://my-app.com/vibe_preview.jpg',
+            CONTENT: content,
+            SECTIONS: 'widgets_company_life',
+            WIDGET_PARAMS: {
+              rootNode: '.my-app-w-container',
+              lang: {
+                ru: {
+                  W_TITLE: 'People and their ages',
+                  W_EMPTY: 'No data',
+                },
+                en: {
+                  W_TITLE: 'People and their ages',
+                  W_EMPTY: 'Empty',
+                },
+              },
+              handler: 'https://my-app.com/vibe.php',
+              style: 'https://my-app.com/vibe.css',
+              demoData: {
+                desc: 'Just a test widget',
+                count: 420,
+                persons: [
+                  { name: 'Person 1', age: 21 },
+                  { name: 'Person 2', age: 42 },
+                  { name: 'Person 3', age: 123 },
+                ],
+              },
+            },
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Registered widget ID:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function registerVibeWidget() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const content = '<div class="my-app-w-container"><!-- Vue template --></div>'
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repowidget.register',
+            params: {
+              code: 'my_widget',
+              fields: {
+                NAME: 'My widget',
+                PREVIEW: 'https://my-app.com/vibe_preview.jpg',
+                CONTENT: content,
+                SECTIONS: 'widgets_company_life',
+                WIDGET_PARAMS: {
+                  rootNode: '.my-app-w-container',
+                  lang: {
+                    ru: {
+                      W_TITLE: 'People and their ages',
+                      W_EMPTY: 'No data',
+                    },
+                    en: {
+                      W_TITLE: 'People and their ages',
+                      W_EMPTY: 'Empty',
+                    },
+                  },
+                  handler: 'https://my-app.com/vibe.php',
+                  style: 'https://my-app.com/vibe.css',
+                  demoData: {
+                    desc: 'Just a test widget',
+                    count: 420,
+                    persons: [
+                      { name: 'Person 1', age: 21 },
+                      { name: 'Person 2', age: 42 },
+                      { name: 'Person 3', age: 123 },
+                    ],
+                  },
+                },
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Registered widget ID:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', registerVibeWidget)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vibe/landing-repowidget-unregister.md
+++ b/api-reference/vibe/landing-repowidget-unregister.md
@@ -32,28 +32,73 @@
 
 {% list tabs %}
 
-- JS
+- JS (TS)
 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```js
-    try
-    {
-    	const response = await $b24.callMethod(
-    		'landing.repowidget.unregister', {
-    			code: 'my_widget'
-    		}
-    	);
-    	
-    	const result = response.getData().result;
-    	if(result.error())
-    		console.error(result.error());
-    	else
-    		console.info(result);
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<boolean>({
+        method: 'landing.repowidget.unregister',
+        params: {
+          code: 'my_widget',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Widget unregistered:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch(error)
-    {
-    	console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function unregisterRepoWidget() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'landing.repowidget.unregister',
+            params: {
+              code: 'my_widget',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Widget unregistered:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', unregisterRepoWidget)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.