### PR TITLE
Убрали из примеров конструкции, которые сборщик принимает за свои шаблоны

### DIFF
--- a/tutorials/bizproc/setting-robot.md
+++ b/tutorials/bizproc/setting-robot.md
@@ -287,17 +287,19 @@ await $b24.placement.call('setPropertyValue', {
         )
         rows.append(f'<label>{html.escape(prop["NAME"])}:</label>{inputs}')
 
-    page = f"""<!DOCTYPE html><html><body>
-    <form name="props">{''.join(rows)}</form>
-    <script type="module">
-        import {{ initializeB24Frame }} from 'https://esm.sh/@bitrix24/b24jssdk'
+    # JS держим в обычной строке без f-префикса — фигурные скобки остаются как есть
+    script = """<script type="module">
+        import { initializeB24Frame } from 'https://esm.sh/@bitrix24/b24jssdk'
         const $b24 = await initializeB24Frame()
-        window.setPropertyValue = (id, inputName, multiple) => {{
+        window.setPropertyValue = (id, inputName, multiple) => {
             const data = new FormData(document.forms.props)
             const value = multiple ? data.getAll(inputName) : data.get(inputName)
-            $b24.placement.call('setPropertyValue', {{ [id]: value }})
-        }}
-    </script></body></html>"""
+            $b24.placement.call('setPropertyValue', { [id]: value })
+        }
+    </script>"""
+
+    form_html = f'<form name="props">{"".join(rows)}</form>'
+    page = f"<!DOCTYPE html><html><body>\n{form_html}\n" + script + "</body></html>"
     ```
 
 {% endlist %}

--- a/tutorials/crm/crm-widgets/widget-as-field-in-lead-page.md
+++ b/tutorials/crm/crm-widgets/widget-as-field-in-lead-page.md
@@ -708,17 +708,19 @@ https://your-domain.example/handler.php
 
         if options.get("MODE") == "edit":
             # Значение в форму карточки записывает код внутри iframe поля
-            body = f"""
-                <input id="phone-data" type="text" style="width: 90%;" value="{escape(value)}">
-                <script type="module">
-                    import {{ initializeB24Frame }} from '@bitrix24/b24jssdk'
+            script = """<script type="module">
+                    import { initializeB24Frame } from '@bitrix24/b24jssdk'
 
                     const $b24 = await initializeB24Frame()
                     const input = document.getElementById('phone-data')
 
                     input.addEventListener('keyup', () => $b24.placement.setValue(input.value))
                     $b24.placement.setValue(input.value)
-                </script>
+                </script>"""
+
+            body = f"""
+                <input id="phone-data" type="text" style="width: 90%;" value="{escape(value)}">
+                {script}
             """
         else:
             body = escape(value)

--- a/tutorials/crm/how-to-add-crm-objects/how-to-add-company-with-requisite.md
+++ b/tutorials/crm/how-to-add-crm-objects/how-to-add-company-with-requisite.md
@@ -243,7 +243,8 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, render_template_string
+    from flask import Flask
+    from markupsafe import escape
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -253,22 +254,17 @@
         webhook_token="USER_ID/TOKEN",  # только user_id/token, без https://
     ))
 
+    # Шаблон страницы: %(options)s и %(address_inputs)s подставляем из Python
     PAGE = """
-        {% if requisite_types %}
         <form id="form_to_crm">
             <select name="REQ_TYPE" required>
                 <option value="" disabled selected>Выберите тип реквизитов</option>
-                {% for id, name in requisite_types.items() %}
-                    <option value="{{ id }}">{{ name }}</option>
-                {% endfor %}
+                %(options)s
             </select>
             <input type="text" name="TITLE" placeholder="Название организации" required>
             <input type="text" name="INN" placeholder="ИНН">
             <input type="text" name="PHONE" placeholder="Телефон">
-            {% for key, field in address_fields.items() %}
-                <input type="text" name="ADDRESS[{{ key }}]"
-                       placeholder="{{ field.title }}" {{ 'required' if field.isRequired else '' }}>
-            {% endfor %}
+            %(address_inputs)s
             <input type="submit" value="Отправить">
         </form>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
@@ -284,10 +280,9 @@
             });
         });
         </script>
-        {% else %}
-        <p>Нет доступных типов реквизитов.</p>
-        {% endif %}
     """
+
+    EMPTY_PAGE = "<p>Нет доступных типов реквизитов.</p>"
 
 
     @app.route("/")
@@ -297,12 +292,26 @@
         presets = client.crm.requisite.preset.list(select=["ID", "NAME"]).result
 
         requisite_types = {p["ID"]: p["NAME"] for p in presets}
+        if not requisite_types:
+            return EMPTY_PAGE
 
         # Удаляем системные и неиспользуемые поля адреса
         for f in ("TYPE_ID", "ENTITY_TYPE_ID", "ENTITY_ID", "COUNTRY_CODE", "ANCHOR_TYPE_ID", "ANCHOR_ID"):
             address_fields.pop(f, None)
 
-        return render_template_string(PAGE, requisite_types=requisite_types, address_fields=address_fields)
+        # Собираем выпадающий список реквизитов и поля адреса
+        options = "".join(
+            f'<option value="{escape(preset_id)}">{escape(name)}</option>'
+            for preset_id, name in requisite_types.items()
+        )
+        address_inputs = "".join(
+            f'<input type="text" name="ADDRESS[{escape(key)}]" '
+            f'placeholder="{escape(field["title"])}" '
+            f'{"required" if field["isRequired"] else ""}>'
+            for key, field in address_fields.items()
+        )
+
+        return PAGE % {"options": options, "address_inputs": address_inputs}
     ```
 
 {% endlist %}

--- a/tutorials/crm/how-to-add-crm-objects/how-to-add-contact-with-requisite.md
+++ b/tutorials/crm/how-to-add-crm-objects/how-to-add-contact-with-requisite.md
@@ -244,7 +244,8 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, render_template_string
+    from flask import Flask
+    from markupsafe import escape
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -254,22 +255,17 @@
         webhook_token="USER_ID/TOKEN",  # только user_id/token, без https://
     ))
 
