### PR TITLE
Уменьшили нагрузку виджета и починили раскладку формы

### DIFF
--- a/.yfm
+++ b/.yfm
@@ -8,8 +8,7 @@ resources:
   script:
     - _assets/b24loc.js?20240925-02
     - _assets/b24addons.js?20241208-01
-    - _assets/simulator/core.js?20260814-01
-    - _assets/simulator/widget.js?20260814-01
+    - _assets/simulator/boot.js?20260817-01
 
 search: true
 

--- a/_assets/simulator/boot.js
+++ b/_assets/simulator/boot.js
@@ -1,0 +1,109 @@
+(function () {
+    'use strict';
+
+    // Загрузчик симулятора. Подключается на всех страницах документации, поэтому
+    // делает минимум: смотрит адрес и заголовок страницы и только на страницах
+    // методов подтягивает ядро и виджет. На остальных ~1100 страницах не грузится
+    // ничего и не создаётся ни одного наблюдателя.
+
+    var ASSETS_ROOT = resolveAssetsRoot();
+    var CHECK_INTERVAL = 400;
+
+    var loading = false;
+    var lastPath = null;
+    var retries = 0;
+
+    function resolveAssetsRoot() {
+        var script = document.currentScript;
+        var src = script ? script.src : '';
+        var marker = src.lastIndexOf('/simulator/');
+        return marker === -1 ? '/_assets/simulator/' : src.slice(0, marker) + '/simulator/';
+    }
+
+    // То же правило, что у генератора схем: имя метода — последний «точечный»
+    // идентификатор в заголовке страницы.
+    function methodOnPage() {
+        if (window.location.pathname.indexOf('/api-reference/') === -1) {
+            return null;
+        }
+
+        var heading = document.querySelector('.dc-doc-page__body h1, main h1, h1');
+        if (!heading) {
+            return null;
+        }
+
+        var matches = heading.textContent.match(/\b[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+\b/gi);
+        if (!matches) {
+            return null;
+        }
+
+        var candidate = matches[matches.length - 1];
+        if (/\.(md|html|json|php|js)$/i.test(candidate)) {
+            return null;
+        }
+        if (candidate === candidate.toUpperCase() || /^BX24\./i.test(candidate)) {
+            return null; // события и методы BX24.js вызвать нельзя
+        }
+
+        return candidate;
+    }
+
+    function addScript(src, onload) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        script.onload = onload || null;
+        document.head.appendChild(script);
+    }
+
+    function ensureLoaded() {
+        if (window.B24SimWidget) {
+            window.B24SimWidget.mount();
+            return;
+        }
+        if (loading) {
+            return;
+        }
+        loading = true;
+        addScript(ASSETS_ROOT + 'core.js', function () {
+            addScript(ASSETS_ROOT + 'widget.js');
+        });
+    }
+
+    // Документация работает как SPA: адрес меняется раньше, чем содержимое,
+    // поэтому после смены адреса несколько раз перепроверяем заголовок.
+    function tick() {
+        var path = window.location.pathname;
+
+        if (path !== lastPath) {
+            lastPath = path;
+            retries = 5;
+        }
+
+        if (methodOnPage()) {
+            retries = 0;
+            ensureLoaded();
+            return;
+        }
+
+        if (retries > 0) {
+            retries--;
+            return;
+        }
+
+        if (window.B24SimWidget) {
+            window.B24SimWidget.unmount();
+        }
+    }
+
+    function start() {
+        tick();
+        setInterval(tick, CHECK_INTERVAL);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+})();

--- a/_assets/simulator/widget.css
+++ b/_assets/simulator/widget.css
@@ -10,18 +10,22 @@
     padding: 14px 16px 16px;
 }
 
-.b24sim__form table {
-    width: 100%;
-    margin: 0 0 4px;
+.b24sim__param + .b24sim__param {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--g-color-line-generic, rgba(0, 0, 0, 0.1));
 }
 
