### PR TITLE
Перевели туториал по каталогу на актуальные SDK: B24JsSDK, B24PhpSDK и b24pysdk

### DIFF
--- a/tutorials/catalog/index.md
+++ b/tutorials/catalog/index.md
@@ -25,9 +25,9 @@
 
 Перед запуском примеров подготовьте окружение:
 
-- JS-код выполняется в приложении Битрикс24, где доступен объект `BX24`
-- PHP-код использует класс `CRest`; настройте вебхук или OAuth-авторизацию для вызовов методов
-- файлы для загрузки должны быть доступны коду примера: в JS — по относительному URL приложения, в PHP — по пути на сервере
+- установите SDK для своего языка: `npm install @bitrix24/b24jssdk`, `composer require bitrix24/b24phpsdk:"^3.0"` или `pip install b24pysdk`
+- примеры выполняются на сервере и авторизуются по [входящему вебхуку](../../local-integrations/local-webhooks.md) с правом `catalog`. Замените адрес вебхука на свой
+- файлы для загрузки должны быть доступны коду примера по пути на сервере
 
 ## 1. Подготовим свойства
 
@@ -47,6 +47,16 @@
 - `Сертификат` — файловое свойство
 - `Галерея` — множественное файловое свойство
 
+{% note warning "Одиночному списочному свойству нужно минимум два значения" %}
+
+Для одиночного списочного свойства — `multiple: N` — создайте минимум два значения списка. Если значение всего одно, Битрикс24 определяет такое свойство как «Да/Нет» — `userType: BoolEnum`. Идентификатор значения списка в поле `propertyN` не сохранится: товар вернет `propertyN: "N"`, ошибки при этом не будет.
+
+Поэтому для свойства `Цвет` создадим два значения — `Синий` и `Красный`. Множественного списочного свойства это ограничение не касается.
+
+Проверить, как определилось свойство, можно методом [catalog.product.getFieldsByFilter](../../api-reference/catalog/product/catalog-product-get-fields-by-filter.md) — в ответе у поля `propertyN` будет `userType: BoolEnum`. Метод [catalog.productProperty.get](../../api-reference/catalog/product-property/catalog-product-property-get.md) вернет `userType: null`, потому что тип «Да/Нет» вычисляется по количеству значений списка.
+
+{% endnote %}
+
 {% include [Сноска о примерах](../../_includes/examples.md) %}
 
 {% list tabs %}