+    # Шаблон страницы: %(options)s и %(address_inputs)s подставляем из Python
     PAGE = """
-        {% if requisite_types %}
         <form id="form_to_crm">
             <select name="REQ_TYPE" required>
                 <option value="" disabled selected>Выберите тип реквизитов</option>
-                {% for id, name in requisite_types.items() %}
-                    <option value="{{ id }}">{{ name }}</option>
-                {% endfor %}
+                %(options)s
             </select>
             <input type="text" name="NAME" placeholder="Имя" required>
             <input type="text" name="LAST_NAME" placeholder="Фамилия">
             <input type="text" name="PHONE" placeholder="Телефон">
-            {% for key, field in address_fields.items() %}
-                <input type="text" name="ADDRESS[{{ key }}]"
-                       placeholder="{{ field.title }}" {{ 'required' if field.isRequired else '' }}>
-            {% endfor %}
+            %(address_inputs)s
             <input type="submit" value="Отправить">
         </form>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
@@ -285,10 +281,9 @@
             });
         });
         </script>
-        {% else %}
-        <p>Нет доступных типов реквизитов.</p>
-        {% endif %}
     """
+
+    EMPTY_PAGE = "<p>Нет доступных типов реквизитов.</p>"
 
 
     @app.route("/")
@@ -298,12 +293,26 @@
         presets = client.crm.requisite.preset.list(select=["ID", "NAME"]).result
 
         requisite_types = {p["ID"]: p["NAME"] for p in presets}
+        if not requisite_types:
+            return EMPTY_PAGE
 
         # Удаляем системные и неиспользуемые поля адреса
         for f in ("TYPE_ID", "ENTITY_TYPE_ID", "ENTITY_ID", "COUNTRY_CODE", "ANCHOR_TYPE_ID", "ANCHOR_ID"):
             address_fields.pop(f, None)
 