-.b24sim__param-cell {
-    width: 25%;
-    vertical-align: middle;
+.b24sim__label {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
 }
 
-.b24sim__param-cell p {
-    margin: 0 0 4px;
+.b24sim__type {
+    font-size: 0.9em;
 }
 
 .b24sim__fields > div:first-child {
@@ -30,14 +34,24 @@
 
 .b24sim__field-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 11fr) minmax(0, 13fr) auto;
     gap: 6px;
     align-items: center;
     margin-bottom: 6px;
 }
 
+/* Когда выбрано «другое поле», рядом со списком появляется ввод имени —
+   строка становится из четырёх колонок, а не переносится. */
+.b24sim__field-row_custom {
+    grid-template-columns: minmax(0, 8fr) minmax(0, 8fr) minmax(0, 8fr) auto;
+}
+
 .b24sim__field-value {
     min-width: 0;
+}
+
+.b24sim-select .g-text-input__control {
+    text-overflow: ellipsis;
 }
 
 .b24sim__add {
@@ -63,13 +77,19 @@
     overflow: auto;
 }
 
-/* Нативный <select> внутри обёртки g-text-input */
+/* Нативный <select> внутри обёртки g-text-input: отступы обёртки рассчитаны на
+   <input>, у select они обрезают текст по вертикали. */
 .b24sim-select .g-text-input__control {
     width: 100%;
+    height: 100%;
+    padding-top: 0;
+    padding-bottom: 0;
     border: 0;
     background: transparent;
     color: inherit;
     font: inherit;
+    line-height: normal;
+    text-overflow: ellipsis;
     cursor: pointer;
 }
 

--- a/_assets/simulator/widget.js
+++ b/_assets/simulator/widget.js
@@ -263,13 +263,15 @@
         function addRow(fieldName) {
             var row = el('div', 'b24sim__field-row');
 
+            // В подписи только имя поля: вместе с типом она не влезает в select
+            // и обрезается. Тип уходит в подсказку внутри поля значения.
             var nameSelect = gSelect();
             def.fields.forEach(function (field) {
-                var option = el('option', null, field.name + '  ·  ' + typeLabel(field));
+                var option = el('option', null, field.name);
                 option.value = field.name;
                 nameSelect.control.appendChild(option);
             });
-            var custom = el('option', null, '— другое поле (UF_…) —');
+            var custom = el('option', null, 'другое поле (UF_…)');
             custom.value = '__custom__';
             nameSelect.control.appendChild(custom);
 
@@ -289,6 +291,10 @@
                 valueHolder.innerHTML = '';
                 var field = findField(def, nameSelect.control.value) || { base: 'string', type: 'string' };
                 var control = createValueControl(field, undefined);
+                if (control.control && control.control.tagName === 'INPUT' && !control.control.placeholder) {
+                    control.control.placeholder = typeLabel(field);
+                }
+                nameSelect.control.title = field.name ? field.name + ' · ' + typeLabel(field) : '';
                 valueHolder.appendChild(control);
                 row.read = function () {
                     var name = nameSelect.control.value === '__custom__' ? customName.control.value.trim() : nameSelect.control.value;
@@ -301,7 +307,9 @@
             }
 
             nameSelect.control.addEventListener('change', function () {
-                customName.style.display = nameSelect.control.value === '__custom__' ? '' : 'none';
+                var isCustom = nameSelect.control.value === '__custom__';
+                customName.style.display = isCustom ? '' : 'none';
+                row.classList.toggle('b24sim__field-row_custom', isCustom);
                 renderValue();
             });
 
@@ -517,47 +525,38 @@
         var form = el('form', 'b24sim__form');
         var controls = {};
 
-        var table = el('table');
-        var tbody = el('tbody');
-
+        // Подпись сверху, поле под ней на всю ширину. Двухколоночная таблица здесь
+        // не годится: колонка статьи узкая, и вложенный редактор полей в половине
+        // её ширины сжимается до нечитаемого.
         spec.params.forEach(function (param) {
-            var row = el('tr');
+            var block = el('div', 'b24sim__param');
 
-            var nameCell = el('td', 'b24sim__param-cell');
-            var namePara = el('p');
-            namePara.appendChild(el('strong', null, param.name));
-            namePara.appendChild(el('br'));
-            namePara.appendChild(el('code', null, typeLabel(param)));
-            nameCell.appendChild(namePara);
-
-            // Описание параметра целиком есть на странице выше — в форме оно только
-            // в подсказке, иначе виджет вырастает на несколько экранов.
-            if (param.description) {
-                nameCell.title = param.description;
-            }
+            var label = el('div', 'b24sim__label');
+            label.appendChild(el('strong', null, param.name));
+            label.appendChild(el('code', 'b24sim__type', typeLabel(param)));
 
             if (param.required === true) {
-                nameCell.appendChild(gLabel('обязательный', 'danger'));
+                label.appendChild(gLabel('обязательный', 'danger'));
             } else if (param.required === 'unknown') {
                 // Не ошибка и не угроза — просто документация не размечает обязательность.
                 var unknown = gLabel('обязательность неизвестна', 'unknown');
                 unknown.title = 'На странице метода не проставлена звёздочка обязательности, поэтому симулятор не может её проверить';
-                nameCell.appendChild(unknown);
+                label.appendChild(unknown);
             }
 
+            // Описание параметра целиком есть на странице выше — здесь только подсказка.
+            if (param.description) {
+                label.title = param.description;
+            }
 
-            var controlCell = el('td');
+            block.appendChild(label);
+
             var control = createParamControl(spec, param);
             controls[param.name] = control;
-            controlCell.appendChild(control);
+            block.appendChild(control);
 
-            row.appendChild(nameCell);
-            row.appendChild(controlCell);
-            tbody.appendChild(row);
+            form.appendChild(block);
         });
-
-        table.appendChild(tbody);
-        form.appendChild(table);
 
         var actions = el('div', 'b24sim__actions');
         var run = gButton('Выполнить', 'action');
@@ -702,11 +701,7 @@
         var method = findMethodForPage();
 
         if (!method) {
-            var stale = document.querySelector('.b24sim');
-            if (stale && stale.parentNode) {
-                stale.parentNode.removeChild(stale);
-            }
-            state.mounted = null;
+            removeWidget();
             return;
         }
 
@@ -734,55 +729,28 @@
             });
     }
 