@@ -54,273 +64,316 @@
 - JS
 
     ```js
-    const iblockId = 23;
+    // npm install @bitrix24/b24jssdk
+    import { B24Hook } from '@bitrix24/b24jssdk'
 
-    function callMethod(method, params) {
-        return new Promise((resolve, reject) => {
-            BX24.callMethod(method, params, function(result) {
-                if (result.error()) {
-                    reject(result.error() + ': ' + result.error_description());
-                    return;
-                }
+    const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/USER_ID/TOKEN/')
 
-                resolve(result.data());
-            });
-        });
+    const iblockId = 23
+
+    async function callMethod(method, params, requestId) {
+        const response = await $b24.actions.v2.call.make({ method, params, requestId })
+
+        if (!response.isSuccess) {
+            throw new Error(response.getErrorMessages().join('; '))
+        }
+
+        return response.getData().result
+    }
+
+    async function addProperty(fields) {
+        const result = await callMethod(
+            'catalog.productProperty.add',
+            { fields },
+            `property-add-${fields.code}`
+        )
+
+        return result.productProperty
+    }
+
+    async function addPropertyEnum(propertyId, value, xmlId, sort) {
+        const result = await callMethod(
+            'catalog.productPropertyEnum.add',
+            { fields: { propertyId, value, xmlId, sort } },
+            `property-enum-add-${xmlId}`
+        )
+
+        return result.productPropertyEnum
     }
 
     async function prepareProperties() {
-        const colorProperty = await callMethod(
-            'catalog.productProperty.add',
-            {
-                fields: {
-                    iblockId: iblockId,
-                    name: 'Цвет',
-                    code: 'COLOR',
-                    propertyType: 'L',
-                    listType: 'L',
-                    multiple: 'N',
-                    active: 'Y',
-                    sort: 100
-                }
-            }
-        );
+        const colorProperty = await addProperty({
+            iblockId: iblockId,
+            name: 'Цвет',
+            code: 'COLOR',
+            propertyType: 'L',
+            listType: 'L',
+            multiple: 'N',
+            active: 'Y',
+            sort: 100
+        })
 
-        const sizeProperty = await callMethod(
-            'catalog.productProperty.add',
-            {
-                fields: {
-                    iblockId: iblockId,
-                    name: 'Размеры',
-                    code: 'SIZES',
-                    propertyType: 'L',
-                    listType: 'C',
-                    multiple: 'Y',
-                    active: 'Y',
-                    sort: 200
-                }
-            }
-        );
+        const sizeProperty = await addProperty({
+            iblockId: iblockId,
+            name: 'Размеры',
+            code: 'SIZES',
+            propertyType: 'L',
+            listType: 'C',
+            multiple: 'Y',
+            active: 'Y',
+            sort: 200
+        })
 
-        const certificateProperty = await callMethod(
-            'catalog.productProperty.add',
-            {
-                fields: {
-                    iblockId: iblockId,
-                    name: 'Сертификат',
-                    code: 'CERTIFICATE',
-                    propertyType: 'F',
-                    multiple: 'N',
-                    active: 'Y',
-                    sort: 300
-                }
-            }
-        );
+        const certificateProperty = await addProperty({
+            iblockId: iblockId,
+            name: 'Сертификат',
+            code: 'CERTIFICATE',
+            propertyType: 'F',
+            multiple: 'N',
+            active: 'Y',
+            sort: 300
+        })
 
-        const galleryProperty = await callMethod(
-            'catalog.productProperty.add',
-            {
-                fields: {
-                    iblockId: iblockId,
-                    name: 'Галерея',
-                    code: 'GALLERY',
-                    propertyType: 'F',
-                    multiple: 'Y',
-                    active: 'Y',
-                    sort: 400
-                }
-            }
-        );
+        const galleryProperty = await addProperty({
+            iblockId: iblockId,
+            name: 'Галерея',
+            code: 'GALLERY',
+            propertyType: 'F',
+            multiple: 'Y',
+            active: 'Y',
+            sort: 400
+        })
 
-        const colorBlue = await callMethod(
-            'catalog.productPropertyEnum.add',
-            {
-                fields: {
-                    propertyId: colorProperty.productProperty.id,
-                    value: 'Синий',
-                    xmlId: 'BLUE',
-                    sort: 100
-                }
-            }
-        );
-
-        const sizeM = await callMethod(
-            'catalog.productPropertyEnum.add',
-            {
-                fields: {
-                    propertyId: sizeProperty.productProperty.id,
-                    value: 'M',
-                    xmlId: 'M',
-                    sort: 100
-                }
-            }
-        );
-
-        const sizeL = await callMethod(
-            'catalog.productPropertyEnum.add',
-            {
-                fields: {
-                    propertyId: sizeProperty.productProperty.id,
-                    value: 'L',
-                    xmlId: 'L',
-                    sort: 200
-                }
-            }
-        );
+        const colorBlue = await addPropertyEnum(colorProperty.id, 'Синий', 'BLUE', 100)
+        const colorRed = await addPropertyEnum(colorProperty.id, 'Красный', 'RED', 200)
+        const sizeM = await addPropertyEnum(sizeProperty.id, 'M', 'M', 100)
+        const sizeL = await addPropertyEnum(sizeProperty.id, 'L', 'L', 200)
 
         console.log({
-            colorPropertyId: colorProperty.productProperty.id,
-            colorBlueId: colorBlue.productPropertyEnum.id,
-            sizePropertyId: sizeProperty.productProperty.id,
-            sizeValueIds: [
-                sizeM.productPropertyEnum.id,
-                sizeL.productPropertyEnum.id
-            ],
-            certificatePropertyId: certificateProperty.productProperty.id,
-            galleryPropertyId: galleryProperty.productProperty.id
-        });
+            colorPropertyId: colorProperty.id,
+            colorBlueId: colorBlue.id,
+            colorRedId: colorRed.id,
+            sizePropertyId: sizeProperty.id,
+            sizeValueIds: [sizeM.id, sizeL.id],
+            certificatePropertyId: certificateProperty.id,
+            galleryPropertyId: galleryProperty.id
+        })
     }
 
-    prepareProperties().catch(console.error);
+    try {
+        await prepareProperties()
+    } catch (error) {
+        console.error('Ошибка:', error.message)
+    } finally {
+        $b24.destroy()
+    }
     ```
 
 - PHP
 
     ```php
     <?php
-    require_once('crest.php');
+    // composer require bitrix24/b24phpsdk:"^3.0"
+    require_once 'vendor/autoload.php';
+
+    use Bitrix24\SDK\Core\Exceptions\BaseException;
+    use Bitrix24\SDK\Services\ServiceBuilderFactory;
+    use Monolog\Handler\StreamHandler;
+    use Monolog\Logger;
+    use Symfony\Component\EventDispatcher\EventDispatcher;
+
+    $log = new Logger('b24');
+    $log->pushHandler(new StreamHandler('php://stdout'));
+
+    $b24 = (new ServiceBuilderFactory(new EventDispatcher(), $log))
+        ->initFromWebhook('https://your-domain.bitrix24.com/rest/USER_ID/TOKEN/');
 
     $iblockId = 23;
 
-    function callRestMethod(string $method, array $params): array
+    function addProperty($b24, array $fields): array
     {
-        $result = CRest::call($method, $params);
+        return $b24->core->call('catalog.productProperty.add', ['fields' => $fields])
+            ->getResponseData()
+            ->getResult()['productProperty'];
+    }
 
-        if (!empty($result['error']))
-        {
-            throw new RuntimeException($result['error_description']);
-        }
-
-        return $result['result'];
+    function addPropertyEnum($b24, int $propertyId, string $value, string $xmlId, int $sort): array
+    {
+        return $b24->core->call(
+            'catalog.productPropertyEnum.add',
+            [
+                'fields' => [
+                    'propertyId' => $propertyId,
+                    'value' => $value,
+                    'xmlId' => $xmlId,
+                    'sort' => $sort,
+                ],
+            ]
+        )->getResponseData()->getResult()['productPropertyEnum'];
     }
 
     try
     {
-        $colorProperty = callRestMethod(
-            'catalog.productProperty.add',
-            [
-                'fields' => [
-                    'iblockId' => $iblockId,
-                    'name' => 'Цвет',
-                    'code' => 'COLOR',
-                    'propertyType' => 'L',
-                    'listType' => 'L',
-                    'multiple' => 'N',
-                    'active' => 'Y',
-                    'sort' => 100,
-                ],
-            ]
-        );
+        $colorProperty = addProperty($b24, [
+            'iblockId' => $iblockId,
+            'name' => 'Цвет',
+            'code' => 'COLOR',
+            'propertyType' => 'L',
+            'listType' => 'L',
+            'multiple' => 'N',
+            'active' => 'Y',
+            'sort' => 100,
+        ]);
 
-        $sizeProperty = callRestMethod(
-            'catalog.productProperty.add',
-            [
-                'fields' => [
-                    'iblockId' => $iblockId,
-                    'name' => 'Размеры',
-                    'code' => 'SIZES',
-                    'propertyType' => 'L',
-                    'listType' => 'C',
-                    'multiple' => 'Y',
-                    'active' => 'Y',
-                    'sort' => 200,
-                ],
-            ]
-        );
+        $sizeProperty = addProperty($b24, [
+            'iblockId' => $iblockId,
+            'name' => 'Размеры',
+            'code' => 'SIZES',
+            'propertyType' => 'L',
+            'listType' => 'C',
+            'multiple' => 'Y',
+            'active' => 'Y',
+            'sort' => 200,
+        ]);
 
-        $certificateProperty = callRestMethod(
-            'catalog.productProperty.add',
-            [
-                'fields' => [
-                    'iblockId' => $iblockId,
-                    'name' => 'Сертификат',
-                    'code' => 'CERTIFICATE',
-                    'propertyType' => 'F',
-                    'multiple' => 'N',
-                    'active' => 'Y',
-                    'sort' => 300,
-                ],
-            ]
-        );
+        $certificateProperty = addProperty($b24, [
+            'iblockId' => $iblockId,
+            'name' => 'Сертификат',
+            'code' => 'CERTIFICATE',
+            'propertyType' => 'F',
+            'multiple' => 'N',
+            'active' => 'Y',
+            'sort' => 300,
+        ]);
 
-        $galleryProperty = callRestMethod(
-            'catalog.productProperty.add',
-            [
-                'fields' => [
-                    'iblockId' => $iblockId,
-                    'name' => 'Галерея',
-                    'code' => 'GALLERY',
-                    'propertyType' => 'F',
-                    'multiple' => 'Y',
-                    'active' => 'Y',
-                    'sort' => 400,
-                ],
-            ]
-        );
+        $galleryProperty = addProperty($b24, [
+            'iblockId' => $iblockId,
+            'name' => 'Галерея',
+            'code' => 'GALLERY',
+            'propertyType' => 'F',
+            'multiple' => 'Y',
+            'active' => 'Y',
+            'sort' => 400,
+        ]);
 
-        $colorBlue = callRestMethod(
-            'catalog.productPropertyEnum.add',
-            [
-                'fields' => [
-                    'propertyId' => $colorProperty['productProperty']['id'],
-                    'value' => 'Синий',
-                    'xmlId' => 'BLUE',
-                    'sort' => 100,
-                ],
-            ]
-        );
-
-        $sizeM = callRestMethod(
-            'catalog.productPropertyEnum.add',
-            [
-                'fields' => [
-                    'propertyId' => $sizeProperty['productProperty']['id'],
-                    'value' => 'M',
-                    'xmlId' => 'M',
-                    'sort' => 100,
-                ],
-            ]
-        );
-
-        $sizeL = callRestMethod(
-            'catalog.productPropertyEnum.add',
-            [
-                'fields' => [
-                    'propertyId' => $sizeProperty['productProperty']['id'],
-                    'value' => 'L',
-                    'xmlId' => 'L',
-                    'sort' => 200,
-                ],
-            ]
-        );
+        $colorBlue = addPropertyEnum($b24, $colorProperty['id'], 'Синий', 'BLUE', 100);
+        $colorRed = addPropertyEnum($b24, $colorProperty['id'], 'Красный', 'RED', 200);
+        $sizeM = addPropertyEnum($b24, $sizeProperty['id'], 'M', 'M', 100);
+        $sizeL = addPropertyEnum($b24, $sizeProperty['id'], 'L', 'L', 200);
 
         print_r([
-            'colorPropertyId' => $colorProperty['productProperty']['id'],
-            'colorBlueId' => $colorBlue['productPropertyEnum']['id'],
-            'sizePropertyId' => $sizeProperty['productProperty']['id'],
+            'colorPropertyId' => $colorProperty['id'],
+            'colorBlueId' => $colorBlue['id'],
+            'colorRedId' => $colorRed['id'],
+            'sizePropertyId' => $sizeProperty['id'],
             'sizeValueIds' => [
-                $sizeM['productPropertyEnum']['id'],
-                $sizeL['productPropertyEnum']['id'],
+                $sizeM['id'],
+                $sizeL['id'],
             ],
-            'certificatePropertyId' => $certificateProperty['productProperty']['id'],
-            'galleryPropertyId' => $galleryProperty['productProperty']['id'],
+            'certificatePropertyId' => $certificateProperty['id'],
+            'galleryPropertyId' => $galleryProperty['id'],
         ]);
     }
-    catch (Throwable $exception)
+    catch (BaseException $exception)
     {
         echo 'Ошибка: '.$exception->getMessage();
     }
     ?>
+    ```
+
+- Python
+
+    ```python
+    # pip install b24pysdk
+    from b24pysdk import BitrixWebhook, Client
+    from b24pysdk.errors import BitrixAPIError
+
+    client = Client(
+        BitrixWebhook(
+            domain="your-domain.bitrix24.com",
+            webhook_token="user_id/webhook_key",
+        )
+    )
+
+    iblock_id = 23
+
+
+    def add_property(fields):
+        return client.catalog.product_property.add(fields=fields).response.result["productProperty"]
+
+
+    def add_property_enum(property_id, value, xml_id, sort):
+        return client.catalog.product_property_enum.add(
+            fields={
+                "propertyId": property_id,
+                "value": value,
+                "xmlId": xml_id,
+                "sort": sort,
+            },
+        ).response.result["productPropertyEnum"]
+
+
+    try:
+        color_property = add_property({
+            "iblockId": iblock_id,
+            "name": "Цвет",
+            "code": "COLOR",
+            "propertyType": "L",
+            "listType": "L",
+            "multiple": "N",
+            "active": "Y",
+            "sort": 100,
+        })
+
+        size_property = add_property({
+            "iblockId": iblock_id,
+            "name": "Размеры",
+            "code": "SIZES",
+            "propertyType": "L",
+            "listType": "C",
+            "multiple": "Y",
+            "active": "Y",
+            "sort": 200,
+        })
+
+        certificate_property = add_property({
+            "iblockId": iblock_id,
+            "name": "Сертификат",
+            "code": "CERTIFICATE",
+            "propertyType": "F",
+            "multiple": "N",
+            "active": "Y",
+            "sort": 300,
+        })
+
+        gallery_property = add_property({
+            "iblockId": iblock_id,
+            "name": "Галерея",
+            "code": "GALLERY",
+            "propertyType": "F",
+            "multiple": "Y",
+            "active": "Y",
+            "sort": 400,
+        })
+
+        color_blue = add_property_enum(color_property["id"], "Синий", "BLUE", 100)
+        color_red = add_property_enum(color_property["id"], "Красный", "RED", 200)
+        size_m = add_property_enum(size_property["id"], "M", "M", 100)
+        size_l = add_property_enum(size_property["id"], "L", "L", 200)
+
+    except BitrixAPIError as error:
+        print(f"Ошибка: {error}")
+
+    else:
+        print({
+            "colorPropertyId": color_property["id"],
+            "colorBlueId": color_blue["id"],
+            "colorRedId": color_red["id"],
+            "sizePropertyId": size_property["id"],
+            "sizeValueIds": [size_m["id"], size_l["id"]],
+            "certificatePropertyId": certificate_property["id"],
+            "galleryPropertyId": gallery_property["id"],
+        })
     ```
 
 {% endlist %}
