### PR TITLE
docs(vote): actualize JS examples to TS + UMD (b24jssdk actions API)

### DIFF
--- a/api-reference/vote/vote.attachedvote.get.md
+++ b/api-reference/vote/vote.attachedvote.get.md
@@ -90,27 +90,95 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.get',
-            {
-                attachId: **put_attach_id**
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Dat a:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachedVoteGetResult = {
+      attach: {
+        ID: number
+        VOTE_ID: number
+        COUNTER: number
+        QUESTIONS: Record<string, unknown>
+        ANONYMITY: number
+        OPTIONS: number
+        userAnswerMap: Record<string, unknown>
+        canEdit: boolean
+        canVote: boolean
+        canRevote: boolean
+        isVoted: boolean
+        signedAttachId: string
+        resultUrl: string
+        downloadUrl: string
+        entityId: number
+        isFinished: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachedVoteGetResult>({
+        method: 'vote.AttachedVote.get',
+        params: {
+          attachId: 1,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.attach.ID, result.attach.signedAttachId, result.attach.isVoted)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAttachedVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.get',
+            params: {
+              attachId: 1,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.attach.ID, result.attach.signedAttachId, result.attach.isVoted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAttachedVote)
+    </script>
     ```
 
 - PHP
@@ -204,29 +272,99 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.get
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.get',
-            {
-                moduleId: 'im',
-                entityType: 'Bitrix\\Vote\\Attachment\\ImMessageConnector',
-                entityId: 32221
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Dat a:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachedVoteGetResult = {
+      attach: {
+        ID: number
+        VOTE_ID: number
+        COUNTER: number
+        QUESTIONS: Record<string, unknown>
+        ANONYMITY: number
+        OPTIONS: number
+        userAnswerMap: Record<string, unknown>
+        canEdit: boolean
+        canVote: boolean
+        canRevote: boolean
+        isVoted: boolean
+        signedAttachId: string
+        resultUrl: string
+        downloadUrl: string
+        entityId: number
+        isFinished: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachedVoteGetResult>({
+        method: 'vote.AttachedVote.get',
+        params: {
+          moduleId: 'im',
+          entityType: 'Bitrix\\Vote\\Attachment\\ImMessageConnector',
+          entityId: 32221,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.attach.ID, result.attach.signedAttachId, result.attach.isVoted)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAttachedVoteByEntity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.get',
+            params: {
+              moduleId: 'im',
+              entityType: 'Bitrix\\Vote\\Attachment\\ImMessageConnector',
+              entityId: 32221,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.attach.ID, result.attach.signedAttachId, result.attach.isVoted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAttachedVoteByEntity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.getAnswerVoted.md
+++ b/api-reference/vote/vote.attachedvote.getAnswerVoted.md
@@ -106,33 +106,95 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.getAnswerVoted
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.getAnswerVoted',
-            {
-                attachId: **put_attach_id**,
-                answerId: **put_answer_id**,
-                pageNavigation: {
-                    pageSize: **put_page_size**,
-                    currentPage: **put_page**
-                },
-                userForMobileFormat: false
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Dat a:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetAnswerVotedResult = {
+      items: {
+        ID: number
+        NAME: string
+        IMAGE: string
+        WORK_POSITION: string
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetAnswerVotedResult>({
+        method: 'vote.AttachedVote.getAnswerVoted',
+        params: {
+          attachId: 1,
+          answerId: 1,
+          pageNavigation: {
+            pageSize: 10,
+            currentPage: 1,
+          },
+          userForMobileFormat: false,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Voted users:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAnswerVoted() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.getAnswerVoted',
+            params: {
+              attachId: 1,
+              answerId: 1,
+              pageNavigation: {
+                pageSize: 10,
+                currentPage: 1,
+              },
+              userForMobileFormat: false,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Voted users:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAnswerVoted)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.getMany.md
+++ b/api-reference/vote/vote.attachedvote.getMany.md
@@ -64,29 +64,99 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.getMany
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.getMany',
-            {
-                moduleId: 'im',
-                entityType: 'Bitrix\\Vote\\Attachment\\ImMessageConnector',
-                entityIds: [1, 2, 3]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Dat a:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachedVoteGetManyResult = {
+      items: {
+        ID: number
+        VOTE_ID: number
+        COUNTER: number
+        QUESTIONS: Record<string, unknown>
+        ANONYMITY: number
+        OPTIONS: number
+        userAnswerMap: Record<string, unknown>
+        canEdit: boolean
+        canVote: boolean
+        canRevote: boolean
+        isVoted: boolean
+        signedAttachId: string
+        resultUrl: string
+        downloadUrl: string
+        entityId: number
+        isFinished: boolean
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<AttachedVoteGetManyResult>({
+        method: 'vote.AttachedVote.getMany',
+        params: {
+          moduleId: 'im',
+          entityType: 'Bitrix\\Vote\\Attachment\\ImMessageConnector',
+          entityIds: [1, 2, 3],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Votes fetched:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getManyAttachedVotes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.getMany',
+            params: {
+              moduleId: 'im',
+              entityType: 'Bitrix\\Vote\\Attachment\\ImMessageConnector',
+              entityIds: [1, 2, 3],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Votes fetched:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getManyAttachedVotes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.getWithVoted.md
+++ b/api-reference/vote/vote.attachedvote.getWithVoted.md
@@ -106,29 +106,105 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.getWithVoted
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.getWithVoted',
-            {
-                attachId: **put_attach_id**,
-                pageSize: **put_page_size**,
-                userForMobileFormat: false
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Dat a:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type GetWithVotedResult = {
+      attach: {
+        ID: number
+        VOTE_ID: number
+        COUNTER: number
+        QUESTIONS: Record<string, unknown>
+        ANONYMITY: number
+        OPTIONS: number
+        userAnswerMap: Record<string, unknown>
+        canEdit: boolean
+        canVote: boolean
+        canRevote: boolean
+        isVoted: boolean
+        signedAttachId: string
+        resultUrl: string
+        downloadUrl: string
+        entityId: number
+        isFinished: boolean
+      }
+      voted: Record<string, Array<{
+        ID: number
+        NAME: string
+        IMAGE: string
+        WORK_POSITION: string
+      }>>
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<GetWithVotedResult>({
+        method: 'vote.AttachedVote.getWithVoted',
+        params: {
+          attachId: 1,
+          pageSize: 10,
+          userForMobileFormat: false,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Attach ID:', result.attach.ID, '| Is voted:', result.attach.isVoted)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getWithVoted() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.getWithVoted',
+            params: {
+              attachId: 1,
+              pageSize: 10,
+              userForMobileFormat: false,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Attach ID:', result.attach.ID, '| Is voted:', result.attach.isVoted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getWithVoted)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.recall.md
+++ b/api-reference/vote/vote.attachedvote.recall.md
@@ -88,27 +88,95 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.recall
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.recall',
-            {
-                attachId: '**put_attach_id**',
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Recalled vote with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RecallResult = {
+      attach: {
+        ID: number
+        VOTE_ID: number
+        COUNTER: number
+        QUESTIONS: Record<string, unknown>
+        ANONYMITY: number
+        OPTIONS: number
+        userAnswerMap: unknown[]
+        canEdit: boolean
+        canVote: boolean
+        canRevote: boolean
+        isVoted: boolean
+        signedAttachId: string
+        resultUrl: string
+        downloadUrl: string
+        entityId: number
+        isFinished: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<RecallResult>({
+        method: 'vote.AttachedVote.recall',
+        params: {
+          attachId: '**put_attach_id**',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Recalled vote attach ID:', result.attach.ID, 'isVoted:', result.attach.isVoted)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function recallVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.recall',
+            params: {
+              attachId: '**put_attach_id**',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Recalled vote attach ID:', result.attach.ID, 'isVoted:', result.attach.isVoted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', recallVote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.resume.md
+++ b/api-reference/vote/vote.attachedvote.resume.md
@@ -88,27 +88,73 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.resume
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.resume',
-            {
-                attachId: **put_attach_id**
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Resumed vote with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    try {
+      const response = await $b24.actions.v2.call.make<unknown[]>({
+        method: 'vote.AttachedVote.resume',
+        params: {
+          attachId: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Vote resumed successfully, items:', result.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function resumeAttachedVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.resume',
+            params: {
+              attachId: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Vote resumed successfully, items:', result.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', resumeAttachedVote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.stop.md
+++ b/api-reference/vote/vote.attachedvote.stop.md
@@ -88,27 +88,76 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.stop
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.stop',
-            {
-                attachId: **put_attach_id**
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Stopped vote with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type StopVoteResult = unknown[]
+
+    try {
+      const response = await $b24.actions.v2.call.make<StopVoteResult>({
+        method: 'vote.AttachedVote.stop',
+        params: {
+          attachId: 123,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Vote stopped successfully, result:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function stopVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.stop',
+            params: {
+              attachId: 123,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Vote stopped successfully, result:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', stopVote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.attachedvote.vote.md
+++ b/api-reference/vote/vote.attachedvote.vote.md
@@ -124,31 +124,103 @@
     https://**put_your_bitrix24_address**/rest/vote.AttachedVote.vote
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.AttachedVote.vote',
-            {
-                attachId: **put_attach_id**,
-                ballot: {
-                    '1': ['2', '3'],
-                    '2': ['5']
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        
-        processResult(result);
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type VoteResult = {
+      attach: {
+        ID: number
+        VOTE_ID: number
+        COUNTER: number
+        QUESTIONS: Record<string, unknown>
+        ANONYMITY: number
+        OPTIONS: number
+        userAnswerMap: Record<string, unknown>
+        canEdit: boolean
+        canVote: boolean
+        canRevote: boolean
+        isVoted: boolean
+        signedAttachId: string
+        resultUrl: string
+        downloadUrl: string
+        entityId: number
+        isFinished: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v2.call.make<VoteResult>({
+        method: 'vote.AttachedVote.vote',
+        params: {
+          attachId: 1,
+          ballot: {
+            '1': ['2', '3'],
+            '2': ['5'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Vote submitted, attach ID:', result.attach.ID, 'isVoted:', result.attach.isVoted)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function castVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.AttachedVote.vote',
+            params: {
+              attachId: 1,
+              ballot: {
+                '1': ['2', '3'],
+                '2': ['5'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Vote submitted, attach ID:', result.attach.ID, 'isVoted:', result.attach.isVoted)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', castVote)
+    </script>
     ```
 
 - PHP

--- a/api-reference/vote/vote.integration.im.send.md
+++ b/api-reference/vote/vote.integration.im.send.md
@@ -106,42 +106,111 @@
     https://**put_your_bitrix24_address**/rest/vote.Integration.Im.send
     ```
 
-- JS
+- JS (TS)
 
-    ```js  
-    try
-    {
-        const response = await $b24.callMethod(
-            'vote.Integration.Im.send',
-            {
-                chatId: **put_chat_id**,
-                IM_MESSAGE_VOTE_DATA: {
-                    QUESTIONS: [
-                        {
-                            QUESTION: '**put_question_title**',
-                            FIELD_TYPE: 0,
-                            ANSWERS: [
-                                { MESSAGE: '**put_message_content**' },
-                                { MESSAGE: '**put_message_content**' },
-                                { MESSAGE: '**put_message_content**' }
-                            ]
-                        }
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
+
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type VoteIntegrationImSendResult = {
+      messageId: number
+      voteId: number
+    }
+
+    try {
+      const response = await $b24.actions.v2.call.make<VoteIntegrationImSendResult>({
+        method: 'vote.Integration.Im.send',
+        params: {
+          chatId: 1,
+          IM_MESSAGE_VOTE_DATA: {
+            QUESTIONS: [
+              {
+                QUESTION: 'What is your favorite color?',
+                FIELD_TYPE: 0,
+                ANSWERS: [
+                  { MESSAGE: 'Red' },
+                  { MESSAGE: 'Green' },
+                  { MESSAGE: 'Blue' },
+                ],
+              },
+            ],
+            ANONYMITY: 0,
+            OPTIONS: 0,
+          },
+          templateId: null,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Message ID:', result.messageId, 'Vote ID:', result.voteId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendImVote() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v2.call.make({
+            method: 'vote.Integration.Im.send',
+            params: {
+              chatId: 1,
+              IM_MESSAGE_VOTE_DATA: {
+                QUESTIONS: [
+                  {
+                    QUESTION: 'What is your favorite color?',
+                    FIELD_TYPE: 0,
+                    ANSWERS: [
+                      { MESSAGE: 'Red' },
+                      { MESSAGE: 'Green' },
+                      { MESSAGE: 'Blue' },
                     ],
-                    ANONYMITY: 0,
-                    OPTIONS: 0
-                },
-                templateId: null
-            }
-        );
+                  },
+                ],
+                ANONYMITY: 0,
+                OPTIONS: 0,
+              },
+              templateId: null,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
 
-        const result = response.getData().result;
-        console.log('Created element with ID:', result);
-        processResult(result);
-    }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Message ID:', result.messageId, 'Vote ID:', result.voteId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendImVote)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What

Actualizes the JavaScript examples in **<label>**: the legacy `- JS` tab
(`$b24.callMethod` / `callListMethod` / `fetchListMethod`) is replaced by two tabs —
`- JS (TS)` and `- JS (UMD)` — on the current actions API (`$b24.actions.v2.call.make`).

## Why

`callMethod` / `callListMethod` / `fetchListMethod` are **removed in `@bitrix24/b24jssdk` 2.0**.
The examples now use the supported actions API: a typed TypeScript variant and a
copy-paste UMD variant that runs inside a Bitrix24 frame.

## Scope & guarantees

- **Only the `- JS` tab changes.** The cURL (Webhook/OAuth), PHP, BX24.js, PHP CRest and
  Python tabs, and all page prose / parameter tables / response sections, are unchanged.
- List methods use `call.make` with `start`; `getTotal()` (removed in SDK 2.0) is replaced by
  `.length` + the list helpers.
- Each example was validated in the fork (`tsc` against `@bitrix24/b24jssdk`, plus a structural
  `- JS (TS)` / `- JS (UMD)` check). The branch carries only this section's `api-reference/`
  content — no tooling, no CI files.
- One section per PR to keep review small.

No breaking changes — documentation examples only.