-    // Документация работает как SPA, поэтому за сменой страницы следим наблюдателем.
-    // Другие скрипты страницы правят DOM непрерывно (например, b24addons.js
-    // навешивает иконки копирования), поэтому здесь троттлинг с гарантированным
-    // запуском, а не debounce: сбрасываемый таймер под потоком мутаций
-    // не срабатывал бы никогда и виджет не смонтировался бы вовсе.
-    var MIN_INTERVAL = 400;
-
-    function observePageChanges() {
-        var lastRun = 0;
-        var pending = null;
-
-        function fire() {
-            pending = null;
-            lastRun = Date.now();
-            ensureForCurrentPage();
+    function removeWidget() {
+        var existing = document.querySelector('.b24sim');
+        if (existing && existing.parentNode) {
+            existing.parentNode.removeChild(existing);
         }
+        state.mounted = null;
+    }
 
-        new MutationObserver(function (records) {
-            // Собственные изменения виджета не считаем поводом для пересборки.
-            var external = records.some(function (record) {
-                var target = record.target;
-                return !(target && target.closest && target.closest('.b24sim'));
-            });
-            if (!external || pending) {
+    // Сменой страницы управляет boot.js: он один следит за адресом и вызывает эти
+    // методы. Своего наблюдателя за DOM здесь нет — на странице документации
+    // мутации идут потоком, и подписка на них обходилась дороже самой работы.
+    window.B24SimWidget = {
+        mount: function () {
+            if (!window.B24Sim) {
                 return;
             }
+            ensureForCurrentPage();
+        },
+        unmount: removeWidget,
+    };
 
-            var elapsed = Date.now() - lastRun;
-            if (elapsed >= MIN_INTERVAL) {
-                fire();
-            } else {
-                pending = setTimeout(fire, MIN_INTERVAL - elapsed);
-            }
-        }).observe(document.body, { childList: true, subtree: true });
-    }
-
-    function boot() {
-        if (!window.B24Sim) {
-            console.warn('Симулятор: ядро B24Sim не загружено');
-            return;
-        }
-
+    if (window.B24Sim) {
         ensureForCurrentPage();
-        observePageChanges();
-    }
-
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', boot);
-    } else {
-        boot();
     }
 })();

--- a/simulator/build.js
+++ b/simulator/build.js
@@ -35,6 +35,7 @@ run('generate-spec.js', []);
 run('generate-fixtures.js', dateArg ? [dateArg] : []);
 
 console.log('\nКопирование runtime:');
+copy(path.join(__dirname, 'widget', 'boot.js'), path.join(OUT, 'boot.js'));
 copy(path.join(__dirname, 'lib', 'core.js'), path.join(OUT, 'core.js'));
 copy(path.join(__dirname, 'widget', 'widget.js'), path.join(OUT, 'widget.js'));
 copy(path.join(__dirname, 'widget', 'widget.css'), path.join(OUT, 'widget.css'));