@@ -331,10 +384,11 @@
 {
     "colorPropertyId": 431,
     "colorBlueId": 1739,
+    "colorRedId": 1740,
     "sizePropertyId": 432,
     "sizeValueIds": [
-        1740,
-        1741
+        1741,
+        1742
     ],
     "certificatePropertyId": 433,
     "galleryPropertyId": 434
@@ -361,30 +415,27 @@
 - JS
 
     ```js
-    const iblockId = 23;
-    const colorPropertyId = 431;
-    const colorBlueId = 1739;
-    const sizePropertyId = 432;
-    const sizeValueIds = [1740, 1741];
-    const certificatePropertyId = 433;
-    const galleryPropertyId = 434;
+    // npm install @bitrix24/b24jssdk
+    import { readFile } from 'node:fs/promises'
+    import { B24Hook } from '@bitrix24/b24jssdk'
 
-    function fileToBase64(filePath) {
-        return fetch(filePath)
-            .then(response => response.blob())
-            .then(blob => new Promise((resolve, reject) => {
-                const reader = new FileReader();
-                reader.onload = () => resolve(reader.result.split(',')[1]);
-                reader.onerror = reject;
-                reader.readAsDataURL(blob);
-            }));
+    const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/USER_ID/TOKEN/')
+
+    const iblockId = 23
+    const colorPropertyId = 431
+    const colorBlueId = 1739
+    const sizePropertyId = 432
+    const sizeValueIds = [1741, 1742]
+    const certificatePropertyId = 433
+    const galleryPropertyId = 434
+
+    async function encodeFile(filePath) {
+        const content = await readFile(filePath)
+
+        return [filePath.split('/').pop(), content.toString('base64')]
     }
 
     async function addProduct() {
-        const certificateBase64 = await fileToBase64('pictures/certificate.pdf');
-        const galleryFirstBase64 = await fileToBase64('pictures/gallery-1.jpg');
-        const gallerySecondBase64 = await fileToBase64('pictures/gallery-2.jpg');
-
         const fields = {
             iblockId: iblockId,
             name: 'Футболка с принтом',
@@ -394,63 +445,70 @@
             ['property' + sizePropertyId]: sizeValueIds,
             ['property' + certificatePropertyId]: {
                 value: {
-                    fileData: [
-                        'certificate.pdf',
-                        certificateBase64
-                    ]
+                    fileData: await encodeFile('pictures/certificate.pdf')
                 }
             },
             ['property' + galleryPropertyId]: [
                 {
                     value: {
-                        fileData: [
-                            'gallery-1.jpg',
-                            galleryFirstBase64
-                        ]
+                        fileData: await encodeFile('pictures/gallery-1.jpg')
                     }
                 },
                 {
                     value: {
-                        fileData: [
-                            'gallery-2.jpg',
-                            gallerySecondBase64
-                        ]
+                        fileData: await encodeFile('pictures/gallery-2.jpg')
                     }
                 }
             ]
-        };
+        }
 
-        BX24.callMethod(
-            'catalog.product.add',
-            {
-                fields: fields
-            },
-            function(result) {
-                if (result.error()) {
-                    console.error(result.error() + ': ' + result.error_description());
-                    return;
-                }
+        const response = await $b24.actions.v2.call.make({
+            method: 'catalog.product.add',
+            params: { fields },
+            requestId: 'product-add'
+        })
 
-                const productId = Number(result.data().element.id);
-                console.log('Товар добавлен: ' + productId);
-            }
-        );
+        if (!response.isSuccess) {
+            throw new Error(response.getErrorMessages().join('; '))
+        }
+
+        const productId = Number(response.getData().result.element.id)
+        console.log('Товар добавлен: ' + productId)
     }
 
-    addProduct().catch(console.error);
+    try {
+        await addProduct()
+    } catch (error) {
+        console.error('Ошибка:', error.message)
+    } finally {
+        $b24.destroy()
+    }
     ```
 
 - PHP
 
     ```php
     <?php
-    require_once('crest.php');
+    // composer require bitrix24/b24phpsdk:"^3.0"
+    require_once 'vendor/autoload.php';
+
+    use Bitrix24\SDK\Core\Exceptions\BaseException;
+    use Bitrix24\SDK\Services\ServiceBuilderFactory;
+    use Monolog\Handler\StreamHandler;
+    use Monolog\Logger;
+    use Symfony\Component\EventDispatcher\EventDispatcher;
+
+    $log = new Logger('b24');
+    $log->pushHandler(new StreamHandler('php://stdout'));
+
+    $b24 = (new ServiceBuilderFactory(new EventDispatcher(), $log))
+        ->initFromWebhook('https://your-domain.bitrix24.com/rest/USER_ID/TOKEN/');
 
     $iblockId = 23;
     $colorPropertyId = 431;
     $colorBlueId = 1739;
     $sizePropertyId = 432;
-    $sizeValueIds = [1740, 1741];
+    $sizeValueIds = [1741, 1742];
     $certificatePropertyId = 433;
     $galleryPropertyId = 434;
 
@@ -495,32 +553,84 @@
             ],
         ];
 
-        $result = CRest::call(
-            'catalog.product.add',
-            [
-                'fields' => $fields,
-            ]
-        );
+        $productId = $b24->getCatalogScope()->product()->add($fields)->product()->id;
 
-        if (!empty($result['error']))
-        {
-            echo 'Ошибка: '.$result['error_description'];
-            return;
-        }
-
-        $productId = (int)$result['result']['element']['id'];
         echo 'Товар добавлен: '.$productId;
     }
-    catch (Throwable $exception)
+    catch (BaseException|RuntimeException $exception)
     {
         echo 'Ошибка: '.$exception->getMessage();
     }
     ?>
     ```
 
+- Python
+
+    ```python
+    # pip install b24pysdk
+    import base64
+
+    from b24pysdk import BitrixWebhook, Client
+    from b24pysdk.errors import BitrixAPIError
+
+    client = Client(
+        BitrixWebhook(
+            domain="your-domain.bitrix24.com",
+            webhook_token="user_id/webhook_key",
+        )
+    )
+
+    iblock_id = 23
+    color_property_id = 431
+    color_blue_id = 1739
+    size_property_id = 432
+    size_value_ids = [1741, 1742]
+    certificate_property_id = 433
+    gallery_property_id = 434
+
+
+    def encode_file(path):
+        with open(path, "rb") as file:
+            return [path.split("/")[-1], base64.b64encode(file.read()).decode()]
+
+
+    fields = {
+        "iblockId": iblock_id,
+        "name": "Футболка с принтом",
+        "active": "Y",
+        "sort": 100,
+        f"property{color_property_id}": color_blue_id,
+        f"property{size_property_id}": size_value_ids,
+        f"property{certificate_property_id}": {
+            "value": {
+                "fileData": encode_file("pictures/certificate.pdf"),
+            },
+        },
+        f"property{gallery_property_id}": [
+            {
+                "value": {
+                    "fileData": encode_file("pictures/gallery-1.jpg"),
+                },
+            },
+            {
+                "value": {
+                    "fileData": encode_file("pictures/gallery-2.jpg"),
+                },
+            },
+        ],
+    }
+
+    try:
+        element = client.catalog.product.add(fields=fields).response.result["element"]
+    except BitrixAPIError as error:
+        print(f"Ошибка: {error}")
+    else:
+        print(f"Товар добавлен: {element['id']}")
+    ```
+
 {% endlist %}
 
-Если товар добавлен успешно, метод вернет объект `element`. В ответе будут поля товара и значения пользовательских свойств.
+Если товар добавлен успешно, метод вернет объект `element`. В ответе будут поля товара и значения пользовательских свойств. Файловые свойства возвращаются со ссылкой на загруженный файл, а не с исходной строкой Base64.
 
 ```json
 {
@@ -529,18 +639,48 @@
             "id": 1267,
             "iblockId": 23,
             "name": "Футболка с принтом",
+            "active": "Y",
             "property431": {
                 "value": "1739",
+                "valueEnum": "Синий",
                 "valueId": "9816"
             },
             "property432": [
                 {
-                    "value": "1740",
+                    "value": "1741",
+                    "valueEnum": "M",
                     "valueId": "9817"
                 },
                 {
-                    "value": "1741",
+                    "value": "1742",
+                    "valueEnum": "L",
                     "valueId": "9818"
+                }
+            ],
+            "property433": {
+                "value": {
+                    "id": "4801",
+                    "url": "/rest/catalog.product.download?fields%5BfieldName%5D=property433&fields%5BfileId%5D=4801&fields%5BproductId%5D=1267",
+                    "urlMachine": "/rest/catalog.product.download?fields%5BfieldName%5D=property433&fields%5BfileId%5D=4801&fields%5BproductId%5D=1267"
+                },
+                "valueId": "9819"
+            },
+            "property434": [
+                {
+                    "value": {
+                        "id": "4803",
+                        "url": "/rest/catalog.product.download?fields%5BfieldName%5D=property434&fields%5BfileId%5D=4803&fields%5BproductId%5D=1267",
+                        "urlMachine": "/rest/catalog.product.download?fields%5BfieldName%5D=property434&fields%5BfileId%5D=4803&fields%5BproductId%5D=1267"
+                    },
+                    "valueId": "9820"
+                },
+                {
+                    "value": {
+                        "id": "4805",
+                        "url": "/rest/catalog.product.download?fields%5BfieldName%5D=property434&fields%5BfileId%5D=4805&fields%5BproductId%5D=1267",
+                        "urlMachine": "/rest/catalog.product.download?fields%5BfieldName%5D=property434&fields%5BfileId%5D=4805&fields%5BproductId%5D=1267"
+                    },
+                    "valueId": "9821"
                 }
             ]
         }
@@ -561,60 +701,115 @@
 - JS
 
     ```js
-    const productId = 1267;
-    const catalogGroupId = 1;
+    // npm install @bitrix24/b24jssdk
+    import { B24Hook } from '@bitrix24/b24jssdk'
 
-    BX24.callMethod(
-        'catalog.price.add',
-        {
-            fields: {
-                productId: productId,
-                catalogGroupId: catalogGroupId,
-                price: 4900,
-                currency: 'RUB'
-            }
-        },
-        function(result) {
-            if (result.error()) {
-                console.error(result.error() + ': ' + result.error_description());
-                return;
-            }
+    const $b24 = B24Hook.fromWebhookUrl('https://your-domain.bitrix24.com/rest/USER_ID/TOKEN/')
 
-            console.log('Цена добавлена: ' + result.data().price.id);
+    const productId = 1267
+    const catalogGroupId = 1
+
+    try {
+        const response = await $b24.actions.v2.call.make({
+            method: 'catalog.price.add',
+            params: {
+                fields: {
+                    productId: productId,
+                    catalogGroupId: catalogGroupId,
+                    price: 4900,
+                    currency: 'RUB'
+                }
+            },
+            requestId: 'price-add'
+        })
+
+        if (!response.isSuccess) {
+            throw new Error(response.getErrorMessages().join('; '))
         }
-    );
+
+        console.log('Цена добавлена: ' + response.getData().result.price.id)
+    } catch (error) {
+        console.error('Ошибка:', error.message)
+    } finally {
+        $b24.destroy()
+    }
     ```
 
 - PHP
 
     ```php
     <?php
-    require_once('crest.php');
+    // composer require bitrix24/b24phpsdk:"^3.0"
+    require_once 'vendor/autoload.php';
+
+    use Bitrix24\SDK\Core\Exceptions\BaseException;
+    use Bitrix24\SDK\Services\ServiceBuilderFactory;
+    use Monolog\Handler\StreamHandler;
+    use Monolog\Logger;
+    use Symfony\Component\EventDispatcher\EventDispatcher;
+
+    $log = new Logger('b24');
+    $log->pushHandler(new StreamHandler('php://stdout'));
+
+    $b24 = (new ServiceBuilderFactory(new EventDispatcher(), $log))
+        ->initFromWebhook('https://your-domain.bitrix24.com/rest/USER_ID/TOKEN/');
 
     $productId = 1267;
     $catalogGroupId = 1;
 
-    $result = CRest::call(
-        'catalog.price.add',
-        [
-            'fields' => [
-                'productId' => $productId,
-                'catalogGroupId' => $catalogGroupId,
-                'price' => 4900,
-                'currency' => 'RUB',
-            ],
-        ]
-    );
+    try
+    {
+        $price = $b24->core->call(
+            'catalog.price.add',
+            [
+                'fields' => [
+                    'productId' => $productId,
+                    'catalogGroupId' => $catalogGroupId,
+                    'price' => 4900,
+                    'currency' => 'RUB',
+                ],
+            ]
+        )->getResponseData()->getResult()['price'];
 
-    if (!empty($result['error']))
-    {
-        echo 'Ошибка: '.$result['error_description'];
+        echo 'Цена добавлена: '.$price['id'];
     }
-    else
+    catch (BaseException $exception)
     {
-        echo 'Цена добавлена: '.$result['result']['price']['id'];
+        echo 'Ошибка: '.$exception->getMessage();
     }
     ?>
+    ```
+
+- Python
+
+    ```python
+    # pip install b24pysdk
+    from b24pysdk import BitrixWebhook, Client
+    from b24pysdk.errors import BitrixAPIError
+
+    client = Client(
+        BitrixWebhook(
+            domain="your-domain.bitrix24.com",
+            webhook_token="user_id/webhook_key",
+        )
+    )
+
+    product_id = 1267
+    catalog_group_id = 1
+
+    try:
+        price = client.catalog.price.add(
+            fields={
+                "productId": product_id,
+                "catalogGroupId": catalog_group_id,
+                "price": 4900,
+                "currency": "RUB",
+            },
+        ).response.result["price"]
+    except BitrixAPIError as error:
+        print(f"Ошибка: {error}")
+    else:
+        print(f"Цена добавлена: {price['id']}")
     ```
 
 {% endlist %}
@@ -629,7 +824,12 @@
             "productId": 1267,
             "catalogGroupId": 1,
             "price": 4900,
-            "currency": "RUB"
+            "priceScale": 4900,
+            "currency": "RUB",
+            "extraId": null,
+            "quantityFrom": null,
+            "quantityTo": null,
+            "timestampX": "2024-11-01T17:00:55+03:00"
         }
     }
 }
@@ -654,6 +854,11 @@
 - `Код свойства не может начинаться с цифры` — значение `code` свойства начинается с цифры
 - `Access Denied` — у пользователя нет прав на изменение каталога, свойств, товара или цены
 - `Validate price error. Catalog price group is wrong` — в `catalogGroupId` передан неверный тип цены
+
+Метод может не вернуть ошибку, но и не сохранить значение свойства.
+
+- `propertyN: "N"` в ответе вместо значения списка — у одиночного списочного свойства всего одно значение, поэтому Битрикс24 определил его как свойство «Да/Нет». Добавьте свойству второе значение списка методом [catalog.productPropertyEnum.add](../../api-reference/catalog/product-property-enum/catalog-product-property-enum-add.md)
+- `propertyN: null` при изменении товара — метод [catalog.product.update](../../api-reference/catalog/product/catalog-product-update.md) не принимает идентификатор значения списка напрямую. Передайте его в формате `{value: 1739}`
 
 ## Продолжите изучение
 


### PR DESCRIPTION
Продолжение [#345](https://github.com/bitrix-tools/b24-rest-docs/pull/345). Страница `tutorials/catalog/index.md` не вошла в тот PR: в коммите 4811ff6 сценарий переписали на методы `catalog.*`, поэтому старая миграция была неактуальна и страницу нужно было переносить заново. Файл в #345 не менялся, конфликтов между PR нет — их можно мерджить в любом порядке.

## Что было

Три группы вкладок, в каждой только JS и PHP, обе на легаси-коде: `BX24.callMethod` и `CRest::call`. Вкладок Python не было.

## Что стало

* вкладки **JS · PHP · Python** во всех трех группах
* **JS** — B24JsSDK: `B24Hook.fromWebhookUrl` + `actions.v2.call.make`, чтение файлов через `node:fs/promises`
* **PHP** — B24PhpSDK: типизированный `getCatalogScope()->product()->add()`; для `catalog.productProperty.add`, `catalog.productPropertyEnum.add` и `catalog.price.add` типизированных сервисов в SDK нет, поэтому они идут через `core->call` (в `CatalogServiceBuilder` есть только `product()` и `catalog()`)
* **Python** — b24pysdk: типизированные `client.catalog.product_property`, `product_property_enum`, `product`, `price`
* переписан блок про окружение — вместо `BX24` и `CRest` установка SDK и авторизация по вебхуку
* `composer require bitrix24/b24phpsdk:"^3.0"` — как в остальной документации после #345

## Исправление сценария: свойство «Цвет» не сохранялось

При проверке примеров выяснилось, что сценарий на странице **не воспроизводится**. Для свойства `Цвет` создавалось одно значение списка `Синий`. Если у одиночного списочного свойства (`multiple: N`) всего одно значение, Битрикс24 определяет его как «Да/Нет» (`userType: BoolEnum`) и **молча игнорирует** идентификатор значения — товар возвращает `property431: "N"` вместо значения, ошибки при этом нет.

То есть документированный ответ

```json
"property431": { "value": "1739", "valueId": "9816" }
```

получить по инструкции со страницы было нельзя.

Проверено на тестовом портале, свойство `L` + `multiple: N`:

| значений списка | `userType` | значение сохраняется |
|---|---|---|
| 1 | `BoolEnum` | нет, возвращается `"N"` |
| 2 | `null` | да |

При `multiple: Y` ограничения нет. `catalog.productProperty.get` всегда возвращает `userType: null` — тип вычисляется по количеству значений и виден только через `catalog.product.getFieldsByFilter`.

В PR свойству `Цвет` добавлено второе значение `Красный` (для свойства цвета это и логичнее), добавлено предупреждение с описанием ограничения и два пункта в разбор ошибок — про `propertyN: "N"` и про `propertyN: null` при `catalog.product.update`, который в отличие от `add` не принимает идентификатор значения напрямую и требует формат `{value: 1739}`.

## Уточнены JSON-ответы

Приведены к фактическим ответам API: добавлено поле `valueEnum` у списочных свойств, добавлены файловые свойства (возвращаются ссылкой `{value: {id, url, urlMachine}}`, а не исходной строкой Base64), в ответе `catalog.price.add` — реальный набор полей.

## Проверка

Каждый из девяти блоков кода извлечен со страницы и выполнен **как есть** на тестовом портале (подставлялись только адрес вебхука и `iblockId`): свойства → товар с файлами и значениями свойств → цена. Во всех трех SDK значения свойств, оба файла и цена `4900 RUB` сохранились и подтверждены через `catalog.product.get` и `catalog.price.list`. Тестовые данные удалены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)