-        return render_template_string(PAGE, requisite_types=requisite_types, address_fields=address_fields)
+        # Собираем выпадающий список реквизитов и поля адреса
+        options = "".join(
+            f'<option value="{escape(preset_id)}">{escape(name)}</option>'
+            for preset_id, name in requisite_types.items()
+        )
+        address_inputs = "".join(
+            f'<input type="text" name="ADDRESS[{escape(key)}]" '
+            f'placeholder="{escape(field["title"])}" '
+            f'{"required" if field["isRequired"] else ""}>'
+            for key, field in address_fields.items()
+        )
+
+        return PAGE % {"options": options, "address_inputs": address_inputs}
     ```
 
 {% endlist %}

--- a/tutorials/crm/how-to-add-crm-objects/how-to-add-deal-with-choice-of-requisite.md
+++ b/tutorials/crm/how-to-add-crm-objects/how-to-add-deal-with-choice-of-requisite.md
@@ -154,23 +154,33 @@
 
 - Python
 
-    ```html
-    <!-- Jinja2-шаблон: список реквизитов и поля адреса подставляются из данных -->
-    <form id="form_to_crm">
-        <select name="REQ_TYPE" required>
-            <option value="" disabled selected>Select</option>
-            {% for id, name in requisite_types.items() %}
-                <option value="{{ id }}">{{ name }}</option>
-            {% endfor %}
-        </select>
-        <input type="text" name="TITLE" placeholder="Org name" required>
-        <input type="text" name="INN" placeholder="INN">
-        <input type="text" name="PHONE" placeholder="Phone">
-        {% for key, field in address_fields.items() %}
-            <input type="text" name="ADDRESS[{{ key }}]" placeholder="{{ field.title }}" {{ 'required' if field.isRequired else '' }}>
-        {% endfor %}
-        <input type="submit" value="Submit">
-    </form>
+    ```python
+    # строку с формой собираем из полученных данных и вставляем в ответ сервера
+    from markupsafe import escape
+
+    options = "".join(
+        f'<option value="{escape(preset_id)}">{escape(name)}</option>'
+        for preset_id, name in requisite_types.items()
+    )
+    address_inputs = "".join(
+        f'<input type="text" name="ADDRESS[{escape(key)}]" '
+        f'placeholder="{escape(field["title"])}" '
+        f'{"required" if field["isRequired"] else ""}>'
+        for key, field in address_fields.items()
+    )
+
+    form_html = f"""
+        <form id="form_to_crm">
+            <select name="REQ_TYPE" required>
+                <option value="" disabled selected>Select</option>
+                {options}
+            </select>
+            <input type="text" name="TITLE" placeholder="Org name" required>
+            <input type="text" name="INN" placeholder="INN">
+            <input type="text" name="PHONE" placeholder="Phone">
+            {address_inputs}
+            <input type="submit" value="Submit">
+        </form>"""
     ```
 
 {% endlist %}
@@ -321,7 +331,8 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, render_template_string
+    from flask import Flask
+    from markupsafe import escape
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -331,23 +342,8 @@
         webhook_token="USER_ID/TOKEN",  # только user_id/token, без https://
     ))
 
-    PAGE = """
-        {% if requisite_types %}
-        <form id="form_to_crm">
-            <select name="REQ_TYPE" required>
-                <option value="" disabled selected>Select</option>
-                {% for id, name in requisite_types.items() %}
-                    <option value="{{ id }}">{{ name }}</option>
-                {% endfor %}
-            </select>
-            <input type="text" name="TITLE" placeholder="Org name" required>
-            <input type="text" name="INN" placeholder="INN">
-            <input type="text" name="PHONE" placeholder="Phone">
-            {% for key, field in address_fields.items() %}
-                <input type="text" name="ADDRESS[{{ key }}]" placeholder="{{ field.title }}" {{ 'required' if field.isRequired else '' }}>
-            {% endfor %}
-            <input type="submit" value="Submit">
-        </form>
+    # обычная строка без подстановок: фигурные скобки JS не нужно экранировать
+    SCRIPT = """
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
         <script>
         $(document).ready(function() {
@@ -361,9 +357,6 @@
             });
         });
         </script>