--- a/simulator/widget/boot.js
+++ b/simulator/widget/boot.js
@@ -1,0 +1,109 @@
+(function () {
+    'use strict';
+
+    // Загрузчик симулятора. Подключается на всех страницах документации, поэтому
+    // делает минимум: смотрит адрес и заголовок страницы и только на страницах
+    // методов подтягивает ядро и виджет. На остальных ~1100 страницах не грузится
+    // ничего и не создаётся ни одного наблюдателя.
+
+    var ASSETS_ROOT = resolveAssetsRoot();
+    var CHECK_INTERVAL = 400;
+
+    var loading = false;
+    var lastPath = null;
+    var retries = 0;
+
+    function resolveAssetsRoot() {
+        var script = document.currentScript;
+        var src = script ? script.src : '';
+        var marker = src.lastIndexOf('/simulator/');
+        return marker === -1 ? '/_assets/simulator/' : src.slice(0, marker) + '/simulator/';
+    }
+
+    // То же правило, что у генератора схем: имя метода — последний «точечный»
+    // идентификатор в заголовке страницы.
+    function methodOnPage() {
+        if (window.location.pathname.indexOf('/api-reference/') === -1) {
+            return null;
+        }
+
+        var heading = document.querySelector('.dc-doc-page__body h1, main h1, h1');
+        if (!heading) {
+            return null;
+        }
+
+        var matches = heading.textContent.match(/\b[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+\b/gi);
+        if (!matches) {
+            return null;
+        }
+
+        var candidate = matches[matches.length - 1];
+        if (/\.(md|html|json|php|js)$/i.test(candidate)) {
+            return null;
+        }
+        if (candidate === candidate.toUpperCase() || /^BX24\./i.test(candidate)) {
+            return null; // события и методы BX24.js вызвать нельзя
+        }
+
+        return candidate;
+    }
+
+    function addScript(src, onload) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.async = true;
+        script.onload = onload || null;
+        document.head.appendChild(script);
+    }
+
+    function ensureLoaded() {
+        if (window.B24SimWidget) {
+            window.B24SimWidget.mount();
+            return;
+        }
+        if (loading) {
+            return;
+        }
+        loading = true;
+        addScript(ASSETS_ROOT + 'core.js', function () {
+            addScript(ASSETS_ROOT + 'widget.js');
+        });
+    }
+
+    // Документация работает как SPA: адрес меняется раньше, чем содержимое,
+    // поэтому после смены адреса несколько раз перепроверяем заголовок.
+    function tick() {
+        var path = window.location.pathname;
+
+        if (path !== lastPath) {
+            lastPath = path;
+            retries = 5;
+        }
+
+        if (methodOnPage()) {
+            retries = 0;
+            ensureLoaded();
+            return;
+        }
+
+        if (retries > 0) {
+            retries--;
+            return;
+        }
+
+        if (window.B24SimWidget) {
+            window.B24SimWidget.unmount();
+        }
+    }
+
+    function start() {
+        tick();
+        setInterval(tick, CHECK_INTERVAL);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+})();

--- a/simulator/widget/widget.css
+++ b/simulator/widget/widget.css
@@ -10,18 +10,22 @@
     padding: 14px 16px 16px;
 }
 
-.b24sim__form table {
-    width: 100%;
-    margin: 0 0 4px;
+.b24sim__param + .b24sim__param {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--g-color-line-generic, rgba(0, 0, 0, 0.1));
 }
 
