### PR TITLE
docs(rest-v3): actualize JS examples to TS + UMD

### DIFF
--- a/api-reference/rest-v3/humanresources/employee/humanresources-employee-count.md
+++ b/api-reference/rest-v3/humanresources/employee/humanresources-employee-count.md
@@ -52,25 +52,74 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.employee.count
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.employee.count',
-            {}
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.total);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CountResult = {
+      total: number
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<CountResult>({
+        method: 'humanresources.employee.count',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Total employees:', result.total)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEmployeeCount() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.employee.count',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Total employees:', result.total)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEmployeeCount)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/employee/humanresources-employee-field-get.md
+++ b/api-reference/rest-v3/humanresources/employee/humanresources-employee-field-get.md
@@ -86,40 +86,116 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.employee.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.employee.field.get',
-            {
-                name: 'userId',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'validationRules',
-                    'requiredGroups',
-                    'filterable',
-                    'sortable',
-                    'editable',
-                    'multiple',
-                    'elementType'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.item);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EmployeeFieldGetResult = {
+      item: {
+        description: string | null
+        editable: boolean
+        elementType: string | null
+        filterable: boolean
+        multiple: boolean
+        name: string
+        requiredGroups: string[] | null
+        sortable: boolean
+        title: string
+        type: string
+        validationRules: unknown[]
+      }
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<EmployeeFieldGetResult>({
+        method: 'humanresources.employee.field.get',
+        params: {
+          name: 'userId',
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'validationRules',
+            'requiredGroups',
+            'filterable',
+            'sortable',
+            'editable',
+            'multiple',
+            'elementType',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.name, result.item.type, result.item.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEmployeeField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.employee.field.get',
+            params: {
+              name: 'userId',
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'validationRules',
+                'requiredGroups',
+                'filterable',
+                'sortable',
+                'editable',
+                'multiple',
+                'elementType',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.name, result.item.type, result.item.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEmployeeField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/employee/humanresources-employee-field-list.md
+++ b/api-reference/rest-v3/humanresources/employee/humanresources-employee-field-list.md
@@ -74,39 +74,116 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.employee.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.employee.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'validationRules',
-                    'requiredGroups',
-                    'filterable',
-                    'sortable',
-                    'editable',
-                    'multiple',
-                    'elementType'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.items);
+    type FieldItem = {
+      name: string
+      type: string
+      title: string
+      description: string | null
+      validationRules: unknown[]
+      requiredGroups: unknown | null
+      filterable: boolean
+      sortable: boolean
+      editable: boolean
+      multiple: boolean
+      elementType: string | null
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EmployeeFieldListResult = {
+      items: FieldItem[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<EmployeeFieldListResult>({
+        method: 'humanresources.employee.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'validationRules',
+            'requiredGroups',
+            'filterable',
+            'sortable',
+            'editable',
+            'multiple',
+            'elementType',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Employee fields count:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEmployeeFieldList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.employee.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'validationRules',
+                'requiredGroups',
+                'filterable',
+                'sortable',
+                'editable',
+                'multiple',
+                'elementType',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Employee fields count:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEmployeeFieldList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/employee/humanresources-employee-multidepartment.md
+++ b/api-reference/rest-v3/humanresources/employee/humanresources-employee-multidepartment.md
@@ -52,25 +52,85 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.employee.multidepartment
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.employee.multidepartment',
-            {}
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.employees);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MultidepartmentResult = {
+      employees: {
+        userId: number
+        name: string
+        workPosition: string
+        departments: {
+          id: number
+          name: string
+        }[]
+      }[]
+      total: number
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MultidepartmentResult>({
+        method: 'humanresources.employee.multidepartment',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Total employees in multiple departments:', result.total)
+        console.info('Employees:', result.employees)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMultidepartmentEmployees() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.employee.multidepartment',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Total employees in multiple departments:', result.total)
+          console.info('Employees:', result.employees)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMultidepartmentEmployees)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/employee/humanresources-employee-search.md
+++ b/api-reference/rest-v3/humanresources/employee/humanresources-employee-search.md
@@ -76,36 +76,104 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.employee.search
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.employee.search',
-            {
-                name: 'Иван',
-                select: [
-                    'userId',
-                    'name',
-                    'workPosition',
-                    'avatar',
-                    'url',
-                    'departments',
-                    'teams'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.items);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EmployeeSearchResult = {
+      items: {
+        userId: number
+        name: string
+        workPosition: string
+        avatar: string
+        url: string
+        departments: { id: number; name: string }[]
+        teams: { id: number; name: string }[]
+      }[]
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<EmployeeSearchResult>({
+        method: 'humanresources.employee.search',
+        params: {
+          name: 'Ivan',
+          select: [
+            'userId',
+            'name',
+            'workPosition',
+            'avatar',
+            'url',
+            'departments',
+            'teams',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchEmployees() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.employee.search',
+            params: {
+              name: 'Ivan',
+              select: [
+                'userId',
+                'name',
+                'workPosition',
+                'avatar',
+                'url',
+                'departments',
+                'teams',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchEmployees)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/employee/humanresources-employee-subordinates.md
+++ b/api-reference/rest-v3/humanresources/employee/humanresources-employee-subordinates.md
@@ -62,27 +62,84 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.employee.subordinates
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.employee.subordinates',
-            {
-                id: 7
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SubordinatesResult = {
+      userId: number
+      departments: Array<{
+        nodeId: number
+        name: string
+        role: string
+        subordinatesCount: number
+      }>
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<SubordinatesResult>({
+        method: 'humanresources.employee.subordinates',
+        params: {
+          id: 7,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.userId, result.departments)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEmployeeSubordinates() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.employee.subordinates',
+            params: {
+              id: 7,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.userId, result.departments)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEmployeeSubordinates)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node-communication/humanresources-node-communication-edit.md
+++ b/api-reference/rest-v3/humanresources/node-communication/humanresources-node-communication-edit.md
@@ -96,32 +96,88 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.communication.edit
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.communication.edit',
-            {
-                nodeId: 15,
-                communicationType: 'CHAT',
-                ids: [21],
-                removeIds: [18],
-                createDefault: false,
-                withChildren: false
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.success);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeCommunicationEditResult = {
+      success: boolean
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeCommunicationEditResult>({
+        method: 'humanresources.node.communication.edit',
+        params: {
+          nodeId: 15,
+          communicationType: 'CHAT',
+          ids: [21],
+          removeIds: [18],
+          createDefault: false,
+          withChildren: false,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Communication edited successfully:', result.success)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function editNodeCommunication() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.communication.edit',
+            params: {
+              nodeId: 15,
+              communicationType: 'CHAT',
+              ids: [21],
+              removeIds: [18],
+              createDefault: false,
+              withChildren: false,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Communication edited successfully:', result.success)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', editNodeCommunication)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node-communication/humanresources-node-communication-list.md
+++ b/api-reference/rest-v3/humanresources/node-communication/humanresources-node-communication-list.md
@@ -62,27 +62,104 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.communication.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.communication.list',
-            {
-                id: 15
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result);
+    type CommunicationItem = {
+      avatar: string | null
+      color?: string
+      dialogId: string
+      hasAccess: boolean
+      id: number
+      isExtranet?: boolean
+      originalNodeId: number | null
+      subtitle: string
+      title: string
+      type: string
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeCommunicationListResult = {
+      channels: CommunicationItem[]
+      channelsNoAccess: number
+      chats: CommunicationItem[]
+      chatsNoAccess: number
+      collabs: CommunicationItem[]
+      collabsNoAccess: number
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeCommunicationListResult>({
+        method: 'humanresources.node.communication.list',
+        params: {
+          id: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(
+          'Channels:', result.channels,
+          'Chats:', result.chats,
+          'Collabs:', result.collabs
+        )
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchNodeCommunications() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.communication.list',
+            params: {
+              id: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(
+            'Channels:', result.channels,
+            'Chats:', result.chats,
+            'Collabs:', result.collabs
+          )
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchNodeCommunications)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-add.md
+++ b/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-add.md
@@ -80,29 +80,82 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.member.add
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.member.add',
-            {
-                nodeId: 15,
-                userIds: [7, 12, 18],
-                role: 'MEMBER_EMPLOYEE'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log(result.success);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeMemberAddResult = {
+      success: boolean
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeMemberAddResult>({
+        method: 'humanresources.node.member.add',
+        params: {
+          nodeId: 15,
+          userIds: [7, 12, 18],
+          role: 'MEMBER_EMPLOYEE',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Members added successfully:', result.success)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addNodeMembers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.member.add',
+            params: {
+              nodeId: 15,
+              userIds: [7, 12, 18],
+              role: 'MEMBER_EMPLOYEE',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Members added successfully:', result.success)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addNodeMembers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-move.md
+++ b/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-move.md
@@ -82,29 +82,82 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.member.move
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.member.move',
-            {
-                nodeId: 28,
-                userIds: [12, 18],
-                role: 'MEMBER_EMPLOYEE'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Member move result:', result.success);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeMemberMoveResult = {
+      success: boolean
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeMemberMoveResult>({
+        method: 'humanresources.node.member.move',
+        params: {
+          nodeId: 28,
+          userIds: [12, 18],
+          role: 'MEMBER_EMPLOYEE',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Move result:', result.success)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveNodeMembers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.member.move',
+            params: {
+              nodeId: 28,
+              userIds: [12, 18],
+              role: 'MEMBER_EMPLOYEE',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Move result:', result.success)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveNodeMembers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-remove.md
+++ b/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-remove.md
@@ -66,29 +66,86 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.member.remove
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.member.remove',
-            {
-                nodeId: 15,
-                userIds: [18, 25, 31]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Removed:', result.removed);
-        console.log('Failed:', result.failed);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type RemoveMemberResult = {
+      removed: number[]
+      failed: {
+        userId: number
+        reason: string
+      }[]
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<RemoveMemberResult>({
+        method: 'humanresources.node.member.remove',
+        params: {
+          nodeId: 15,
+          userIds: [18, 25, 31],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Removed:', result.removed)
+        console.info('Failed:', result.failed)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function removeMember() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.member.remove',
+            params: {
+              nodeId: 15,
+              userIds: [18, 25, 31],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Removed:', result.removed)
+          console.info('Failed:', result.failed)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', removeMember)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-set.md
+++ b/api-reference/rest-v3/humanresources/node-member/humanresources-node-member-set.md
@@ -87,32 +87,88 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.member.set
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.member.set',
-            {
-                nodeId: 15,
-                userIds: {
-                    MEMBER_HEAD: [7],
-                    MEMBER_DEPUTY_HEAD: [12],
-                    MEMBER_EMPLOYEE: [18, 25, 31]
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Member set result:', result.success);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeMemberSetResult = {
+      success: boolean
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeMemberSetResult>({
+        method: 'humanresources.node.member.set',
+        params: {
+          nodeId: 15,
+          userIds: {
+            MEMBER_HEAD: [7],
+            MEMBER_DEPUTY_HEAD: [12],
+            MEMBER_EMPLOYEE: [18, 25, 31],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.success)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function setNodeMembers() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.member.set',
+            params: {
+              nodeId: 15,
+              userIds: {
+                MEMBER_HEAD: [7],
+                MEMBER_DEPUTY_HEAD: [12],
+                MEMBER_EMPLOYEE: [18, 25, 31],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.success)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', setNodeMembers)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-add.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-add.md
@@ -190,41 +190,125 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.add
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.add',
-            {
-                type: 'DEPARTMENT',
-                name: 'Отдел маркетинга',
-                parentId: 1,
-                description: 'Отвечает за продвижение',
-                userIds: {
-                    MEMBER_HEAD: [7],
-                    MEMBER_EMPLOYEE: [12, 15]
-                },
-                moveUsersToNode: true,
-                createChat: true,
-                bindingChatIds: [31],
-                settings: {
-                    BUSINESS_PROC_AUTHORITY: ['HEAD', 'DEPUTY_HEAD'],
-                    REPORTS_AUTHORITY: ['HEAD']
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info('Department created with ID', result.id);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeAddResult = {
+      id: number
+      name: string
+      type: string
+      structureId: number
+      parentId: number
+      description: string | null
+      accessCode: string
+      userCount: number
+      colorName: string | null
+      xmlId: string | null
+      createdAt: ISODate
+      updatedAt: ISODate
+      members: Array<{
+        userId: number
+        name: string
+        workPosition: string
+        role: string
+        avatar: string | null
+        url: string
+      }>
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeAddResult>({
+        method: 'humanresources.node.add',
+        params: {
+          type: 'DEPARTMENT',
+          name: 'Marketing department',
+          parentId: 1,
+          description: 'Handles promotion',
+          userIds: {
+            MEMBER_HEAD: [7],
+            MEMBER_EMPLOYEE: [12, 15],
+          },
+          moveUsersToNode: true,
+          createChat: true,
+          bindingChatIds: [31],
+          settings: {
+            BUSINESS_PROC_AUTHORITY: ['HEAD', 'DEPUTY_HEAD'],
+            REPORTS_AUTHORITY: ['HEAD'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Node created:', result.id, result.name, result.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addNode() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.add',
+            params: {
+              type: 'DEPARTMENT',
+              name: 'Marketing department',
+              parentId: 1,
+              description: 'Handles promotion',
+              userIds: {
+                MEMBER_HEAD: [7],
+                MEMBER_EMPLOYEE: [12, 15],
+              },
+              moveUsersToNode: true,
+              createChat: true,
+              bindingChatIds: [31],
+              settings: {
+                BUSINESS_PROC_AUTHORITY: ['HEAD', 'DEPUTY_HEAD'],
+                REPORTS_AUTHORITY: ['HEAD'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Node created:', result.id, result.name, result.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addNode)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-children.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-children.md
@@ -79,41 +79,121 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.children
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.children',
-            {
-                id: 1,
-                select: [
-                    'id',
-                    'name',
-                    'type',
-                    'structureId',
-                    'parentId',
-                    'description',
-                    'accessCode',
-                    'userCount',
-                    'colorName',
-                    'xmlId',
-                    'createdAt',
-                    'updatedAt'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result.items;
-        console.info(result.length);
+    type NodeItem = {
+      id: number
+      name: string
+      type: string
+      structureId: number
+      parentId: number | null
+      description: string | null
+      accessCode: string
+      userCount: number
+      colorName: string | null
+      xmlId: string | null
+      createdAt: ISODate
+      updatedAt: ISODate
     }
-    catch (error)
-    {
-        console.error(error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeChildrenResult = {
+      items: NodeItem[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeChildrenResult>({
+        method: 'humanresources.node.children',
+        params: {
+          id: 1,
+          select: [
+            'id',
+            'name',
+            'type',
+            'structureId',
+            'parentId',
+            'description',
+            'accessCode',
+            'userCount',
+            'colorName',
+            'xmlId',
+            'createdAt',
+            'updatedAt',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchNodeChildren() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.children',
+            params: {
+              id: 1,
+              select: [
+                'id',
+                'name',
+                'type',
+                'structureId',
+                'parentId',
+                'description',
+                'accessCode',
+                'userCount',
+                'colorName',
+                'xmlId',
+                'createdAt',
+                'updatedAt',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchNodeChildren)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-count.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-count.md
@@ -52,21 +52,75 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.count
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod('humanresources.node.count', {});
-        const result = response.getData().result;
-        console.info('Departments:', result.departments, 'Teams:', result.teams);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeCountResult = {
+      departments: number
+      teams: number
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeCountResult>({
+        method: 'humanresources.node.count',
+        params: {},
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Departments:', result.departments, 'Teams:', result.teams)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNodeCount() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.count',
+            params: {},
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Departments:', result.departments, 'Teams:', result.teams)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNodeCount)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-edit.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-edit.md
@@ -83,29 +83,93 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.edit
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.edit',
-            {
-                id: 44,
-                name: 'Отдел продаж B2B',
-                description: 'Работает с корпоративными клиентами'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info('Department updated with ID', result.id);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeEditResult = {
+      id: number
+      name: string
+      type: string
+      structureId: number
+      parentId: number
+      description: string
+      accessCode: string
+      userCount: number
+      colorName: string | null
+      xmlId: string | null
+      createdAt: ISODate | null
+      updatedAt: ISODate | null
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeEditResult>({
+        method: 'humanresources.node.edit',
+        params: {
+          id: 44,
+          name: 'B2B Sales Department',
+          description: 'Works with corporate clients',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Updated node:', result.id, result.name, result.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function editNode() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.edit',
+            params: {
+              id: 44,
+              name: 'B2B Sales Department',
+              description: 'Works with corporate clients',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Updated node:', result.id, result.name, result.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', editNode)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-field-get.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-field-get.md
@@ -92,32 +92,92 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.field.get',
-            {
-                name: 'name',
-                select: [
-                    'name',
-                    'type',
-                    'title'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeFieldGetResult = {
+      item: {
+        name?: string
+        type?: string
+        title?: string
+      }
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeFieldGetResult>({
+        method: 'humanresources.node.field.get',
+        params: {
+          name: 'name',
+          select: [
+            'name',
+            'type',
+            'title',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.name, result.item.type, result.item.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNodeField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.field.get',
+            params: {
+              name: 'name',
+              select: [
+                'name',
+                'type',
+                'title',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.name, result.item.type, result.item.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNodeField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-field-list.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-field-list.md
@@ -74,33 +74,98 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'filterable',
-                    'sortable'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    type NodeField = {
+      name: string
+      type: string
+      title: string
+      filterable: boolean
+      sortable: boolean
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeFieldListResult = {
+      items: NodeField[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeFieldListResult>({
+        method: 'humanresources.node.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'filterable',
+            'sortable',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fields:', result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listNodeFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'filterable',
+                'sortable',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fields:', result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listNodeFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-get.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-get.md
@@ -80,42 +80,129 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.get',
-            {
-                id: 1,
-                select: [
-                    'id',
-                    'name',
-                    'type',
-                    'structureId',
-                    'parentId',
-                    'description',
-                    'accessCode',
-                    'userCount',
-                    'colorName',
-                    'xmlId',
-                    'createdAt',
-                    'updatedAt',
-                    'members'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Node item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeGetResult = {
+      item: {
+        id: number
+        name: string
+        type: string
+        structureId: number
+        parentId: number | null
+        description: string
+        accessCode: string
+        userCount: number
+        colorName: string | null
+        xmlId: string | null
+        createdAt: ISODate
+        updatedAt: ISODate
+        members: Array<{
+          userId: number
+          name: string
+          workPosition: string
+          role: string
+          avatar: string
+          url: string
+        }>
+      }
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeGetResult>({
+        method: 'humanresources.node.get',
+        params: {
+          id: 1,
+          select: [
+            'id',
+            'name',
+            'type',
+            'structureId',
+            'parentId',
+            'description',
+            'accessCode',
+            'userCount',
+            'colorName',
+            'xmlId',
+            'createdAt',
+            'updatedAt',
+            'members',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.id, result.item.name, result.item.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getNode() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.get',
+            params: {
+              id: 1,
+              select: [
+                'id',
+                'name',
+                'type',
+                'structureId',
+                'parentId',
+                'description',
+                'accessCode',
+                'userCount',
+                'colorName',
+                'xmlId',
+                'createdAt',
+                'updatedAt',
+                'members',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.id, result.item.name, result.item.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getNode)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-list.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-list.md
@@ -87,46 +87,141 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.list',
-            {
-                type: 'DEPARTMENT',
-                select: [
-                    'id',
-                    'name',
-                    'type',
-                    'structureId',
-                    'parentId',
-                    'description',
-                    'accessCode',
-                    'userCount',
-                    'colorName',
-                    'xmlId',
-                    'createdAt',
-                    'updatedAt'
-                ],
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Node list:', result);
+    type NodeItem = {
+      id: number
+      name: string
+      type: string
+      structureId: number
+      parentId: number | null
+      description: string
+      accessCode: string
+      userCount: number
+      colorName: string | null
+      xmlId: string | null
+      createdAt: ISODate | null
+      updatedAt: ISODate | null
     }
-    catch (error)
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeListResult = {
+      items: NodeItem[]
     }
+
+    try {
+      // humanresources.node.list returns a single page (max 200 records). For the whole result set
+      // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+      // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + pagination variant when sort matters.
+      const response = await $b24.actions.v3.call.make<NodeListResult>({
+        method: 'humanresources.node.list',
+        params: {
+          type: 'DEPARTMENT',
+          select: [
+            'id',
+            'name',
+            'type',
+            'structureId',
+            'parentId',
+            'description',
+            'accessCode',
+            'userCount',
+            'colorName',
+            'xmlId',
+            'createdAt',
+            'updatedAt',
+          ],
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Nodes retrieved:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listNodes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // humanresources.node.list returns a single page (max 200 records). For the whole result set
+          // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+          // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + pagination variant when sort matters.
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.list',
+            params: {
+              type: 'DEPARTMENT',
+              select: [
+                'id',
+                'name',
+                'type',
+                'structureId',
+                'parentId',
+                'description',
+                'accessCode',
+                'userCount',
+                'colorName',
+                'xmlId',
+                'createdAt',
+                'updatedAt',
+              ],
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Nodes retrieved:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listNodes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-move.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-move.md
@@ -66,28 +66,91 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.move
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.move',
-            {
-                id: 44,
-                parentId: 2
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info('Department moved to parent', result.parentId);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeMoveResult = {
+      id: number
+      name: string
+      type: string
+      structureId: number
+      parentId: number
+      description: string
+      accessCode: string
+      userCount: number
+      colorName: string | null
+      xmlId: string | null
+      createdAt: ISODate | null
+      updatedAt: ISODate | null
     }
-    catch (error)
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeMoveResult>({
+        method: 'humanresources.node.move',
+        params: {
+          id: 44,
+          parentId: 2,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Department moved, id:', result.id, 'parentId:', result.parentId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveNode() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.move',
+            params: {
+              id: 44,
+              parentId: 2,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Department moved, id:', result.id, 'parentId:', result.parentId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveNode)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/humanresources/node/humanresources-node-search.md
+++ b/api-reference/rest-v3/humanresources/node/humanresources-node-search.md
@@ -75,32 +75,102 @@
     https://**put_your_bitrix24_address**/rest/api/humanresources.node.search
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'humanresources.node.search',
-            {
-                type: 'DEPARTMENT',
-                name: 'Продажи',
-                parentId: 1,
-                pagination: {
-                    limit: 20
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info('Found departments', result.length);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type NodeSearchResult = {
+      items: NodeItem[]
     }
-    catch (error)
-    {
-        console.error(error);
+    type NodeItem = {
+      id: number
+      name: string
+      type: string
+      structureId: number
+      parentId: number | null
+      description: string | null
+      accessCode: string
+      userCount: number
+      colorName: string | null
+      xmlId: string | null
+      createdAt: ISODate | null
+      updatedAt: ISODate | null
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<NodeSearchResult>({
+        method: 'humanresources.node.search',
+        params: {
+          type: 'DEPARTMENT',
+          name: 'Sales',
+          parentId: 1,
+          pagination: {
+            limit: 20,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Found departments:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function searchNodes() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'humanresources.node.search',
+            params: {
+              type: 'DEPARTMENT',
+              name: 'Sales',
+              parentId: 1,
+              pagination: {
+                limit: 20,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Found departments:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', searchNodes)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/mailbox/mail-mailbox-field-get.md
+++ b/api-reference/rest-v3/mail/mailbox/mail-mailbox-field-get.md
@@ -83,32 +83,92 @@
     https://**put_your_bitrix24_address**/rest/api/mail.mailbox.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.mailbox.field.get',
-            {
-                name: 'email',
-                select: [
-                    'name',
-                    'type',
-                    'title'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailboxFieldGetResult = {
+      item: {
+        name?: string
+        type?: string
+        title?: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailboxFieldGetResult>({
+        method: 'mail.mailbox.field.get',
+        params: {
+          name: 'email',
+          select: [
+            'name',
+            'type',
+            'title',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailboxField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.mailbox.field.get',
+            params: {
+              name: 'email',
+              select: [
+                'name',
+                'type',
+                'title',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailboxField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/mailbox/mail-mailbox-field-list.md
+++ b/api-reference/rest-v3/mail/mailbox/mail-mailbox-field-list.md
@@ -74,33 +74,98 @@
     https://**put_your_bitrix24_address**/rest/api/mail.mailbox.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.mailbox.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'filterable',
-                    'sortable'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    type MailboxFieldItem = {
+      name: string
+      type: string
+      title: string
+      filterable: boolean
+      sortable: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailboxFieldListResult = {
+      items: MailboxFieldItem[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailboxFieldListResult>({
+        method: 'mail.mailbox.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'filterable',
+            'sortable',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fields count:', result.items.length, 'Fields:', result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchMailboxFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.mailbox.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'filterable',
+                'sortable',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fields count:', result.items.length, 'Fields:', result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchMailboxFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/mailbox/mail-mailbox-get.md
+++ b/api-reference/rest-v3/mail/mailbox/mail-mailbox-get.md
@@ -70,33 +70,95 @@
     https://**put_your_bitrix24_address**/rest/api/mail.mailbox.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.mailbox.get',
-            {
-                id: 1,
-                select: [
-                    'id',
-                    'name',
-                    'email',
-                    'senderName'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Mailbox item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailboxGetResult = {
+      item: {
+        id: number
+        name: string
+        email: string
+        senderName: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailboxGetResult>({
+        method: 'mail.mailbox.get',
+        params: {
+          id: 1,
+          select: [
+            'id',
+            'name',
+            'email',
+            'senderName',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.id, result.item.name, result.item.email, result.item.senderName)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailbox() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.mailbox.get',
+            params: {
+              id: 1,
+              select: [
+                'id',
+                'name',
+                'email',
+                'senderName',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.id, result.item.name, result.item.email, result.item.senderName)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailbox)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/mailbox/mail-mailbox-list.md
+++ b/api-reference/rest-v3/mail/mailbox/mail-mailbox-list.md
@@ -67,33 +67,95 @@
     https://**put_your_bitrix24_address**/rest/api/mail.mailbox.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.mailbox.list',
-            {
-                name: 'work',
-                email: 'example.com',
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Mailbox list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailboxListResult = {
+      items: {
+        id: number
+        name: string
+        email: string
+        senderName: string
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailboxListResult>({
+        method: 'mail.mailbox.list',
+        params: {
+          name: 'work',
+          email: 'example.com',
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Mailboxes found:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailboxList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.mailbox.list',
+            params: {
+              name: 'work',
+              email: 'example.com',
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Mailboxes found:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailboxList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/mailbox/mail-mailbox-senders.md
+++ b/api-reference/rest-v3/mail/mailbox/mail-mailbox-senders.md
@@ -63,31 +63,90 @@
     https://**put_your_bitrix24_address**/rest/api/mail.mailbox.senders
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.mailbox.senders',
-            {
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Sender list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailboxSendersResult = {
+      items: {
+        email: string
+        name: string
+        sender: string
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailboxSendersResult>({
+        method: 'mail.mailbox.senders',
+        params: {
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Senders:', result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailboxSenders() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.mailbox.senders',
+            params: {
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Senders:', result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailboxSenders)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-createcalendarevent.md
+++ b/api-reference/rest-v3/mail/message/mail-message-createcalendarevent.md
@@ -72,30 +72,86 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.createcalendarevent
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.createcalendarevent',
-            {
-                messageId: 15,
-                dateFrom: '2026-04-15 10:00:00',
-                dateTo: '2026-04-15 11:00:00',
-                name: 'Встреча по договору'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Calendar event:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CreateCalendarEventResult = {
+      success: boolean
+      eventId: number
+      messageId: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<CreateCalendarEventResult>({
+        method: 'mail.message.createcalendarevent',
+        params: {
+          messageId: 15,
+          dateFrom: '2026-04-15 10:00:00',
+          dateTo: '2026-04-15 11:00:00',
+          name: 'Contract meeting',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Created calendar event ID:', result.eventId, 'for message ID:', result.messageId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createCalendarEvent() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.createcalendarevent',
+            params: {
+              messageId: 15,
+              dateFrom: '2026-04-15 10:00:00',
+              dateTo: '2026-04-15 11:00:00',
+              name: 'Contract meeting',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Created calendar event ID:', result.eventId, 'for message ID:', result.messageId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createCalendarEvent)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-createchat.md
+++ b/api-reference/rest-v3/mail/message/mail-message-createchat.md
@@ -62,27 +62,81 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.createchat
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.createchat',
-            {
-                messageId: 15
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Chat create:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CreateChatResult = {
+      success: boolean
+      chatId: number
+      messageId: number
+      existing: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<CreateChatResult>({
+        method: 'mail.message.createchat',
+        params: {
+          messageId: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Chat created:', result.chatId, 'existing:', result.existing)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createChatFromMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.createchat',
+            params: {
+              messageId: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Chat created:', result.chatId, 'existing:', result.existing)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createChatFromMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-createcrmactivity.md
+++ b/api-reference/rest-v3/mail/message/mail-message-createcrmactivity.md
@@ -62,27 +62,73 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.createcrmactivity
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.createcrmactivity',
-            {
-                messageId: 15
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('CRM activity create:', result);
+    try {
+      const response = await $b24.actions.v3.call.make<boolean>({
+        method: 'mail.message.createcrmactivity',
+        params: {
+          messageId: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('CRM activity created:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createCrmActivity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.createcrmactivity',
+            params: {
+              messageId: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('CRM activity created:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createCrmActivity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-createfeedpost.md
+++ b/api-reference/rest-v3/mail/message/mail-message-createfeedpost.md
@@ -66,28 +66,82 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.createfeedpost
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.createfeedpost',
-            {
-                messageId: 15,
-                title: 'Обсуждение договора'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Feed post create:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CreateFeedPostResult = {
+      success: boolean
+      postId: number
+      messageId: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<CreateFeedPostResult>({
+        method: 'mail.message.createfeedpost',
+        params: {
+          messageId: 15,
+          title: 'Discussion of the contract',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Feed post created:', result.postId, '| success:', result.success)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createFeedPost() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.createfeedpost',
+            params: {
+              messageId: 15,
+              title: 'Discussion of the contract',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Feed post created:', result.postId, '| success:', result.success)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createFeedPost)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-createtask.md
+++ b/api-reference/rest-v3/mail/message/mail-message-createtask.md
@@ -72,29 +72,84 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.createtask
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.createtask',
-            {
-                messageId: 15,
-                title: 'Подготовить договор',
-                responsibleId: 7
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Task create:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type CreateTaskResult = {
+      success: boolean
+      taskId: number
+      messageId: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<CreateTaskResult>({
+        method: 'mail.message.createtask',
+        params: {
+          messageId: 15,
+          title: 'Prepare the contract',
+          responsibleId: 7,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task created:', result.taskId, 'from message:', result.messageId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function createMailMessageTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.createtask',
+            params: {
+              messageId: 15,
+              title: 'Prepare the contract',
+              responsibleId: 7,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task created:', result.taskId, 'from message:', result.messageId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', createMailMessageTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-field-get.md
+++ b/api-reference/rest-v3/mail/message/mail-message-field-get.md
@@ -92,32 +92,92 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.field.get',
-            {
-                name: 'subject',
-                select: [
-                    'name',
-                    'type',
-                    'title'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldGetResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<FieldGetResult>({
+        method: 'mail.message.field.get',
+        params: {
+          name: 'subject',
+          select: [
+            'name',
+            'type',
+            'title',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.name, result.item.type, result.item.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMessageField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.field.get',
+            params: {
+              name: 'subject',
+              select: [
+                'name',
+                'type',
+                'title',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.name, result.item.type, result.item.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMessageField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-field-list.md
+++ b/api-reference/rest-v3/mail/message/mail-message-field-list.md
@@ -74,33 +74,98 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'filterable',
-                    'sortable'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailMessageFieldListResult = {
+      items: {
+        name: string
+        type: string
+        title: string
+        filterable: boolean
+        sortable: boolean
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailMessageFieldListResult>({
+        method: 'mail.message.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'filterable',
+            'sortable',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field count:', result.items.length)
+        console.info(result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailMessageFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'filterable',
+                'sortable',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field count:', result.items.length)
+          console.info(result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailMessageFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-forward.md
+++ b/api-reference/rest-v3/mail/message/mail-message-forward.md
@@ -76,31 +76,87 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.forward
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.forward',
-            {
-                forwardMessageId: 15,
-                from: 'user@example.com',
-                to: ['manager@example.com'],
-                subject: 'Fwd: Договор',
-                body: 'Пересылаю письмо.'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Forward result:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ForwardResult = {
+      success: boolean
+      to: string[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<ForwardResult>({
+        method: 'mail.message.forward',
+        params: {
+          forwardMessageId: 15,
+          from: 'user@example.com',
+          to: ['manager@example.com'],
+          subject: 'Fwd: Contract',
+          body: 'Forwarding the message.',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Forwarded successfully:', result.success, 'To:', result.to)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function forwardMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.forward',
+            params: {
+              forwardMessageId: 15,
+              from: 'user@example.com',
+              to: ['manager@example.com'],
+              subject: 'Fwd: Contract',
+              body: 'Forwarding the message.',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Forwarded successfully:', result.success, 'To:', result.to)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', forwardMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-get.md
+++ b/api-reference/rest-v3/mail/message/mail-message-get.md
@@ -79,42 +79,122 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.get',
-            {
-                id: 15,
-                select: [
-                    'id',
-                    'mailboxId',
-                    'mailboxEmail',
-                    'subject',
-                    'from',
-                    'to',
-                    'cc',
-                    'date',
-                    'isSeen',
-                    'hasAttachments',
-                    'url',
-                    'bindings',
-                    'body'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Message item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MessageGetResult = {
+      item: {
+        id: number
+        mailboxId: number
+        mailboxEmail: string
+        subject: string
+        from: string
+        to: string
+        cc: string | null
+        date: ISODate | null
+        isSeen: boolean
+        hasAttachments: boolean
+        url: string
+        bindings: unknown[]
+        body: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MessageGetResult>({
+        method: 'mail.message.get',
+        params: {
+          id: 15,
+          select: [
+            'id',
+            'mailboxId',
+            'mailboxEmail',
+            'subject',
+            'from',
+            'to',
+            'cc',
+            'date',
+            'isSeen',
+            'hasAttachments',
+            'url',
+            'bindings',
+            'body',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Message:', result.item.id, result.item.subject, result.item.from)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.get',
+            params: {
+              id: 15,
+              select: [
+                'id',
+                'mailboxId',
+                'mailboxEmail',
+                'subject',
+                'from',
+                'to',
+                'cc',
+                'date',
+                'isSeen',
+                'hasAttachments',
+                'url',
+                'bindings',
+                'body',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Message:', result.item.id, result.item.subject, result.item.from)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-list.md
+++ b/api-reference/rest-v3/mail/message/mail-message-list.md
@@ -89,34 +89,118 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.list',
-            {
-                mailboxId: 1,
-                searchQuery: 'договор',
-                hasAttachments: true,
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Message list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailMessageListResult = {
+      items: MailMessageItem[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    type MailMessageItem = {
+      id: number
+      mailboxId: number
+      mailboxEmail: string
+      subject: string
+      from: string
+      to: string
+      cc: string
+      date: ISODate | null
+      isSeen: boolean
+      hasAttachments: boolean
+      url: string
+      bindings: unknown[]
+      body: string
     }
+
+    try {
+      // mail.message.list returns a single page (default 25, max 200 records). For the whole result set
+      // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+      // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `pagination` variant when sort matters.
+      const response = await $b24.actions.v3.call.make<MailMessageListResult>({
+        method: 'mail.message.list',
+        params: {
+          mailboxId: 1,
+          searchQuery: 'contract',
+          hasAttachments: true,
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Messages fetched:', result.items.length, result.items[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchMessageList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // mail.message.list returns a single page (default 25, max 200 records). For the whole result set
+          // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+          // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `pagination` variant when sort matters.
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.list',
+            params: {
+              mailboxId: 1,
+              searchQuery: 'contract',
+              hasAttachments: true,
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Messages fetched:', result.items.length, result.items[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchMessageList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-movetofolder.md
+++ b/api-reference/rest-v3/mail/message/mail-message-movetofolder.md
@@ -74,28 +74,82 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.movetofolder
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.movetofolder',
-            {
-                messageIds: [15, 16],
-                action: 'spam'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Success:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MoveToFolderResult = {
+      success: boolean
+      movedCount: number
+      action: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MoveToFolderResult>({
+        method: 'mail.message.movetofolder',
+        params: {
+          messageIds: [15, 16],
+          action: 'spam',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Moved count:', result.movedCount, 'Action:', result.action, 'Success:', result.success)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function moveToFolder() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.movetofolder',
+            params: {
+              messageIds: [15, 16],
+              action: 'spam',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Moved count:', result.movedCount, 'Action:', result.action, 'Success:', result.success)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', moveToFolder)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-removecrmactivity.md
+++ b/api-reference/rest-v3/mail/message/mail-message-removecrmactivity.md
@@ -62,27 +62,73 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.removecrmactivity
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.removecrmactivity',
-            {
-                messageId: 15
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Success:', result);
+    try {
+      const response = await $b24.actions.v3.call.make<boolean>({
+        method: 'mail.message.removecrmactivity',
+        params: {
+          messageId: 15,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('CRM activity unlinked:', result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
-    catch( error )
-    {
-        console.error('Error:', error);
-    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function removeCrmActivity() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.removecrmactivity',
+            params: {
+              messageId: 15,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('CRM activity unlinked:', result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', removeCrmActivity)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-reply.md
+++ b/api-reference/rest-v3/mail/message/mail-message-reply.md
@@ -76,31 +76,87 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.reply
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.reply',
-            {
-                replyToMessageId: 15,
-                from: 'user@example.com',
-                to: ['client@example.com'],
-                subject: 'Re: Договор',
-                body: 'Спасибо, получили.'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Success:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ReplyResult = {
+      success: boolean
+      to: string[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<ReplyResult>({
+        method: 'mail.message.reply',
+        params: {
+          replyToMessageId: 15,
+          from: 'user@example.com',
+          to: ['client@example.com'],
+          subject: 'Re: Contract',
+          body: 'Thank you, received.',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Reply sent:', result.success, 'Recipients:', result.to)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendReply() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.reply',
+            params: {
+              replyToMessageId: 15,
+              from: 'user@example.com',
+              to: ['client@example.com'],
+              subject: 'Re: Contract',
+              body: 'Thank you, received.',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Reply sent:', result.success, 'Recipients:', result.to)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendReply)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-send.md
+++ b/api-reference/rest-v3/mail/message/mail-message-send.md
@@ -72,30 +72,85 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.send
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.send',
-            {
-                from: 'user@example.com',
-                to: ['client@example.com'],
-                subject: 'Коммерческое предложение',
-                body: 'Здравствуйте. Отправляю материалы.'
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Success:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SendMessageResult = {
+      success: boolean
+      to: string[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<SendMessageResult>({
+        method: 'mail.message.send',
+        params: {
+          from: 'user@example.com',
+          to: ['client@example.com'],
+          subject: 'Commercial proposal',
+          body: 'Hello. Sending materials.',
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Success:', result.success, 'To:', result.to)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.send',
+            params: {
+              from: 'user@example.com',
+              to: ['client@example.com'],
+              subject: 'Commercial proposal',
+              body: 'Hello. Sending materials.',
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Success:', result.success, 'To:', result.to)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/message/mail-message-thread.md
+++ b/api-reference/rest-v3/mail/message/mail-message-thread.md
@@ -66,28 +66,88 @@
     https://**put_your_bitrix24_address**/rest/api/mail.message.thread
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.message.thread',
-            {
-                id: 15,
-                limit: 20
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Thread:', result);
+    // Shape of each MailMessage returned in result[]
+    type MailMessage = {
+      id: number
+      subject: string
+      from: string
+      to: string
+      cc: string
+      date: string
+      body: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailMessage[]>({
+        method: 'mail.message.thread',
+        params: {
+          id: 15,
+          limit: 20,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Thread messages count:', result.length)
+        console.info('First message subject:', result[0]?.subject)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailMessageThread() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.message.thread',
+            params: {
+              id: 15,
+              limit: 20,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Thread messages count:', result.length)
+          console.info('First message subject:', result[0]?.subject)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailMessageThread)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/recipient/mail-recipient-field-get.md
+++ b/api-reference/rest-v3/mail/recipient/mail-recipient-field-get.md
@@ -82,32 +82,92 @@
     https://**put_your_bitrix24_address**/rest/api/mail.recipient.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.recipient.field.get',
-            {
-                name: 'email',
-                select: [
-                    'name',
-                    'type',
-                    'title'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type MailRecipientFieldGetResult = {
+      item: {
+        name?: string
+        type?: string
+        title?: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<MailRecipientFieldGetResult>({
+        method: 'mail.recipient.field.get',
+        params: {
+          name: 'email',
+          select: [
+            'name',
+            'type',
+            'title',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field description:', result.item)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getMailRecipientField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.recipient.field.get',
+            params: {
+              name: 'email',
+              select: [
+                'name',
+                'type',
+                'title',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field description:', result.item)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getMailRecipientField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/recipient/mail-recipient-field-list.md
+++ b/api-reference/rest-v3/mail/recipient/mail-recipient-field-list.md
@@ -74,33 +74,110 @@
     https://**put_your_bitrix24_address**/rest/api/mail.recipient.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.recipient.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'filterable',
-                    'sortable'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    type FieldItem = {
+      name: string
+      type: string
+      title: string
+      filterable: boolean
+      sortable: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldListResult = {
+      items: FieldItem[]
     }
+
+    try {
+      // mail.recipient.field.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+      // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v3.call.make<FieldListResult>({
+        method: 'mail.recipient.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'filterable',
+            'sortable',
+          ],
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fields:', result.items, 'Count:', result.items.length)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRecipientFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // mail.recipient.field.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+          // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.recipient.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'filterable',
+                'sortable',
+              ],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fields:', result.items, 'Count:', result.items.length)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRecipientFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/recipient/mail-recipient-listcontacts.md
+++ b/api-reference/rest-v3/mail/recipient/mail-recipient-listcontacts.md
@@ -67,32 +67,92 @@
     https://**put_your_bitrix24_address**/rest/api/mail.recipient.listcontacts
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.recipient.listcontacts',
-            {
-                query: 'client',
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Recipient contacts:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ListContactsResult = {
+      items: {
+        id: number
+        email: string
+        name: string
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<ListContactsResult>({
+        method: 'mail.recipient.listcontacts',
+        params: {
+          query: 'client',
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Contacts:', result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listContacts() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.recipient.listcontacts',
+            params: {
+              query: 'client',
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Contacts:', result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listContacts)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/mail/recipient/mail-recipient-listemployees.md
+++ b/api-reference/rest-v3/mail/recipient/mail-recipient-listemployees.md
@@ -67,32 +67,92 @@
     https://**put_your_bitrix24_address**/rest/api/mail.recipient.listemployees
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'mail.recipient.listemployees',
-            {
-                query: 'Иван',
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Recipient employees:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type ListEmployeesResult = {
+      items: {
+        id: number
+        email: string
+        name: string
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<ListEmployeesResult>({
+        method: 'mail.recipient.listemployees',
+        params: {
+          query: 'Ivan',
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Employees found:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function listEmployees() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'mail.recipient.listemployees',
+            params: {
+              query: 'Ivan',
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Employees found:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', listEmployees)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/main/main-eventlog-field-get.md
+++ b/api-reference/rest-v3/main/main-eventlog-field-get.md
@@ -75,36 +75,108 @@
     https://**put_your_bitrix24_address**/rest/api/main.eventlog.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'main.eventlog.field.get',
-            {
-                name: 'timestampX',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Event log field:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EventLogFieldResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+        description: string
+        validationRules: unknown[]
+        requiredGroups: string[] | null
+        filterable: boolean
+        sortable: boolean
+        editable: boolean
+        multiple: boolean
+        elementType: string | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<EventLogFieldResult>({
+        method: 'main.eventlog.field.get',
+        params: {
+          name: 'timestampX',
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.name, result.item.title, result.item.type)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEventLogField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'main.eventlog.field.get',
+            params: {
+              name: 'timestampX',
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.name, result.item.title, result.item.type)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEventLogField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/main/main-eventlog-field-list.md
+++ b/api-reference/rest-v3/main/main-eventlog-field-list.md
@@ -73,35 +73,102 @@
     https://**put_your_bitrix24_address**/rest/api/main.eventlog.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'main.eventlog.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Event log fields:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EventlogFieldListResult = {
+      items: {
+        name: string
+        type: string
+        title: string
+        description: string | null
+        filterable: boolean
+        sortable: boolean
+        multiple: boolean
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<EventlogFieldListResult>({
+        method: 'main.eventlog.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event log fields:', result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchEventlogFieldList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'main.eventlog.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event log fields:', result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchEventlogFieldList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/main/main-eventlog-get.md
+++ b/api-reference/rest-v3/main/main-eventlog-get.md
@@ -77,27 +77,92 @@
     https://**put_your_bitrix24_address**/rest/api/main.eventlog.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'main.eventlog.get',
-            {
-                id: 1250
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Event log item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EventLogItemResult = {
+      item: {
+        id: number
+        timestampX: ISODate | null
+        severity: string
+        auditTypeId: string
+        moduleId: string
+        itemId: string
+        remoteAddr: string
+        userAgent: string
+        requestUri: string
+        siteId: string
+        userId: number
+        guestId: number
+        description: string
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<EventLogItemResult>({
+        method: 'main.eventlog.get',
+        params: {
+          id: 1250,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event log item:', result.item.id, result.item.severity, result.item.auditTypeId)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEventLogItem() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'main.eventlog.get',
+            params: {
+              id: 1250,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event log item:', result.item.id, result.item.severity, result.item.auditTypeId)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEventLogItem)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/main/main-eventlog-list.md
+++ b/api-reference/rest-v3/main/main-eventlog-list.md
@@ -96,48 +96,146 @@
     https://**put_your_bitrix24_address**/rest/api/main.eventlog.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'main.eventlog.list',
-            {
-                select: [
-                    'id',
-                    'timestampX',
-                    'severity',
-                    'auditTypeId',
-                    'moduleId',
-                    'itemId',
-                    'userId',
-                    'description'
-                ],
-                filter: [
-                    ['timestampX', '>=', '2026-01-30T00:00:00+03:00'],
-                    ['timestampX', '<', '2026-01-31T00:00:00+03:00']
-                ],
-                order: {
-                    id: 'ASC'
-                },
-                pagination: {
-                    page: 1,
-                    limit: 20,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Event log list:', result);
+    type EventLogItem = {
+      id: number
+      timestampX: ISODate | null
+      severity: string
+      auditTypeId: string
+      moduleId: string
+      itemId: string
+      remoteAddr: string
+      userAgent: string
+      requestUri: string
+      siteId: string
+      userId: number
+      guestId: number
+      description: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EventLogListResult = {
+      items: EventLogItem[]
     }
+
+    try {
+      // main.eventlog.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+      // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `pagination` variant when sort matters.
+      const response = await $b24.actions.v3.call.make<EventLogListResult>({
+        method: 'main.eventlog.list',
+        params: {
+          select: [
+            'id',
+            'timestampX',
+            'severity',
+            'auditTypeId',
+            'moduleId',
+            'itemId',
+            'userId',
+            'description',
+          ],
+          filter: [
+            ['timestampX', '>=', '2026-01-30T00:00:00+03:00'],
+            ['timestampX', '<', '2026-01-31T00:00:00+03:00'],
+          ],
+          order: {
+            id: 'ASC',
+          },
+          pagination: {
+            page: 1,
+            limit: 20,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Event log entries:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getEventLogList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // main.eventlog.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+          // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `pagination` variant when sort matters.
+          const response = await $b24.actions.v3.call.make({
+            method: 'main.eventlog.list',
+            params: {
+              select: [
+                'id',
+                'timestampX',
+                'severity',
+                'auditTypeId',
+                'moduleId',
+                'itemId',
+                'userId',
+                'description',
+              ],
+              filter: [
+                ['timestampX', '>=', '2026-01-30T00:00:00+03:00'],
+                ['timestampX', '<', '2026-01-31T00:00:00+03:00'],
+              ],
+              order: {
+                id: 'ASC',
+              },
+              pagination: {
+                page: 1,
+                limit: 20,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Event log entries:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getEventLogList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/main/main-eventlog-tail.md
+++ b/api-reference/rest-v3/main/main-eventlog-tail.md
@@ -91,42 +91,124 @@
     https://**put_your_bitrix24_address**/rest/api/main.eventlog.tail
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'main.eventlog.tail',
-            {
-                select: [
-                    'id',
-                    'timestampX',
-                    'severity',
-                    'auditTypeId',
-                    'moduleId',
-                    'itemId',
-                    'userId',
-                    'description'
-                ],
-                filter: [],
-                cursor: {
-                    field: 'id',
-                    value: 446313,
-                    order: 'ASC'
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Event log tail:', result);
+    type EventLogEntry = {
+      id: number
+      timestampX: ISODate
+      severity: string
+      auditTypeId: string
+      moduleId: string
+      itemId: string
+      remoteAddr: string
+      userAgent: string
+      requestUri: string
+      siteId: string
+      userId: number
+      guestId: number
+      description: string
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type EventLogTailResult = {
+      items: EventLogEntry[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<EventLogTailResult>({
+        method: 'main.eventlog.tail',
+        params: {
+          select: [
+            'id',
+            'timestampX',
+            'severity',
+            'auditTypeId',
+            'moduleId',
+            'itemId',
+            'userId',
+            'description',
+          ],
+          filter: [],
+          cursor: {
+            field: 'id',
+            value: 446313,
+            order: 'ASC',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Received entries:', result.items.length, result.items[0]?.id)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchEventLogTail() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'main.eventlog.tail',
+            params: {
+              select: [
+                'id',
+                'timestampX',
+                'severity',
+                'auditTypeId',
+                'moduleId',
+                'itemId',
+                'userId',
+                'description',
+              ],
+              filter: [],
+              cursor: {
+                field: 'id',
+                value: 446313,
+                order: 'ASC',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Received entries:', result.items.length, result.items[0]?.id)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchEventLogTail)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/result/tasks-task-result-add.md
+++ b/api-reference/rest-v3/tasks/result/tasks-task-result-add.md
@@ -73,30 +73,98 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.result.add
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.add',
-            {
-                fields: {
-                    taskId: 51,
-                    text: 'Работа по задаче выполнена'
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result.item);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskResultAddResult = {
+      item: {
+        id: number,
+        taskId: number,
+        text: string,
+        authorId: number,
+        createdAt: ISODate,
+        updatedAt: ISODate | null,
+        status: string,
+        fileIds: number[],
+        rights: {
+          edit: boolean,
+          remove: boolean,
+        },
+        messageId: number | null,
+      },
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskResultAddResult>({
+        method: 'tasks.task.result.add',
+        params: {
+          fields: {
+            taskId: 51,
+            text: 'Task work has been completed',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.id, result.item.taskId, result.item.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTaskResult() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.result.add',
+            params: {
+              fields: {
+                taskId: 51,
+                text: 'Task work has been completed',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.id, result.item.taskId, result.item.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTaskResult)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/result/tasks-task-result-addfromchatmessage.md
+++ b/api-reference/rest-v3/tasks/result/tasks-task-result-addfromchatmessage.md
@@ -71,29 +71,96 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.result.addfromchatmessage
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.addfromchatmessage',
-            {
-                fields: {
-                    messageId: 335
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result.item);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AddFromChatMessageResult = {
+      item: {
+        id: number
+        taskId: number
+        text: string
+        authorId: number
+        createdAt: ISODate
+        updatedAt: ISODate | null
+        status: string
+        fileIds: number[]
+        rights: {
+          edit: boolean
+          remove: boolean
+        }
+        messageId: number
+      }
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<AddFromChatMessageResult>({
+        method: 'tasks.task.result.addfromchatmessage',
+        params: {
+          fields: {
+            messageId: 335,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.id, result.item.taskId, result.item.text)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addResultFromChatMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.result.addfromchatmessage',
+            params: {
+              fields: {
+                messageId: 335,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.id, result.item.taskId, result.item.text)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addResultFromChatMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/result/tasks-task-result-delete.md
+++ b/api-reference/rest-v3/tasks/result/tasks-task-result-delete.md
@@ -60,27 +60,78 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.result.delete
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.delete',
-            {
-                id: 17
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskResultDeleteResult = {
+      result: boolean
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskResultDeleteResult>({
+        method: 'tasks.task.result.delete',
+        params: {
+          id: 17,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Deleted:', result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTaskResult() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.result.delete',
+            params: {
+              id: 17,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Deleted:', result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTaskResult)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/result/tasks-task-result-list.md
+++ b/api-reference/rest-v3/tasks/result/tasks-task-result-list.md
@@ -124,37 +124,106 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.result.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.list',
-            {
-                filter: [
-                    ['taskId', 51]
-                ],
-                select: ['id', 'taskId', 'text', 'authorId', 'createdAt', 'status', 'messageId'],
-                order: {
-                    createdAt: 'DESC'
-                },
-                pagination: {
-                    limit: 10,
-                    offset: 0
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result.items);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskResultListResult = {
+      items: {
+        id: number
+        taskId: number
+        text: string
+        authorId: number
+        createdAt: ISODate
+        status: string
+        messageId: number | null
+      }[]
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskResultListResult>({
+        method: 'tasks.task.result.list',
+        params: {
+          filter: [
+            ['taskId', 51],
+          ],
+          select: ['id', 'taskId', 'text', 'authorId', 'createdAt', 'status', 'messageId'],
+          order: {
+            createdAt: 'DESC',
+          },
+          pagination: {
+            limit: 10,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTaskResults() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.result.list',
+            params: {
+              filter: [
+                ['taskId', 51],
+              ],
+              select: ['id', 'taskId', 'text', 'authorId', 'createdAt', 'status', 'messageId'],
+              order: {
+                createdAt: 'DESC',
+              },
+              pagination: {
+                limit: 10,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTaskResults)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/result/tasks-task-result-update.md
+++ b/api-reference/rest-v3/tasks/result/tasks-task-result-update.md
@@ -71,30 +71,98 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.result.update
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.result.update',
-            {
-                id: 17,
-                fields: {
-                    text: 'Работа по задаче выполнена и проверена'
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.info(result.item);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskResultUpdateResult = {
+      item: {
+        id: number
+        taskId: number
+        text: string
+        authorId: number
+        createdAt: ISODate | null
+        updatedAt: ISODate | null
+        status: string
+        fileIds: number[]
+        rights: {
+          edit: boolean
+          remove: boolean
+        }
+        messageId: number | null
+      }
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskResultUpdateResult>({
+        method: 'tasks.task.result.update',
+        params: {
+          id: 17,
+          fields: {
+            text: 'Work on the task has been completed and verified',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTaskResult() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.result.update',
+            params: {
+              id: 17,
+              fields: {
+                text: 'Work on the task has been completed and verified',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTaskResult)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-access-field-get.md
+++ b/api-reference/rest-v3/tasks/tasks-task-access-field-get.md
@@ -75,36 +75,108 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.access.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.access.field.get',
-            {
-                name: 'id',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AccessFieldGetResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+        description: string | null
+        validationRules: unknown[]
+        requiredGroups: string[] | null
+        filterable: boolean
+        sortable: boolean
+        editable: boolean
+        multiple: boolean
+        elementType: string | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<AccessFieldGetResult>({
+        method: 'tasks.task.access.field.get',
+        params: {
+          name: 'id',
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field item:', result.item)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getAccessField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.access.field.get',
+            params: {
+              name: 'id',
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field item:', result.item)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getAccessField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-access-field-list.md
+++ b/api-reference/rest-v3/tasks/tasks-task-access-field-list.md
@@ -73,35 +73,120 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.access.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.access.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AccessFieldListResult = {
+      items: AccessFieldItem[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    type AccessFieldItem = {
+      name: string
+      type: string
+      title: string
+      description: string
+      validationRules: unknown[]
+      requiredGroups: string[] | null
+      filterable: boolean
+      sortable: boolean
+      editable: boolean
+      multiple: boolean
+      elementType: string | null
     }
+
+    try {
+      // tasks.task.access.field.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+      // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+      const response = await $b24.actions.v3.call.make<AccessFieldListResult>({
+        method: 'tasks.task.access.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+          start: 0,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Fields count:', result.items.length, 'First field:', result.items[0])
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchAccessFieldList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // tasks.task.access.field.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v3.callList.make() returns every record as one
+          // array, $b24.actions.v3.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `start` variant when sort matters.
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.access.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+              start: 0,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Fields count:', result.items.length, 'First field:', result.items[0])
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchAccessFieldList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-access-get.md
+++ b/api-reference/rest-v3/tasks/tasks-task-access-get.md
@@ -62,29 +62,122 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.access.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.access.get',
-            {
-                id: 8017,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Access data:', result);
-        
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskAccessResult = {
+      read: boolean
+      watch: boolean
+      mute: boolean
+      createSubtask: boolean
+      createResult: boolean
+      edit: boolean
+      remove: boolean
+      complete: boolean
+      approve: boolean
+      disapprove: boolean
+      start: boolean
+      take: boolean
+      delegate: boolean
+      defer: boolean
+      renew: boolean
+      deadline: boolean
+      datePlan: boolean
+      changeDirector: boolean
+      changeResponsible: boolean
+      changeAccomplices: boolean
+      pause: boolean
+      timeTracking: boolean
+      mark: boolean
+      changeStatus: boolean
+      reminder: boolean
+      addAuditors: boolean
+      elapsedTime: boolean
+      favorite: boolean
+      checklistAdd: boolean
+      checklistEdit: boolean
+      checklistSave: boolean
+      checklistToggle: boolean
+      automate: boolean
+      resultEdit: boolean
+      completeResult: boolean
+      removeResult: boolean
+      resultRead: boolean
+      admin: boolean
+      copy: boolean
+      saveAsTemplate: boolean
+      attachFile: boolean
+      detachFile: boolean
+      detachParent: boolean
+      createGanttDependence: boolean
+      sort: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskAccessResult>({
+        method: 'tasks.task.access.get',
+        params: {
+          id: 8017,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task access rights — edit:', result.edit, 'complete:', result.complete, 'remove:', result.remove)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskAccess() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.access.get',
+            params: {
+              id: 8017,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task access rights — edit:', result.edit, 'complete:', result.complete, 'remove:', result.remove)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskAccess)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-add.md
+++ b/api-reference/rest-v3/tasks/tasks-task-add.md
@@ -84,33 +84,99 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.add
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.add',
-            {
-                fields: {
-                    title: 'Название задачи',
-                    deadline: '2025-12-31T23:59:59+02:00',
-                    creatorId: 29,
-                    responsibleId: 1,
-                    crmItemIds: ['L_1000959']
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.info('Task created with ID', result.item?.id);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskAddResult = {
+      item: {
+        id: number
+        title: string
+        description: string
+        deadline: ISODate | null
+        priority: string
+        status: string
+        parentId: number | null
+        crmItemIds: string[]
+      }
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskAddResult>({
+        method: 'tasks.task.add',
+        params: {
+          fields: {
+            title: 'Task title',
+            deadline: '2025-12-31T23:59:59+02:00',
+            creatorId: 29,
+            responsibleId: 1,
+            crmItemIds: ['L_1000959'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task created:', result.item.id, result.item.title, result.item.status)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function addTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.add',
+            params: {
+              fields: {
+                title: 'Task title',
+                deadline: '2025-12-31T23:59:59+02:00',
+                creatorId: 29,
+                responsibleId: 1,
+                crmItemIds: ['L_1000959'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task created:', result.item.id, result.item.title, result.item.status)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', addTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-chat-message-field-get.md
+++ b/api-reference/rest-v3/tasks/tasks-task-chat-message-field-get.md
@@ -75,36 +75,104 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.chat.message.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.chat.message.field.get',
-            {
-                name: 'taskId',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldGetResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+        description: string | null
+        filterable: boolean
+        sortable: boolean
+        multiple: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<FieldGetResult>({
+        method: 'tasks.task.chat.message.field.get',
+        params: {
+          name: 'taskId',
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.name, result.item.type, result.item.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskChatMessageField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.chat.message.field.get',
+            params: {
+              name: 'taskId',
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.name, result.item.type, result.item.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskChatMessageField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-chat-message-field-list.md
+++ b/api-reference/rest-v3/tasks/tasks-task-chat-message-field-list.md
@@ -73,35 +73,102 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.chat.message.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.chat.message.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldListResult = {
+      items: {
+        name: string
+        type: string
+        title: string
+        description: string | null
+        filterable: boolean
+        sortable: boolean
+        multiple: boolean
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<FieldListResult>({
+        method: 'tasks.task.chat.message.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Available fields count:', result.items.length, result.items.map(f => f.name))
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskChatMessageFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.chat.message.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Available fields count:', result.items.length, result.items.map(f => f.name))
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskChatMessageFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-chat-message-send.md
+++ b/api-reference/rest-v3/tasks/tasks-task-chat-message-send.md
@@ -75,32 +75,84 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.chat.message.send
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.chat.message.send',
-            {
-                fields: {
-                    taskId: 51,
-                    text: 'Сообщение из внешней системы',
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Message sent with ID:', result);
-        
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type SendMessageResult = {
+      result: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<SendMessageResult>({
+        method: 'tasks.task.chat.message.send',
+        params: {
+          fields: {
+            taskId: 51,
+            text: 'Message from external system',
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Message sent successfully:', result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function sendTaskChatMessage() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.chat.message.send',
+            params: {
+              fields: {
+                taskId: 51,
+                text: 'Message from external system',
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Message sent successfully:', result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', sendTaskChatMessage)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-delete.md
+++ b/api-reference/rest-v3/tasks/tasks-task-delete.md
@@ -64,29 +64,78 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.delete
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.delete',
-            {
-                id: 8131,
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Deleted task:', result);
-        
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type DeleteTaskResult = {
+      result: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<DeleteTaskResult>({
+        method: 'tasks.task.delete',
+        params: {
+          id: 8131,
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task deleted:', result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function deleteTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.delete',
+            params: {
+              id: 8131,
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task deleted:', result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', deleteTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-field-get.md
+++ b/api-reference/rest-v3/tasks/tasks-task-field-get.md
@@ -75,36 +75,108 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.field.get',
-            {
-                name: 'id',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskFieldGetResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+        description: string
+        validationRules: unknown[]
+        requiredGroups: string[] | null
+        filterable: boolean
+        sortable: boolean
+        editable: boolean
+        multiple: boolean
+        elementType: string | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskFieldGetResult>({
+        method: 'tasks.task.field.get',
+        params: {
+          name: 'id',
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field item:', result.item)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.field.get',
+            params: {
+              name: 'id',
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field item:', result.item)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-field-list.md
+++ b/api-reference/rest-v3/tasks/tasks-task-field-list.md
@@ -73,35 +73,104 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    type FieldItem = {
+      name: string
+      type: string
+      title: string
+      description: string | null
+      filterable: boolean
+      sortable: boolean
+      multiple: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskFieldListResult = {
+      items: FieldItem[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskFieldListResult>({
+        method: 'tasks.task.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task fields:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTaskFieldList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task fields:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTaskFieldList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-file-attach.md
+++ b/api-reference/rest-v3/tasks/tasks-task-file-attach.md
@@ -74,30 +74,80 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.file.attach
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.file.attach',
-            {
-                taskId: 8017,
-                fileIds: [1065, 1077],
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Files attached:', result);
-        
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type AttachFileResult = {
+      result: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<AttachFileResult>({
+        method: 'tasks.task.file.attach',
+        params: {
+          taskId: 8017,
+          fileIds: [1065, 1077],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Files attached successfully:', result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function attachTaskFiles() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.file.attach',
+            params: {
+              taskId: 8017,
+              fileIds: [1065, 1077],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Files attached successfully:', result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', attachTaskFiles)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-file-field-get.md
+++ b/api-reference/rest-v3/tasks/tasks-task-file-field-get.md
@@ -75,36 +75,104 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.file.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.file.field.get',
-            {
-                name: 'taskId',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field item:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FileFieldGetResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+        description: string | null
+        filterable: boolean
+        sortable: boolean
+        multiple: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<FileFieldGetResult>({
+        method: 'tasks.task.file.field.get',
+        params: {
+          name: 'taskId',
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Field item:', result.item)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFileField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.file.field.get',
+            params: {
+              name: 'taskId',
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Field item:', result.item)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFileField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-file-field-list.md
+++ b/api-reference/rest-v3/tasks/tasks-task-file-field-list.md
@@ -73,35 +73,102 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.file.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.file.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'description',
-                    'filterable',
-                    'sortable',
-                    'multiple'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Field list:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FileFieldListResult = {
+      items: {
+        name: string
+        type: string
+        title: string
+        description: string | null
+        filterable: boolean
+        sortable: boolean
+        multiple: boolean
+      }[]
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<FileFieldListResult>({
+        method: 'tasks.task.file.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'description',
+            'filterable',
+            'sortable',
+            'multiple',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getFileFieldList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.file.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'description',
+                'filterable',
+                'sortable',
+                'multiple',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getFileFieldList)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-get.md
+++ b/api-reference/rest-v3/tasks/tasks-task-get.md
@@ -72,32 +72,99 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.get',
-            {
-                id: 8017,
-                select: [
-                    'responsible.name',
-                    'responsible.email'
-                ]
-            }
-        );
-        
-        const result = response.getData().result;
-        console.log('Fetched task:', result);
-        processResult(result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskGetResult = {
+      item: {
+        id: number
+        title: string
+        description: string
+        responsible?: {
+          name: string
+          email: string
+        }
+        deadline: ISODate | null
+        status: string
+        priority: string
+        statusChanged: ISODate | null
+        changed: ISODate | null
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskGetResult>({
+        method: 'tasks.task.get',
+        params: {
+          id: 8017,
+          select: [
+            'responsible.name',
+            'responsible.email',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task:', result.item.id, result.item.title, result.item.responsible)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.get',
+            params: {
+              id: 8017,
+              select: [
+                'responsible.name',
+                'responsible.email',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task:', result.item.id, result.item.title, result.item.responsible)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/tasks/tasks-task-update.md
+++ b/api-reference/rest-v3/tasks/tasks-task-update.md
@@ -65,34 +65,92 @@
     https://**put_your_bitrix24_address**/rest/api/tasks.task.update
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch. 
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'tasks.task.update',
-            {
-                id: 11,
-                fields: {
-                    title: 'Название задачи',
-                    deadline: '2025-12-31T23:59:59+02:00',
-                    creatorId: 29,
-                    responsibleId: 1,
-                    crmItemIds: ['L_1000959']
-                }
-            }
-        );
-        
-        const result = response.getData().result;
-        console.info('Task updated:', result);
+    declare const $b24: B24Frame
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TaskUpdateResult = {
+      result: boolean
     }
-    catch( error )
-    {
-        console.error(error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<TaskUpdateResult>({
+        method: 'tasks.task.update',
+        params: {
+          id: 11,
+          fields: {
+            title: 'Task title',
+            deadline: '2025-12-31T23:59:59+02:00',
+            creatorId: 29,
+            responsibleId: 1,
+            crmItemIds: ['L_1000959'],
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Task updated:', result.result)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function updateTask() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'tasks.task.update',
+            params: {
+              id: 11,
+              fields: {
+                title: 'Task title',
+                deadline: '2025-12-31T23:59:59+02:00',
+                creatorId: 29,
+                responsibleId: 1,
+                crmItemIds: ['L_1000959'],
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Task updated:', result.result)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', updateTask)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/timeman/timeman-record-field-get.md
+++ b/api-reference/rest-v3/timeman/timeman-record-field-get.md
@@ -87,34 +87,98 @@
     https://**put_your_bitrix24_address**/rest/api/timeman.record.field.get
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'timeman.record.field.get',
-            {
-                name: 'startTime',
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'filterable',
-                    'sortable'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Record field:', result);
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldGetResult = {
+      item: {
+        name: string
+        type: string
+        title: string
+        filterable: boolean
+        sortable: boolean
+      }
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    try {
+      const response = await $b24.actions.v3.call.make<FieldGetResult>({
+        method: 'timeman.record.field.get',
+        params: {
+          name: 'startTime',
+          select: [
+            'name',
+            'type',
+            'title',
+            'filterable',
+            'sortable',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info(result.item.name, result.item.type, result.item.title)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
     }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchRecordField() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'timeman.record.field.get',
+            params: {
+              name: 'startTime',
+              select: [
+                'name',
+                'type',
+                'title',
+                'filterable',
+                'sortable',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info(result.item.name, result.item.type, result.item.title)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchRecordField)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/timeman/timeman-record-field-list.md
+++ b/api-reference/rest-v3/timeman/timeman-record-field-list.md
@@ -73,33 +73,98 @@
     https://**put_your_bitrix24_address**/rest/api/timeman.record.field.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'timeman.record.field.list',
-            {
-                select: [
-                    'name',
-                    'type',
-                    'title',
-                    'filterable',
-                    'sortable'
-                ]
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Record fields:', result);
+    type FieldItem = {
+      name: string
+      type: string
+      title: string
+      filterable: boolean
+      sortable: boolean
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type FieldListResult = {
+      items: FieldItem[]
     }
+
+    try {
+      const response = await $b24.actions.v3.call.make<FieldListResult>({
+        method: 'timeman.record.field.list',
+        params: {
+          select: [
+            'name',
+            'type',
+            'title',
+            'filterable',
+            'sortable',
+          ],
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Record fields:', result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function getRecordFields() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          const response = await $b24.actions.v3.call.make({
+            method: 'timeman.record.field.list',
+            params: {
+              select: [
+                'name',
+                'type',
+                'title',
+                'filterable',
+                'sortable',
+              ],
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Record fields:', result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', getRecordFields)
+    </script>
     ```
 
 - PHP

--- a/api-reference/rest-v3/timeman/timeman-record-list.md
+++ b/api-reference/rest-v3/timeman/timeman-record-list.md
@@ -102,44 +102,129 @@
     https://**put_your_bitrix24_address**/rest/api/timeman.record.list
     ```
 
-- JS
+- JS (TS)
 
-    SDK пока не поддерживают в вызовах адрес /rest/api/. Используйте прямые HTTP-запросы, например, через curl, fetch.
+    ```ts
+    // This snippet is an ES module: top-level await requires type="module" or a bundler.
+    // $b24 is an already-initialized SDK instance (see the SDK "Get started" guide).
+    import { Text } from '@bitrix24/b24jssdk'
+    import type { B24Frame, ISODate } from '@bitrix24/b24jssdk'
 
-    ```javascript
-    try
-    {
-        const response = await $b24.callMethod(
-            'timeman.record.list',
-            {
-                filter: [
-                    ['userId', 1],
-                    ['startTime', 'between', ['2026-06-01T00:00:00+03:00', '2026-06-30T23:59:59+03:00']]
-                ],
-                select: [
-                    'id',
-                    'startTime',
-                    'endTime',
-                    'duration'
-                ],
-                order: {
-                    startTime: 'DESC'
-                },
-                pagination: { 
-                    page: 1,
-                    limit: 50, 
-                    offset: 0 
-                }
-            }
-        );
+    declare const $b24: B24Frame
 
-        const result = response.getData().result;
-        console.log('Record list:', result);
+    type TimemanRecordItem = {
+      id: number
+      startTime: ISODate
+      endTime: ISODate
+      duration: number
     }
-    catch( error )
-    {
-        console.error('Error:', error);
+
+    // Shape of the payload returned in result (match the "response handling" section of the page)
+    type TimemanRecordListResult = {
+      items: TimemanRecordItem[]
     }
+
+    try {
+      // timeman.record.list returns a single page (max 50 records). For the whole result set
+      // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+      // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+      // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+      // passing it is a TS error) — keep this call.make + `pagination` variant when sort matters.
+      const response = await $b24.actions.v3.call.make<TimemanRecordListResult>({
+        method: 'timeman.record.list',
+        params: {
+          filter: [
+            ['userId', 1],
+            ['startTime', 'between', ['2026-06-01T00:00:00+03:00', '2026-06-30T23:59:59+03:00']],
+          ],
+          select: [
+            'id',
+            'startTime',
+            'endTime',
+            'duration',
+          ],
+          order: {
+            startTime: 'DESC',
+          },
+          pagination: {
+            page: 1,
+            limit: 50,
+            offset: 0,
+          },
+        },
+        requestId: Text.getUuidRfc4122()
+      })
+
+      // The payload is available only on a successful response
+      if (!response.isSuccess) {
+        console.error(response.getErrorMessages().join('; '))
+      } else {
+        const result = response.getData()!.result
+        console.info('Records fetched:', result.items.length, result.items)
+      }
+    } catch (error) {
+      // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+      console.error(error)
+    }
+    ```
+
+- JS (UMD)
+
+    ```html
+    <!-- Load the SDK (UMD build); it is exposed as the global B24Js -->
+    <script src="https://unpkg.com/@bitrix24/b24jssdk@1/dist/umd/index.min.js"></script>
+    <script>
+      async function fetchTimemanRecordList() {
+        try {
+          // Initialize the SDK inside a Bitrix24 frame
+          const $b24 = await B24Js.initializeB24Frame()
+
+          // timeman.record.list returns a single page (max 50 records). For the whole result set
+          // use a list helper: $b24.actions.v2.callList.make() returns every record as one
+          // array, $b24.actions.v2.fetchList.make() yields them in chunks (async generator).
+          // NOTE: the list helpers do not accept `order` (it is excluded from their params, so
+          // passing it is a TS error) — keep this call.make + `pagination` variant when sort matters.
+          const response = await $b24.actions.v3.call.make({
+            method: 'timeman.record.list',
+            params: {
+              filter: [
+                ['userId', 1],
+                ['startTime', 'between', ['2026-06-01T00:00:00+03:00', '2026-06-30T23:59:59+03:00']],
+              ],
+              select: [
+                'id',
+                'startTime',
+                'endTime',
+                'duration',
+              ],
+              order: {
+                startTime: 'DESC',
+              },
+              pagination: {
+                page: 1,
+                limit: 50,
+                offset: 0,
+              },
+            },
+            requestId: B24Js.Text.getUuidRfc4122()
+          })
+
+          // The payload is available only on a successful response
+          if (!response.isSuccess) {
+            console.error(response.getErrorMessages().join('; '))
+            return
+          }
+
+          const result = response.getData().result
+          console.info('Records fetched:', result.items.length, result.items)
+        } catch (error) {
+          // Thrown on transport or SDK failures (AjaxError, SdkError, etc.)
+          console.error(error)
+        }
+      }
+
+      document.addEventListener('DOMContentLoaded', fetchTimemanRecordList)
+    </script>
     ```
 
 - PHP


### PR DESCRIPTION
## What
Actualizes the JavaScript examples across **rest-v3** (74 pages): the legacy `- JS` tab
(`$b24.callMethod`) is replaced by two tabs — `- JS (TS)` and `- JS (UMD)` — on the current
actions API (`$b24.actions.v3.call.make`).

## Scope & guarantees
- Only the `- JS` tab changes. cURL/PHP/BX24.js/PHP-CRest/Python tabs and all prose /
  parameter tables / response sections are unchanged.
- Each example validated with `tsc` against `@bitrix24/b24jssdk` + a structural TS/UMD check.
- The branch carries only `api-reference/rest-v3/` content — no tooling, no CI.

No breaking changes — documentation examples only.