-        {% else %}
-        No requisite types.
-        {% endif %}
     """
 
 
@@ -373,12 +366,37 @@
         presets = client.crm.requisite.preset.list(select=["ID", "NAME"]).result
 
         requisite_types = {p["ID"]: p["NAME"] for p in presets}
+        if not requisite_types:
+            return "No requisite types."
 
         # unset system + uninteresting address fields
         for f in ("TYPE_ID", "ENTITY_TYPE_ID", "ENTITY_ID", "COUNTRY_CODE", "ANCHOR_TYPE_ID", "ANCHOR_ID"):
             address_fields.pop(f, None)
 
-        return render_template_string(PAGE, requisite_types=requisite_types, address_fields=address_fields)
+        # строку с формой собираем из полученных данных
+        options = "".join(
+            f'<option value="{escape(preset_id)}">{escape(name)}</option>'
+            for preset_id, name in requisite_types.items()
+        )
+        address_inputs = "".join(
+            f'<input type="text" name="ADDRESS[{escape(key)}]" '
+            f'placeholder="{escape(field["title"])}" '
+            f'{"required" if field["isRequired"] else ""}>'
+            for key, field in address_fields.items()
+        )
+
+        return f"""
+            <form id="form_to_crm">
+                <select name="REQ_TYPE" required>
+                    <option value="" disabled selected>Select</option>
+                    {options}
+                </select>
+                <input type="text" name="TITLE" placeholder="Org name" required>
+                <input type="text" name="INN" placeholder="INN">
+                <input type="text" name="PHONE" placeholder="Phone">
+                {address_inputs}
+                <input type="submit" value="Submit">
+            </form>""" + SCRIPT
     ```
 
 {% endlist %}

--- a/tutorials/crm/how-to-edit-crm-objects/how-to-generate-edit-form-for-company.md
+++ b/tutorials/crm/how-to-edit-crm-objects/how-to-generate-edit-form-for-company.md
@@ -793,7 +793,8 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, request, render_template_string, jsonify
+    from flask import Flask, request, jsonify
+    from markupsafe import escape
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -856,11 +857,11 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" crossorigin="anonymous">
         <div class="container">
             <form id="auto_form" enctype="multipart/form-data" method="post">
-                {% if item_id %}<input type="hidden" name="form[ID]" value="{{ item_id }}">{% endif %}
+                %(hidden_id)s
                 <h2>Standard fields</h2>
-                <div class="row">{{ standard | safe }}</div>
+                <div class="row">%(standard)s</div>
                 <h2>Custom fields</h2>
-                <div class="row">{{ custom | safe }}</div>
+                <div class="row">%(custom)s</div>
                 <div class="row"><div class="col-sm-10 mt-5">
                     <input type="submit" class="btn btn-primary" value="Submit">
                 </div></div>
@@ -972,7 +973,11 @@
             else:
                 s_result += block
 
-        return render_template_string(PAGE, item_id=item.get("ID"), standard=s_result, custom=s_result_custom)
+        # Скрытое поле ID добавляем только для формы редактирования
+        hidden_id = ""
+        if item.get("ID"):
+            hidden_id = f'<input type="hidden" name="form[ID]" value="{escape(item["ID"])}">'
+        return PAGE % {"hidden_id": hidden_id, "standard": s_result, "custom": s_result_custom}
 
 
     if __name__ == "__main__":

--- a/tutorials/crm/how-to-edit-crm-objects/how-to-generate-edit-form-for-deal.md
+++ b/tutorials/crm/how-to-edit-crm-objects/how-to-generate-edit-form-for-deal.md
@@ -896,7 +896,8 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, request, render_template_string, jsonify
+    from html import escape
+    from flask import Flask, request, jsonify
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -960,11 +961,11 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" crossorigin="anonymous">
         <div class="container">
             <form id="auto_form" enctype="multipart/form-data" method="post">
-                {% if item_id %}<input type="hidden" name="form[ID]" value="{{ item_id }}">{% endif %}
+                %(hidden_id)s
                 <h2>Standard fields</h2>
-                <div class="row">{{ standard | safe }}</div>
+                <div class="row">%(standard)s</div>
                 <h2>Custom fields</h2>
-                <div class="row">{{ custom | safe }}</div>
+                <div class="row">%(custom)s</div>
                 <div class="row"><div class="col-sm-10 mt-5">
                     <input type="submit" class="btn btn-primary" value="Submit">
                 </div></div>
@@ -999,8 +1000,9 @@
             ar_result["ITEM"] = client.crm.deal.get(bitrix_id=item_id).result
             # Воронки (направления) сделок — для поля CATEGORY_ID.
             # Метод crm.dealcategory.list пока без обёртки в SDK — вызываем напрямую.
+            category_filter = {"IS_LOCKED": "N"}
             ar_result["VALUE_CATEGORY_ID"] = token.call_method(
-                "crm.dealcategory.list", {"filter": {"IS_LOCKED": "N"}})["result"]
+                "crm.dealcategory.list", {"filter": category_filter})["result"]
             # Предложения сделки — для read-only поля QUOTE_ID
             ar_result["VALUE_QUOTE_ID"] = client.crm.quote.list(
                 filter={"DEAL_ID": item_id}, select=["ID", "TITLE"]).result
@@ -1101,7 +1103,12 @@
             else:
                 s_result += block
 
-        return render_template_string(PAGE, item_id=item.get("ID"), standard=s_result, custom=s_result_custom)
+        # Скрытое поле ID добавляем только для формы редактирования
+        item_id_value = item.get("ID")
+        hidden_id = ""
+        if item_id_value:
+            hidden_id = f'<input type="hidden" name="form[ID]" value="{escape(str(item_id_value))}">'
+        return PAGE % {"hidden_id": hidden_id, "standard": s_result, "custom": s_result_custom}
 
 
     if __name__ == "__main__":

--- a/tutorials/crm/how-to-edit-crm-objects/how-to-generate-edit-form-for-lead.md
+++ b/tutorials/crm/how-to-edit-crm-objects/how-to-generate-edit-form-for-lead.md
@@ -757,7 +757,8 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, request, render_template_string
+    from flask import Flask, request
+    from markupsafe import escape
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -820,11 +821,11 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" crossorigin="anonymous">
         <div class="container">
             <form id="auto_form" enctype="multipart/form-data" method="post">
-                {% if item_id %}<input type="hidden" name="form[ID]" value="{{ item_id }}">{% endif %}
+                %(hidden_id)s
                 <h2>Standard fields</h2>
-                <div class="row">{{ standard | safe }}</div>
+                <div class="row">%(standard)s</div>
                 <h2>Custom fields</h2>
-                <div class="row">{{ custom | safe }}</div>
+                <div class="row">%(custom)s</div>
                 <div class="row"><div class="col-sm-10 mt-5">
                     <input type="submit" class="btn btn-primary" value="Submit">
                 </div></div>
@@ -936,7 +937,11 @@
             else:
                 s_result += block
 
-        return render_template_string(PAGE, item_id=item.get("ID"), standard=s_result, custom=s_result_custom)
+        # Скрытое поле с ID добавляем только для формы редактирования
+        hidden_id = ""
+        if item.get("ID"):
+            hidden_id = f'<input type="hidden" name="form[ID]" value="{escape(item["ID"])}">'
+        return PAGE % {"hidden_id": hidden_id, "standard": s_result, "custom": s_result_custom}
 
 
     if __name__ == "__main__":

--- a/tutorials/crm/how-to-edit-crm-objects/how-to-make-contact-edit-card.md
+++ b/tutorials/crm/how-to-edit-crm-objects/how-to-make-contact-edit-card.md
@@ -755,7 +755,9 @@
 
     ```python
     # pip install b24pysdk flask
-    from flask import Flask, request, render_template_string, jsonify
+    from html import escape
+
+    from flask import Flask, request, jsonify
     from b24pysdk import BitrixWebhook, Client
 
     app = Flask(__name__)
@@ -818,11 +820,11 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" crossorigin="anonymous">
         <div class="container">
             <form id="auto_form" enctype="multipart/form-data" method="post">
-                {% if item_id %}<input type="hidden" name="form[ID]" value="{{ item_id }}">{% endif %}
+                %(hidden_id)s
                 <h2>Standard fields</h2>
-                <div class="row">{{ standard | safe }}</div>
+                <div class="row">%(standard)s</div>
                 <h2>Custom fields</h2>
-                <div class="row">{{ custom | safe }}</div>
+                <div class="row">%(custom)s</div>
                 <div class="row"><div class="col-sm-10 mt-5">
                     <input type="submit" class="btn btn-primary" value="Submit">
                 </div></div>
@@ -927,7 +929,12 @@
             else:
                 s_result += block
 
-        return render_template_string(PAGE, item_id=item.get("ID"), standard=s_result, custom=s_result_custom)
+        # Скрытое поле ID подставляем только при редактировании существующего контакта
+        hidden_id = ""
+        if item.get("ID"):
+            hidden_id = f'<input type="hidden" name="form[ID]" value="{escape(str(item["ID"]))}">'
+
+        return PAGE % {"hidden_id": hidden_id, "standard": s_result, "custom": s_result_custom}
 
 
     if __name__ == "__main__":


### PR DESCRIPTION
Фикс ошибок сборки, о которых сообщила команда документации после #345. #345 уже влит в `main`, поэтому исправление выношу отдельным PR.

Причину проверили на самом движке (`@diplodoc/transform`), а не по логу — картина оказалась чуть точнее, чем в исходном описании.

## Что показал движок

**`{% ... %}` и `{{ ... }}` ломают по-разному:**

| Конструкция в блоке кода | Что происходит | Тяжесть |
|---|---|---|
| `{% ... %}` | вычисляется, содержимое **исчезает** | искажение страницы |
| `{{ ... }}` | попадает под подстановку переменных | пока WARN |

Искажение `PAGE` в Python-примере — это `{% if %}` / `{% for %}`: поэтому и оставалась только ветка «Нет доступных типов реквизитов».

`{{ ... }}` сейчас только шумит в логе, но это **отложенная мина**: подстановка идёт и по содержимому блоков кода. Проверили — если в пресетах появится переменная `standard`, то `{{ standard }}` в python-блоке молча заменится на её значение. Поэтому убрали и их.

**`{% raw %}` действительно не помогает** — подтверждаем вывод команды доков. Проверили и вокруг фенса, и внутри: содержимое всё равно схлопывается.

**Подстановка срабатывает не на любые двойные скобки.** Паттерн движка — `{{2}([. \w-|(),]+)}{2}`: внутри допустимы только буквы, цифры, `.`, `-`, `|`, `(`, `)`, `,` и пробелы. Поэтому `{{ initializeB24Frame }}`, `{{ standard | safe }}`, `{{ id }}` совпадают, а `{{ [id]: value }}` и многострочный `function() {{` … `}}` — нет.

## Про предложение №1 (`import * as B24`)

Тут аккуратно возражу: **менять JS-импорт не нужно**. Одиночные скобки движок не трогает — проверено в обоих режимах. `import { initializeB24Frame } from '@bitrix24/b24jssdk'` в JS-вкладках полностью безопасен.

Предупреждение `Variable initializeB24Frame not found` приходило **не из JS-вкладок**, а из Python: там HTML собирался f-строкой, а в f-строке `{{` — это экранированная литеральная `{`. То есть в markdown буквально лежало `import {{ initializeB24Frame }}`, хотя Python на выходе давал корректный `import { ... }`.

Починили причину: вынесли JS/HTML в обычные строки **без** `f`-префикса — экранирование стало не нужно, скобки снова одиночные. Идиоматичный импорт остался, код примера читается легче. Затронуты только `setting-robot.md` и `widget-as-field-in-lead-page.md`; в `activity.md` и `widget-as-detail-tab.md` импорт и так был безопасен — не трогали.

## Что изменено (9 файлов, +163/−99)

**Python/Flask → без Jinja** (предложения №2 и №3): `render_template_string` убран, HTML собирается обычным Python. Экранирование сохранено явно через `markupsafe.escape` / `html.escape` (раньше его делало автоэкранирование Jinja), пустое состояние — обычным `if`.

- `how-to-add-company-with-requisite.md`, `how-to-add-contact-with-requisite.md`, `how-to-add-deal-with-choice-of-requisite.md`
- `how-to-generate-edit-form-for-{lead,company,deal}.md`, `how-to-make-contact-edit-card.md`

**Python f-strings → обычные строки**: `setting-robot.md`, `widget-as-field-in-lead-page.md`

## Проверки

- ноль `{{ }}` / `{% %}` внутри блоков кода — прогнали `@diplodoc/transform` в обоих режимах (`conditionsInCode` on/off), с фенс-логикой самого движка. С этим фиксом **весь раздел `tutorials/` (71 страница) чистый**, включая новую страницу каталога из #346
- 50 Python-блоков в изменённых файлах компилируются (231 по всему разделу)
- вывод HTML сверён с рендером **исходных** шаблонов на `jinja2 3.1.6` с `autoescape=True`: результат эквивалентен, XSS-payload экранируется как и раньше, все пресеты и флаги `required` на месте. Единственная разница — перенос строки между атрибутами внутри тега `<input>` (в исходном шаблоне тег был разбит на две строки); на рендер не влияет

## Замечания на будущее

- В `how-to-product-binding.md` и `how-to-change-product-custom-field-values.md` есть `{% if build == 'dev' %}` — это ваша обёртка для черновиков, не трогали. В прогоне она схлопывает страницу, но это ожидаемо и не связано с этим PR.
- Если у сборки включён `conditionsInCode`, блоки кода вообще не защищены от `{% %}`. Возможно, есть смысл добавить в CI линт «никаких `{{ }}` / `{% %}` внутри фенсов» — скрипт проверки могу отдать.

🤖 Generated with [Claude Code](https://claude.com/claude-code)