-.b24sim__param-cell {
-    width: 25%;
-    vertical-align: middle;
+.b24sim__label {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
 }
 
-.b24sim__param-cell p {
-    margin: 0 0 4px;
+.b24sim__type {
+    font-size: 0.9em;
 }
 
 .b24sim__fields > div:first-child {
@@ -30,14 +34,24 @@
 
 .b24sim__field-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 11fr) minmax(0, 13fr) auto;
     gap: 6px;
     align-items: center;
     margin-bottom: 6px;
 }
 
+/* Когда выбрано «другое поле», рядом со списком появляется ввод имени —
+   строка становится из четырёх колонок, а не переносится. */
+.b24sim__field-row_custom {
+    grid-template-columns: minmax(0, 8fr) minmax(0, 8fr) minmax(0, 8fr) auto;
+}
+
 .b24sim__field-value {
     min-width: 0;
+}
+
+.b24sim-select .g-text-input__control {
+    text-overflow: ellipsis;
 }
 
 .b24sim__add {
@@ -63,13 +77,19 @@
     overflow: auto;
 }
 
-/* Нативный <select> внутри обёртки g-text-input */
+/* Нативный <select> внутри обёртки g-text-input: отступы обёртки рассчитаны на
+   <input>, у select они обрезают текст по вертикали. */
 .b24sim-select .g-text-input__control {
     width: 100%;
+    height: 100%;
+    padding-top: 0;
+    padding-bottom: 0;
     border: 0;
     background: transparent;
     color: inherit;
     font: inherit;
+    line-height: normal;
+    text-overflow: ellipsis;
     cursor: pointer;
 }
 

--- a/simulator/widget/widget.js
+++ b/simulator/widget/widget.js
@@ -263,13 +263,15 @@
         function addRow(fieldName) {
             var row = el('div', 'b24sim__field-row');
 
+            // В подписи только имя поля: вместе с типом она не влезает в select
+            // и обрезается. Тип уходит в подсказку внутри поля значения.
             var nameSelect = gSelect();
             def.fields.forEach(function (field) {
-                var option = el('option', null, field.name + '  ·  ' + typeLabel(field));
+                var option = el('option', null, field.name);
                 option.value = field.name;
                 nameSelect.control.appendChild(option);
             });
-            var custom = el('option', null, '— другое поле (UF_…) —');
+            var custom = el('option', null, 'другое поле (UF_…)');
             custom.value = '__custom__';
             nameSelect.control.appendChild(custom);
 
@@ -289,6 +291,10 @@
                 valueHolder.innerHTML = '';
                 var field = findField(def, nameSelect.control.value) || { base: 'string', type: 'string' };
                 var control = createValueControl(field, undefined);
+                if (control.control && control.control.tagName === 'INPUT' && !control.control.placeholder) {
+                    control.control.placeholder = typeLabel(field);
+                }
+                nameSelect.control.title = field.name ? field.name + ' · ' + typeLabel(field) : '';
                 valueHolder.appendChild(control);
                 row.read = function () {
                     var name = nameSelect.control.value === '__custom__' ? customName.control.value.trim() : nameSelect.control.value;
@@ -301,7 +307,9 @@
             }
 
             nameSelect.control.addEventListener('change', function () {
-                customName.style.display = nameSelect.control.value === '__custom__' ? '' : 'none';
+                var isCustom = nameSelect.control.value === '__custom__';
+                customName.style.display = isCustom ? '' : 'none';
+                row.classList.toggle('b24sim__field-row_custom', isCustom);
                 renderValue();
             });
 
@@ -517,47 +525,38 @@
         var form = el('form', 'b24sim__form');
         var controls = {};
 
-        var table = el('table');
-        var tbody = el('tbody');
-
+        // Подпись сверху, поле под ней на всю ширину. Двухколоночная таблица здесь
+        // не годится: колонка статьи узкая, и вложенный редактор полей в половине
+        // её ширины сжимается до нечитаемого.
         spec.params.forEach(function (param) {
-            var row = el('tr');
+            var block = el('div', 'b24sim__param');
 
-            var nameCell = el('td', 'b24sim__param-cell');
-            var namePara = el('p');
-            namePara.appendChild(el('strong', null, param.name));
-            namePara.appendChild(el('br'));
-            namePara.appendChild(el('code', null, typeLabel(param)));
-            nameCell.appendChild(namePara);
-
-            // Описание параметра целиком есть на странице выше — в форме оно только
-            // в подсказке, иначе виджет вырастает на несколько экранов.
-            if (param.description) {
-                nameCell.title = param.description;
-            }
+            var label = el('div', 'b24sim__label');
+            label.appendChild(el('strong', null, param.name));
+            label.appendChild(el('code', 'b24sim__type', typeLabel(param)));
 
             if (param.required === true) {
-                nameCell.appendChild(gLabel('обязательный', 'danger'));
+                label.appendChild(gLabel('обязательный', 'danger'));
             } else if (param.required === 'unknown') {
                 // Не ошибка и не угроза — просто документация не размечает обязательность.
                 var unknown = gLabel('обязательность неизвестна', 'unknown');
                 unknown.title = 'На странице метода не проставлена звёздочка обязательности, поэтому симулятор не может её проверить';
-                nameCell.appendChild(unknown);
+                label.appendChild(unknown);
             }
 
+            // Описание параметра целиком есть на странице выше — здесь только подсказка.
+            if (param.description) {
+                label.title = param.description;
+            }
 
-            var controlCell = el('td');
+            block.appendChild(label);
+
             var control = createParamControl(spec, param);
             controls[param.name] = control;
-            controlCell.appendChild(control);
+            block.appendChild(control);
 
-            row.appendChild(nameCell);
-            row.appendChild(controlCell);
-            tbody.appendChild(row);
+            form.appendChild(block);
         });
-
-        table.appendChild(tbody);
-        form.appendChild(table);
 
         var actions = el('div', 'b24sim__actions');
         var run = gButton('Выполнить', 'action');
@@ -702,11 +701,7 @@
         var method = findMethodForPage();
 
         if (!method) {
-            var stale = document.querySelector('.b24sim');
-            if (stale && stale.parentNode) {
-                stale.parentNode.removeChild(stale);
-            }
-            state.mounted = null;
+            removeWidget();
             return;
         }
 
@@ -734,55 +729,28 @@
             });
     }
 
-    // Документация работает как SPA, поэтому за сменой страницы следим наблюдателем.
-    // Другие скрипты страницы правят DOM непрерывно (например, b24addons.js
-    // навешивает иконки копирования), поэтому здесь троттлинг с гарантированным
-    // запуском, а не debounce: сбрасываемый таймер под потоком мутаций
-    // не срабатывал бы никогда и виджет не смонтировался бы вовсе.
-    var MIN_INTERVAL = 400;
-
-    function observePageChanges() {
-        var lastRun = 0;
-        var pending = null;
-
-        function fire() {
-            pending = null;
-            lastRun = Date.now();
-            ensureForCurrentPage();
+    function removeWidget() {
+        var existing = document.querySelector('.b24sim');
+        if (existing && existing.parentNode) {
+            existing.parentNode.removeChild(existing);
         }
+        state.mounted = null;
+    }
 
-        new MutationObserver(function (records) {
-            // Собственные изменения виджета не считаем поводом для пересборки.
-            var external = records.some(function (record) {
-                var target = record.target;
-                return !(target && target.closest && target.closest('.b24sim'));
-            });
-            if (!external || pending) {
+    // Сменой страницы управляет boot.js: он один следит за адресом и вызывает эти
+    // методы. Своего наблюдателя за DOM здесь нет — на странице документации
+    // мутации идут потоком, и подписка на них обходилась дороже самой работы.
+    window.B24SimWidget = {
+        mount: function () {
+            if (!window.B24Sim) {
                 return;
             }
+            ensureForCurrentPage();
+        },
+        unmount: removeWidget,
+    };
 
-            var elapsed = Date.now() - lastRun;
-            if (elapsed >= MIN_INTERVAL) {
-                fire();
-            } else {
-                pending = setTimeout(fire, MIN_INTERVAL - elapsed);
-            }
-        }).observe(document.body, { childList: true, subtree: true });
-    }
-
-    function boot() {
-        if (!window.B24Sim) {
-            console.warn('Симулятор: ядро B24Sim не загружено');
-            return;
-        }
-
+    if (window.B24Sim) {
         ensureForCurrentPage();
-        observePageChanges();
-    }
-
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', boot);
-    } else {
-        boot();
     }
 })();


### PR DESCRIPTION
Загрузка. Раньше на всех 2648 страницах документации грузились ядро и виджет — 57 КБ, из которых на ~1100 страницах без методов они не нужны. Теперь в .yfm подключается только boot.js на 3 КБ: он смотрит адрес и заголовок страницы и ядро с виджетом подтягивает лишь там, где есть метод.

Наблюдатель за DOM убран совсем. Он висел на document.body с subtree: true на каждой странице, а на страницах документации мутации идут потоком — например, b24addons.js оборачивает каждый инлайн-код. Подписка обходилась дороже самой работы. Сменой страницы теперь управляет boot.js: сравнивает адрес раз в 400 мс и вызывает B24SimWidget.mount() или unmount().

Раскладка. Двухколоночная таблица «имя | поле» не годится: колонка статьи узкая, и вложенный редактор полей в половине её ширины сжимался до нечитаемого — select показывал пустоту вместо имени поля. Подпись переехала над полем, поле занимает всю ширину. Из подписи в select убран тип: вместе с именем он не влезал и обрезался, теперь тип показан подсказкой в поле значения. У нативного select сняты вертикальные отступы обёртки g-text-input, из-за которых текст обрезался по высоте. Выбор «другое поле» больше не ломает строку: она становится из четырёх колонок.

Замер на процессоре, замедленном вчетверо: страница блокирует главный поток на ~1000 мс сама по себе, вклад симулятора — около 50 мс.